### PR TITLE
Update confounds.py

### DIFF
--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -80,9 +80,13 @@ def load_acompcor(confoundspd, confoundjs):
     # select the first five components
     csflist = []; wmlist = []
     for i in range(0,4):
-        csflist.append(CSF[i][0])
-        wmlist.append(WM[i][0])
-    acompcor = wmlist +csflist  
+        try:
+            csflist.append(CSF[i][0])
+        except: pass
+        try:
+            wmlist.append(WM[i][0])
+        except: pass
+    acompcor = wmlist +csflist    
     return confoundspd[acompcor]
 
 

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -62,7 +62,7 @@ def load_WM_CSF(confoundspd):
 def load_cosine(confoundspd):
     """select cosine for compcor"""
     cosine = [];
-    for key,value in confoundjs.items():
+    for key in confoundspd.keys():
         if 'cosine' in key:
             cosine.append(key)
     return confoundspd[cosine]

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -61,7 +61,11 @@ def load_WM_CSF(confoundspd):
 
 def load_cosine(confoundspd):
     """select cosine for compcor"""
-    return confoundspd[["cosine00","cosine01","cosine02","cosine03","cosine04","cosine05"]]
+    cosine = [];
+    for key,value in confoundjs.items():
+        if 'cosine' in key:
+            cosine.append(key)
+    return confoundspd[cosine]
 
 def load_acompcor(confoundspd, confoundjs):
     """ select WM and GM acompcor separately."""


### PR DESCRIPTION
1) Make it so XCP does not crash if fewer than 5 WM or CSF acompcor components exist
2) Load all cosine regressors for acompcor (not just first 5, some runs will not even have 5 cosine regressors).