### PR TITLE
[FIX] Address failing RTD build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==58.5.3", "wheel"]
+requires = ["setuptools==58.2.0", "wheel"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==58.2.0", "wheel"]
+requires = ["setuptools==58.5.3", "wheel"]
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """ xcp_d setup script """
-import sys
 from setuptools import setup
+
 import versioneer
-
-
-# Give setuptools a hint to complain if it's too old a version
-# 40.8.0 allows us to put most metadata in setup.cfg
-# Should match pyproject.toml
-SETUP_REQUIRES = ["setuptools >= 50"]
-# This enables setuptools to install wheel on-the-fly
-SETUP_REQUIRES += ["wheel"] if "bdist_wheel" in sys.argv else []
 
 
 if __name__ == "__main__":
@@ -19,5 +11,4 @@ if __name__ == "__main__":
         name="xcp_d",
         version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
-        setup_requires=SETUP_REQUIRES,
     )


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request
Remove SETUP_REQUIRES from setup.py. pyproject.toml handles it.
<!--
Please describe here the main features / changes proposed for review and integration in aslprep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *aslprep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

## Documentation that should be reviewed
None

## Traceback

Here is the full traceback for the failing RTD build:

```
Processing /home/docs/checkouts/readthedocs.org/user_builds/xcp-d/checkouts/475
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [64 lines of output]
      running dist_info
      creating /tmp/pip-modern-metadata-7xxvzll7/xcp_d.egg-info
      writing /tmp/pip-modern-metadata-7xxvzll7/xcp_d.egg-info/PKG-INFO
      writing dependency_links to /tmp/pip-modern-metadata-7xxvzll7/xcp_d.egg-info/dependency_links.txt
      writing entry points to /tmp/pip-modern-metadata-7xxvzll7/xcp_d.egg-info/entry_points.txt
      writing requirements to /tmp/pip-modern-metadata-7xxvzll7/xcp_d.egg-info/requires.txt
      writing top-level names to /tmp/pip-modern-metadata-7xxvzll7/xcp_d.egg-info/top_level.txt
      writing manifest file '/tmp/pip-modern-metadata-7xxvzll7/xcp_d.egg-info/SOURCES.txt'
      Traceback (most recent call last):
        File "/home/docs/checkouts/readthedocs.org/user_builds/xcp-d/envs/475/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/home/docs/checkouts/readthedocs.org/user_builds/xcp-d/envs/475/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/docs/checkouts/readthedocs.org/user_builds/xcp-d/envs/475/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 164, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/build_meta.py", line 156, in prepare_metadata_for_build_wheel
          self.run_setup()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/build_meta.py", line 242, in run_setup
          super(_BuildMetaLegacyBackend,
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/build_meta.py", line 142, in run_setup
          exec(compile(code, __file__, 'exec'), locals())
        File "setup.py", line 18, in <module>
          setup(
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/__init__.py", line 145, in setup
          return distutils.core.setup(**attrs)
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/distutils/core.py", line 148, in setup
          dist.run_commands()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/distutils/dist.py", line 966, in run_commands
          self.run_command(cmd)
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/distutils/dist.py", line 985, in run_command
          cmd_obj.run()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/command/dist_info.py", line 31, in run
          egg_info.run()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 296, in run
          self.find_sources()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 303, in find_sources
          mm.run()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 534, in run
          self.add_defaults()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 570, in add_defaults
          sdist.add_defaults(self)
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/distutils/command/sdist.py", line 226, in add_defaults
          self._add_defaults_python()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/command/sdist.py", line 135, in _add_defaults_python
          build_py = self.get_finalized_command('build_py')
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/distutils/cmd.py", line 299, in get_finalized_command
          cmd_obj.ensure_finalized()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/distutils/cmd.py", line 107, in ensure_finalized
          self.finalize_options()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/command/build_py.py", line 34, in finalize_options
          orig.build_py.finalize_options(self)
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/distutils/command/build_py.py", line 43, in finalize_options
          self.set_undefined_options('build',
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/distutils/cmd.py", line 286, in set_undefined_options
          src_cmd_obj = self.distribution.get_command_obj(src_cmd)
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/distutils/dist.py", line 857, in get_command_obj
          klass = self.get_command_class(command)
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/setuptools/dist.py", line 834, in get_command_class
          self.cmdclass[command] = cmdclass = ep.load()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2444, in load
          return self.resolve()
        File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2450, in resolve
          module = __import__(self.module_name, fromlist=['__name__'], level=0)
      ModuleNotFoundError: No module named 'setuptools.command.build'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```