### PR TITLE
[REF] Lint utils

### DIFF
--- a/xcp_d/utils/__init__.py
+++ b/xcp_d/utils/__init__.py
@@ -1,36 +1,62 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """A range of utility functions for xcp_d interfaces and workflows."""
-from xcp_d.utils.write_save import (read_ndata, write_ndata, read_gii, write_gii,
-                                    despikedatacifti)
-from xcp_d.utils.plot import (plot_svg, compute_dvars, plotimage)
-from xcp_d.utils.confounds import load_confound_matrix
-from xcp_d.utils.fcon import (extract_timeseries_funct, compute_2d_reho, compute_alff,
-                              mesh_adjacency)
+from xcp_d.utils.bids import DerivativesDataSink as bid_derivative
+from xcp_d.utils.bids import (
+    collect_data,
+    collect_participants,
+    extract_t1w_seg,
+    select_cifti_bold,
+    select_registrationfile,
+)
 from xcp_d.utils.cifticonnectivity import CiftiCorrelation
 from xcp_d.utils.ciftiparcellation import CiftiParcellate
-from xcp_d.utils.ciftiseparatemetric import CiftiSeparateMetric
 from xcp_d.utils.ciftiresample import CiftiSurfaceResample
-from xcp_d.utils.bids import (collect_participants, collect_data, select_registrationfile,
-                              select_cifti_bold, extract_t1w_seg)
-from xcp_d.utils.bids import DerivativesDataSink as bid_derivative
-from xcp_d.utils.modified_data import (interpolate_masked_data,
-                                       generate_mask, compute_FD)
-from xcp_d.utils.sentry import sentry_setup
-
-from xcp_d.utils.qcmetrics import regisQ
-
-from xcp_d.utils.utils import (get_maskfiles, get_transformfile, get_transformfilex,
-                               stringforparams, fwhm2sigma, get_customfile)
-
-from xcp_d.utils.plot import (plot_svgx, plot_carpet, confoundplot)
-
-from xcp_d.utils.execsummary import (surf2vol, get_regplot, plot_registrationx,
-                                     generate_brain_sprite, ribbon_to_statmap)
-from xcp_d.utils.dcan2fmriprep import dcan2fmriprep
-from xcp_d.utils.hcp2fmriprep import hcp2fmriprep
-from xcp_d.utils.restingstate import ReHoNamePatch, DespikePatch, ContrastEnhancement
+from xcp_d.utils.ciftiseparatemetric import CiftiSeparateMetric
 from xcp_d.utils.concantenation import concatenatebold
+from xcp_d.utils.confounds import load_confound_matrix
+from xcp_d.utils.dcan2fmriprep import dcan2fmriprep
+from xcp_d.utils.execsummary import (
+    generate_brain_sprite,
+    get_regplot,
+    plot_registrationx,
+    ribbon_to_statmap,
+    surf2vol,
+)
+from xcp_d.utils.fcon import (
+    compute_2d_reho,
+    compute_alff,
+    extract_timeseries_funct,
+    mesh_adjacency,
+)
+from xcp_d.utils.hcp2fmriprep import hcp2fmriprep
+from xcp_d.utils.modified_data import compute_FD, generate_mask, interpolate_masked_data
+from xcp_d.utils.plot import (
+    compute_dvars,
+    confoundplot,
+    plot_carpet,
+    plot_svg,
+    plot_svgx,
+    plotimage,
+)
+from xcp_d.utils.qcmetrics import regisQ
+from xcp_d.utils.restingstate import ContrastEnhancement, DespikePatch, ReHoNamePatch
+from xcp_d.utils.sentry import sentry_setup
+from xcp_d.utils.utils import (
+    fwhm2sigma,
+    get_customfile,
+    get_maskfiles,
+    get_transformfile,
+    get_transformfilex,
+    stringforparams,
+)
+from xcp_d.utils.write_save import (
+    despikedatacifti,
+    read_gii,
+    read_ndata,
+    write_gii,
+    write_ndata,
+)
 
 __all__ = [
     'read_ndata',

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -124,7 +124,6 @@ def collect_participants(
     ['02', '04']
     ...
     """
-
     if isinstance(bids_dir, BIDSLayout):
         layout = bids_dir
     else:

--- a/xcp_d/utils/cifticonnectivity.py
+++ b/xcp_d/utils/cifticonnectivity.py
@@ -10,6 +10,8 @@ iflogger = logging.getLogger("nipype.interface")
 
 
 class CiftiCorrelationInputSpec(CommandLineInputSpec):
+    """Input specification for CiftiCorrelation."""
+
     in_file = File(
         exists=True,
         mandatory=True,
@@ -91,6 +93,8 @@ class CiftiCorrelationInputSpec(CommandLineInputSpec):
 
 
 class CiftiCorrelationOutputSpec(TraitedSpec):
+    """Output specification for CiftiCorrelation."""
+
     out_file = File(exists=True, desc="output CIFTI file")
 
 

--- a/xcp_d/utils/ciftiparcellation.py
+++ b/xcp_d/utils/ciftiparcellation.py
@@ -10,6 +10,8 @@ iflogger = logging.getLogger("nipype.interface")
 
 
 class CiftiParcellateInputSpec(CommandLineInputSpec):
+    """Input specification for the CiftiParcellate command."""
+
     in_file = File(
         exists=True,
         mandatory=True,
@@ -94,13 +96,15 @@ class CiftiParcellateInputSpec(CommandLineInputSpec):
     )
     cor_method = traits.Str(
         position=12,
-        default='MEAN ',
+        default="MEAN ",
         argstr="-method %s",
         desc=" correlation method, option inlcude MODE",
     )
 
 
 class CiftiParcellateOutputSpec(TraitedSpec):
+    """Output specification for the CiftiParcellate command."""
+
     out_file = File(exists=True, desc="output CIFTI file")
 
 

--- a/xcp_d/utils/ciftiresample.py
+++ b/xcp_d/utils/ciftiresample.py
@@ -10,6 +10,8 @@ iflogger = logging.getLogger("nipype.interface")
 
 
 class CiftiSurfaceResampleInputSpec(CommandLineInputSpec):
+    """Input specification for the CiftiSurfaceResample command."""
+
     in_file = File(
         exists=True,
         mandatory=True,
@@ -32,10 +34,12 @@ class CiftiSurfaceResampleInputSpec(CommandLineInputSpec):
         desc=" the new sphere surface to be resample the in_file to, eg fsaverag5 or fsl32k",
     )
 
-    metric = traits.Str(argstr=" %s ",
-                        position=3,
-                        desc=" fixed for anatomic",
-                        default="  BARYCENTRIC  ")
+    metric = traits.Str(
+        argstr=" %s ",
+        position=3,
+        desc=" fixed for anatomic",
+        default="  BARYCENTRIC  ",
+    )
 
     out_file = File(
         name_source=["in_file"],
@@ -48,6 +52,8 @@ class CiftiSurfaceResampleInputSpec(CommandLineInputSpec):
 
 
 class CiftiSurfaceResampleOutputSpec(TraitedSpec):
+    """Input specification for the CiftiSurfaceResample command."""
+
     out_file = File(exists=True, desc="output gifti file")
 
 

--- a/xcp_d/utils/ciftiseparatemetric.py
+++ b/xcp_d/utils/ciftiseparatemetric.py
@@ -10,6 +10,8 @@ iflogger = logging.getLogger("nipype.interface")
 
 
 class CiftiSeparateMetricInputSpec(CommandLineInputSpec):
+    """Input specification for the CiftiSeparateMetric command."""
+
     in_file = File(
         exists=True,
         mandatory=True,
@@ -43,6 +45,8 @@ class CiftiSeparateMetricInputSpec(CommandLineInputSpec):
 
 
 class CiftiSeparateMetricOutputSpec(TraitedSpec):
+    """Input specification for the CiftiSeparateMetric command."""
+
     out_file = File(exists=True, desc="output CIFTI file")
 
 

--- a/xcp_d/utils/concantenation.py
+++ b/xcp_d/utils/concantenation.py
@@ -14,9 +14,10 @@ import numpy as np
 from natsort import natsorted
 from nipype.interfaces.ants import ApplyTransforms
 from templateflow.api import get as get_template
-from xcp_d.utils.utils import get_transformfile
-from xcp_d.utils import read_ndata
+
 from xcp_d.utils.plot import plot_svgx
+from xcp_d.utils.utils import get_transformfile
+from xcp_d.utils.write_save import read_ndata
 
 
 def concatenatebold(subjlist, fmridir, outputdir, work_dir):

--- a/xcp_d/utils/dcan2fmriprep.py
+++ b/xcp_d/utils/dcan2fmriprep.py
@@ -13,9 +13,7 @@ from nilearn.input_data import NiftiMasker
 
 
 def dcan2fmriprep(dcandir, outdir, sub_id=None):
-    """
-    loop over all subjects in dcan dir and convert to fmriprep format
-    """
+    """Loop over all subjects in dcan dir and convert to fmriprep format."""
     dcandir = os.path.abspath(dcandir)
     outdir = os.path.abspath(outdir)
     if sub_id is None:
@@ -32,12 +30,8 @@ def dcan2fmriprep(dcandir, outdir, sub_id=None):
 
 
 def dcan2fmriprepx(dcan_dir, out_dir, sub_id):
-    """
-    dcan2fmriprep(dcan_dir,out_dir)
-    this script convert dcan data to fmriprep format
-    """
+    """Convert dcan data to fmriprep format."""
     # get session id if available
-
     sess = glob.glob(dcan_dir + '/' + sub_id + '/s*')
     ses_id = []
     ses_id = [j.split('ses-')[1] for j in sess]
@@ -256,10 +250,10 @@ def dcan2fmriprepx(dcan_dir, out_dir, sub_id):
 
 
 def copyfileobj_example(src, dst):
-    """
-    Copy a file from source to dest. source and dest
-    must be file-like objects, i.e. any object with a read or
-    write method, like for example StringIO.
+    """Copy a file from source to dest.
+
+    source and dest must be file-like objects,
+    i.e. any object with a read or write method, like for example StringIO.
     """
     import filecmp
     import shutil
@@ -268,24 +262,28 @@ def copyfileobj_example(src, dst):
 
 
 def symlinkfiles(source, dest):
+    """Symlink source file to dest file."""
     # Beware, this example does not handle any edge cases!
     with open(source, 'rb') as src, open(dest, 'wb') as dst:
         copyfileobj_example(src, dst)
 
 
 def extractreg(mask, nifti):
+    """Extract mean signal within mask from NIFTI."""
     masker = NiftiMasker(mask_img=mask)
     signals = masker.fit_transform(nifti)
     return np.mean(signals, axis=1)
 
 
 def writejson(data, outfile):
+    """Write dictionary to JSON file."""
     with open(outfile, 'w') as f:
         json.dump(data, f)
     return outfile
 
 
 def bbregplot(fixed_image, moving_image, contour, out_file='report.svg'):
+    """Plot bbreg results."""
     import numpy as np
     from nilearn.image import load_img, resample_img, threshold_img
     from niworkflows.viz.utils import compose_view, cuts_from_bbox, plot_registration

--- a/xcp_d/utils/execsummary.py
+++ b/xcp_d/utils/execsummary.py
@@ -16,12 +16,23 @@ from svgutils.transform import fromstring
 
 
 def surf2vol(template, left_surf, right_surf, filename, scale=1):
-    """
-    template, t1w image in nii.gz or mgz from freesufer of other subject
-    left_surf,right_surf, gii file
+    """Convert surface data to volumetric space.
+
+    Parameters
+    ----------
+    template : str
+        t1w image in nii.gz or mgz from freesufer of other subject
+    left_surf/right_surf
+        Path to gii file
+    filename : str
+        Output filename
+    scale : float
+        A scale to apply to the intensity values before their written out.
+
+    Returns
+    -------
     filename
     """
-
     # load the t1 image
     t1_image = nb.load(template)
     ras2vox = np.linalg.inv(t1_image.affine)
@@ -49,10 +60,7 @@ def surf2vol(template, left_surf, right_surf, filename, scale=1):
 
 
 def get_regplot(brain, overlay, out_file, cuts=3, order=("x", "y", "z")):
-    """
-
-    """
-
+    """Create registration plot."""
     brain = nb.load(brain)
     overlay = nb.load(overlay)
     from niworkflows.viz.utils import cuts_from_bbox
@@ -78,8 +86,8 @@ def plot_registrationx(
     contour=None,
     compress="auto",
 ):
-    """
-    Plots the foreground and background views
+    """Plot the foreground and background views.
+
     Default order is: axial, coronal, sagittal
     """
     plot_params = {} if plot_params is None else plot_params
@@ -120,7 +128,7 @@ def plot_registrationx(
 
 
 def generate_brain_sprite(template_image, stat_map, out_file):
-
+    """Generate a brainsprite HTML file."""
     file_template = pkgrf("xcp_d", 'data/transform/brainsprite_template.html')
     template = tempita.Template.from_filename(file_template, encoding="utf-8")
 
@@ -146,7 +154,7 @@ def generate_brain_sprite(template_image, stat_map, out_file):
 
 
 def ribbon_to_statmap(ribbon, outfile):
-
+    """Convert a ribbon to a volumetric statistical map."""
     # chek if the data is ribbon or seg_data files
 
     ngbdata = nb.load(ribbon)
@@ -173,7 +181,7 @@ def ribbon_to_statmap(ribbon, outfile):
 
 
 def _get_contour(datax):
-    # contour in each plane
+    """Get contour in each plane."""
     dims = datax.shape
 
     contour = np.zeros_like(datax)

--- a/xcp_d/utils/filemanip.py
+++ b/xcp_d/utils/filemanip.py
@@ -185,15 +185,14 @@ def fnames_presuffix(fnames, prefix="", suffix="", newpath=None, use_ext=True):
 
 
 def hash_rename(filename, hashvalue):
-    """Rename a file given original filename and hash, and set path to output_directory.
-    """
+    """Rename a file given original filename and hash, and set path to output_directory."""
     path, name, ext = split_filename(filename)
     newfilename = "".join((name, "_0x", hashvalue, ext))
     return op.join(path, newfilename)
 
 
 def check_forhash(filename):
-    """Checks if file has a hash in its filename."""
+    """Check if file has a hash in its filename."""
     if isinstance(filename, list):
         filename = filename[0]
     path, name = op.split(filename)
@@ -1109,6 +1108,7 @@ def relpath(path, start=None):
 
 @contextlib.contextmanager
 def indirectory(path):
+    """Change working directory to path."""
     cwd = os.getcwd()
     os.chdir(str(path))
     try:

--- a/xcp_d/utils/hcp2fmriprep.py
+++ b/xcp_d/utils/hcp2fmriprep.py
@@ -15,6 +15,7 @@ from pkg_resources import resource_filename as pkgrf
 
 
 def hcp2fmriprep(hcpdir, outdir, sub_id=None):
+    """Convert HCP-format data to fMRIPrep format."""
     hcpdir = os.path.abspath(hcpdir)
     outdir = os.path.abspath(outdir)
     if sub_id is None:
@@ -32,6 +33,7 @@ def hcp2fmriprep(hcpdir, outdir, sub_id=None):
 
 
 def hcpfmriprepx(hcp_dir, out_dir, subid):
+    """Do the internal work for hcp2fmriprep."""
     sub_id = 'sub-' + subid
     anat_dirx = hcp_dir + '/' + subid + '/T1w/'
 
@@ -192,23 +194,31 @@ def hcpfmriprepx(hcp_dir, out_dir, subid):
 
 
 def copyfileobj_example(src, dst):
+    """Copy a file from source to dest.
+
+    source and dest must be file-like objects,
+    i.e. any object with a read or write method, like for example StringIO.
+    """
     if not os.path.exists(dst) or not filecmp.cmp(src, dst):
         shutil.copyfile(src, dst)
 
 
 def symlinkfiles(source, dest):
+    """Symlink source file to dest file."""
     # Beware, this example does not handle any edge cases!
     with open(source, 'rb') as src, open(dest, 'wb') as dst:
         copyfileobj_example(src, dst)
 
 
 def extractreg(mask, nifti):
+    """Extract mean signal within mask from NIFTI."""
     masker = NiftiMasker(mask_img=mask)
     signals = masker.fit_transform(nifti)
     return np.mean(signals, axis=1)
 
 
 def writejson(data, outfile):
+    """Write dictionary to JSON file."""
     with open(outfile, 'w') as f:
         json.dump(data, f)
     return outfile

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -1,15 +1,27 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-""" compute FD, genetrate mask  """
-
+"""Functions for interpolating over high-motion volumes."""
 import numpy as np
 
 
 def compute_FD(confound, head_radius=50):
-    """
-    computes FD
-    """
+    """Compute framewise displacement.
 
+    NOTE: TS- Which kind of FD? Power?
+    NOTE: TS- What units must rotation parameters be in?
+
+    Parameters
+    ----------
+    confound : pandas.DataFrame
+        DataFrame with six motion parameters.
+    head_radius : int, optional
+        The head radius, in millimeters. Default is 50.
+
+    Returns
+    -------
+    fdres : numpy.ndarray
+        The framewise displacement time series.
+    """
     confound = confound.replace(np.nan, 0)
     mpars = confound[[
         "trans_x", "trans_y", "trans_z", "rot_x", "rot_y", "rot_z"
@@ -22,11 +34,23 @@ def compute_FD(confound, head_radius=50):
     return fdres
 
 
-def generate_mask(
-    fd_res,
-    fd_thresh,
-):
+def generate_mask(fd_res, fd_thresh):
+    """Create binary temporal mask flagging high-motion volumes.
 
+    Parameters
+    ----------
+    fd_res : numpy.ndarray of shape (T)
+        Framewise displacement time series.
+        T = time.
+    fd_thresh : float
+        Threshold used to identify high-motion volumes.
+        Any ``fd_res`` values greater than the threshold will be flagged.
+
+    Returns
+    -------
+    tmask : numpy.ndarray of shape (T)
+        The temporal mask. Zeros are low-motion volumes. Ones are high-motion volumes.
+    """
     tmask = np.zeros(len(fd_res))
     tmask[fd_res > fd_thresh] = 1
 
@@ -34,17 +58,38 @@ def generate_mask(
 
 
 def interpolate_masked_data(bold_data, tmask, TR=1):
+    """Interpolate masked data.
+
+    No interpolation will be performed if more than 50% of the volumes in the BOLD data are
+    flagged by the temporal mask.
+
+    NOTE: TS- Why are slice times being inferred from the number of volumes?
+    Am I missing somehting?
+
+    Parameters
+    ----------
+    bold_data : numpy.ndarray of shape (S, T)
+        The BOLD data to interpolate.
+        T = time, S = samples.
+    tmask : numpy.ndarray of shape (T)
+        A temporal mask in which ones indicate volumes to be flagged and interpolated across.
+    TR : float, optional
+        The repetition time of the BOLD data, in seconds. Default is 1.
+
+    Returns
+    -------
+    bold_data_interpolated : numpy.ndarray of shape (S, T)
+        The interpolated BOLD data.
+    """
     # import interpolate functionality
     from scipy.interpolate import interp1d
 
     # Confirm that interpolation can be correctly performed
     bold_data_interpolated = bold_data
     if np.mean(tmask) == 0:
-        print('No flagged volume, interpolation will not be done .')
+        print('No flagged volume, interpolation will not be done.')
     elif np.mean(tmask) > 0.5:
-        print(
-            'More than 50% of volumes are flagged, interpolation will not be done '
-        )
+        print('More than 50% of volumes are flagged, interpolation will not be done.')
     else:
         # Create slice time array
         slice_times = TR * np.arange(0, (bold_data.shape[1]), 1)

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -19,7 +19,7 @@ from xcp_d.utils.write_save import read_ndata, scalex, write_ndata
 
 
 def _decimate_data(data, seg_data, size):
-    """Decimate timeseries data
+    """Decimate timeseries data.
 
     Parameters
     ----------
@@ -29,7 +29,6 @@ def _decimate_data(data, seg_data, size):
         1 element array of samples
     size : tuple
         2 element for P/T decimation
-
     """
     p_dec = 1 + data.shape[0] // size[0]
     if p_dec:
@@ -42,8 +41,10 @@ def _decimate_data(data, seg_data, size):
 
 
 def plotimage(img, out_file):
-    fig = plt.figure(constrained_layout=False, figsize=(25, 10))
+    """Plot anatomical image and save to file."""
     from nilearn.plotting import plot_anat
+
+    fig = plt.figure(constrained_layout=False, figsize=(25, 10))
     plot_anat(img, draw_cross=False, figure=fig)
     fig.savefig(out_file, bbox_inches="tight", pad_inches=None)
     return out_file
@@ -305,7 +306,6 @@ def confoundplotx(time_series,
                   ylabel=None,
                   FD=False,
                   work_dir=None):
-
     sns.set_style('whitegrid')
 
     # Define TR and number of frames

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -15,8 +15,7 @@ from nilearn._utils import check_niimg_4d
 from nilearn._utils.niimg import _safe_get_data
 from nilearn.signal import clean
 
-from xcp_d.utils import read_ndata, write_ndata
-from xcp_d.utils.write_save import scalex
+from xcp_d.utils.write_save import read_ndata, scalex, write_ndata
 
 
 def _decimate_data(data, seg_data, size):

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -479,29 +479,29 @@ def plot_svgx(rawdata,
               regressed_dvars=None,
               filtered_dvars=None,
               work_dir=None):
-    """
-    generate carpet plot with dvars, fd, and WB
-    ------------
-    rawdata:
-       nifti or cifti before processing
-    regressed_data:
-      nifti or cifti after nuissance regression
-    residual_data:
-      nifti or cifti after regression and filtering
-    mask:
-         mask for nifti if available
-    seg_data:
-        3 tissues seg_data files
-    TR:
-        repetition times
-    fd:
-      framewise displacement
-    unprocessed_filename:
-      output file svg before processing
-    processed_filename:
-      output file svg after processing
-    """
+    """Generate carpet plot with DVARS, FD, and WB.
 
+    Parameters
+    ----------
+    rawdata :
+        nifti or cifti before processing
+    regressed_data :
+        nifti or cifti after nuissance regression
+    residual_data :
+        nifti or cifti after regression and filtering
+    mask :
+        mask for nifti if available
+    seg_data :
+        3 tissues seg_data files
+    TR : float, optional
+        repetition times
+    fd :
+        framewise displacement
+    unprocessed_filename :
+        output file svg before processing
+    processed_filename :
+        output file svg after processing
+    """
     # Compute dvars correctly if not already done
     if type(raw_dvars) != np.ndarray:
         raw_dvars = compute_dvars(read_ndata(datafile=rawdata, maskfile=mask))
@@ -710,10 +710,8 @@ class fMRIPlot:
                 self.spikes.append((np.loadtxt(sp_file), None, False))
 
     def plot(self, labelsize, figure=None):
-        """Main plotter"""
-
+        """Perform main plotting step."""
         # Layout settings
-
         sns.set_style("whitegrid")
         sns.set_context("paper", font_scale=1)
 
@@ -780,40 +778,38 @@ def plot_carpet(
     TR=None,
     lut=None,
 ):
-    """
-    Plot an image representation of voxel intensities across time also know
-    as the "carpet plot" or "Power plot". See Jonathan Power Neuroimage
-    2017 Jul 1; 154:150-158.
+    """Plot an image representation of voxel intensities across time.
+
+    This is also know. as the "carpet plot" or "Power plot".
+    See Jonathan Power Neuroimage 2017 Jul 1; 154:150-158.
 
     Parameters
     ----------
-
-        func : string
-            Path to NIfTI or CIFTI BOLD image
-        atlaslabels: ndarray, optional
-            A 3D array of integer labels from an atlas, resampled into ``img`` space.
-            Required if ``func`` is a NIfTI image.
-        detrend : boolean, optional
-            Detrend and standardize the data prior to plotting.
-        size : tuple, optional
-            Size of figure.
-        subplot : matplotlib Subplot, optional
-            Subplot to plot figure on.
-        title : string, optional
-            The title displayed on the figure.
-        output_file : string, or None, optional
-            The name of an image file to export the plot to. Valid extensions
-            are .png, .pdf, .svg. If output_file is not None, the plot
-            is saved to a file, and the display is closed.
-        legend : bool
-            Whether to render the average functional series with ``atlaslabels`` as
-            overlay.
-        TR : float , optional
-            Specify the TR, if specified it uses this value. If left as None,
-            # of frames is plotted instead of time.
-        lut : ndarray, optional
-            Look up table for segmentations
-
+    func : str
+        Path to NIfTI or CIFTI BOLD image
+    atlaslabels : numpy.ndarray, optional
+        A 3D array of integer labels from an atlas, resampled into ``img`` space.
+        Required if ``func`` is a NIfTI image.
+    detrend : bool, optional
+        Detrend and standardize the data prior to plotting.
+    size : tuple, optional
+        Size of figure.
+    subplot : matplotlib Subplot, optional
+        Subplot to plot figure on.
+    title : str, optional
+        The title displayed on the figure.
+    output_file : str or None, optional
+        The name of an image file to export the plot to. Valid extensions
+        are .png, .pdf, .svg. If output_file is not None, the plot
+        is saved to a file, and the display is closed.
+    legend : bool
+        Whether to render the average functional series with ``atlaslabels`` as
+        overlay.
+    TR : float, optional
+        Specify the TR, if specified it uses this value. If left as None,
+        # of frames is plotted instead of time.
+    lut : numpy.ndarray, optional
+        Look up table for segmentations
     """
     epinii = None
     segnii = None
@@ -927,7 +923,7 @@ def _carpet(func,
             epinii=None,
             segnii=None,
             nslices=None):
-    """Common carpetplot building code for volumetric / CIFTI plots"""
+    """Build carpetplot for volumetric / CIFTI plots."""
     if TR is None:
         TR = 1.0  # Default TR
     sns.set_style("whitegrid")
@@ -1025,9 +1021,7 @@ def _carpet(func,
 
 
 def plot_text(imgdata, grid_spec_ts):
-    """
-    Get the correct text for each plot
-    """
+    """Get the correct text for each plot."""
     grid_specification = mgs.GridSpecFromSubplotSpec(1,
                                                      2,
                                                      subplot_spec=grid_spec_ts,
@@ -1048,9 +1042,7 @@ def plot_text(imgdata, grid_spec_ts):
 
 
 def display_cb(grid_spec_ts):
-    """
-    Settings for colorbar display
-    """
+    """Set settings for colorbar display."""
     grid_specification = mgs.GridSpecFromSubplotSpec(1,
                                                      2,
                                                      subplot_spec=grid_spec_ts,
@@ -1070,8 +1062,7 @@ def display_cb(grid_spec_ts):
 
 
 def _get_TR(img):
-    """
-    Attempt to extract repetition time from NIfTI/CIFTI header
+    """Attempt to extract repetition time from NIfTI/CIFTI header.
 
     Examples
     --------

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -306,6 +306,7 @@ def confoundplotx(time_series,
                   ylabel=None,
                   FD=False,
                   work_dir=None):
+    """Create confounds plot."""
     sns.set_style('whitegrid')
 
     # Define TR and number of frames
@@ -1073,7 +1074,6 @@ def _get_TR(img):
     ...    'sub-01_task-mixedgamblestask_run-02_space-fsLR_den-91k_bold.dtseries.nii'))
     2.0
     """
-
     try:
         return img.header.matrix.get_index_map(0).series_step  # Get TR
     except AttributeError:  # Error out if not in cifti

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -4,6 +4,28 @@ import numpy as np
 
 
 def regisQ(bold2t1w_mask, t1w_mask, bold2template_mask, template_mask):
+    """Compute quality of registration metrics.
+
+    This function will calculate a series of metrics, including Dice's similarity index,
+    Jaccard's coefficient, cross-correlation, and coverage, between the BOLD-to-T1w brain mask
+    and the T1w mask, as well as between the BOLD-to-template brain mask and the template mask.
+
+    Parameters
+    ----------
+    bold2t1w_mask : str
+        Path to the BOLD mask in T1w space.
+    t1w_mask : str
+        Path to the T1w mask.
+    bold2template_mask : str
+        Path to the BOLD mask in template space.
+    template_mask : str
+        Path to the template mask.
+
+    Returns
+    -------
+    reg_qc : dict
+        Quality control measures between different inputs.
+    """
     reg_qc = {
         'coregDice': [dc(bold2t1w_mask, t1w_mask)],
         'coregJaccard': [jc(bold2t1w_mask, t1w_mask)],
@@ -18,27 +40,30 @@ def regisQ(bold2t1w_mask, t1w_mask, bold2template_mask, template_mask):
 
 
 def dc(input1, input2):
-    r"""
-    Dice coefficient
+    r"""Calculate Dice coefficient between two images.
+
     Computes the Dice coefficient (also known as Sorensen index) between the binary
     objects in twom j images.
+
     The metric is defined as
     .. math::
         DC=\frac{2|A\cap B|}{|A|+|B|}
+
     , where :math:`A` is the first and :math:`B` the second set of samples (here: binary objects).
+
     Parameters
     ----------
-    input1 : array_like
-        Input data containing objects. Can be any type but will be converted
-        into binary: background where 0, object everywhere else.
-    input2 : array_like
-        Input data containing objects. Can be any type but will be converted
-        into binary: background where 0, object everywhere else.
+    input1/input2 : str
+        Path to a NIFTI image.
+        Can be any type but will be converted into binary:
+        False where 0, True everywhere else.
+
     Returns
     -------
     dc : float
         The Dice coefficient between the object(s) in ```input1``` and the
         object(s) in ```input2```. It ranges from 0 (no overlap) to 1 (perfect overlap).
+
     Notes
     -----
     This is a real metric.
@@ -62,22 +87,24 @@ def dc(input1, input2):
 
 
 def jc(input1, input2):
-    r"""
-    Jaccard coefficient
+    r"""Calculate Jaccard coefficient between two images.
+
     Computes the Jaccard coefficient between the binary objects in two images.
+
     Parameters
     ----------
-    input1: array_like
-            Input data containing objects. Can be any type but will be converted
-            into binary: background where 0, object everywhere else.
-    input2: array_like
-            Input data containing objects. Can be any type but will be converted
-            into binary: background where 0, object everywhere else.
+    input1/input2 : str
+        Path to a NIFTI image.
+        Can be any type but will be converted into binary:
+        False where 0, True everywhere else.
+
     Returns
     -------
-    jc: float
-        The Jaccard coefficient between the object(s) in `input1` and the
-        object(s) in `input2`. It ranges from 0 (no overlap) to 1 (perfect overlap).
+    jc : float
+        The Jaccard coefficient between the object(s) in ``input1`` and the
+        object(s) in ``input2``.
+        It ranges from 0 (no overlap) to 1 (perfect overlap).
+
     Notes
     -----
     This is a real metric.
@@ -96,9 +123,21 @@ def jc(input1, input2):
 
 
 def crosscorr(input1, input2):
-    r"""
-    cross correlation
-    computer compute cross correction bewteen input mask
+    """Calculate cross correlation between two images.
+
+    NOTE: TS- This appears to be Pearson's correlation, not cross-correlation.
+
+    Parameters
+    ----------
+    input1/input2 : str
+        Path to a NIFTI image.
+        Can be any type but will be converted into binary:
+        False where 0, True everywhere else.
+
+    Returns
+    -------
+    cc : float
+        Correlation between the two images.
     """
     input1 = nb.load(input1).get_fdata()
     input2 = nb.load(input2).get_fdata()
@@ -109,8 +148,19 @@ def crosscorr(input1, input2):
 
 
 def coverage(input1, input2):
-    """
-    estimate the coverage between  two mask
+    """Estimate the coverage between two masks.
+
+    Parameters
+    ----------
+    input1/input2 : str
+        Path to a NIFTI image.
+        Can be any type but will be converted into binary:
+        False where 0, True everywhere else.
+
+    Returns
+    -------
+    cov : float
+        Coverage between two images.
     """
     input1 = nb.load(input1).get_fdata()
     input2 = nb.load(input2).get_fdata()

--- a/xcp_d/utils/restingstate.py
+++ b/xcp_d/utils/restingstate.py
@@ -14,10 +14,11 @@ from nipype.interfaces.base import SimpleInterface
 
 
 class ReHoNamePatch(SimpleInterface):
-    """Compute regional homogenity for a given neighbourhood.l,
-    based on a local neighborhood of that voxel.
+    """Compute ReHo for a given neighbourhood, based on a local neighborhood of that voxel.
+
     For complete details, see the `3dReHo Documentation.
     <https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dReHo.html>`_
+
     Examples
     --------
     >>> from nipype.interfaces import afni
@@ -45,7 +46,7 @@ class ReHoNamePatch(SimpleInterface):
 
 
 class DespikePatch(SimpleInterface):
-    """Removes 'spikes' from the 3D+time input dataset
+    """Remove 'spikes' from the 3D+time input dataset.
 
     For complete details, see the `3dDespike Documentation.
     <https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dDespike.html>`_
@@ -58,7 +59,6 @@ class DespikePatch(SimpleInterface):
     >>> despike.cmdline
     '3dDespike -prefix functional_despike functional.nii'
     >>> res = despike.run()  # doctest: +SKIP
-
     """
 
     _cmd = "3dDespike"
@@ -73,7 +73,8 @@ class DespikePatch(SimpleInterface):
 
 
 class ContrastEnhancement(SimpleInterface):
-    """contrast enhancement with afni
+    """Perform contrast enhancement with AFNI.
+
     3dUnifize  -input inputdat   -prefix  t1w_contras.nii.gz
     """
 

--- a/xcp_d/utils/sentry.py
+++ b/xcp_d/utils/sentry.py
@@ -34,6 +34,7 @@ def start_ping(run_uuid, npart):
 
 
 def sentry_setup(opts, exec_env):
+    """Set up sentry."""
     from os import cpu_count
 
     import psutil
@@ -91,7 +92,7 @@ def sentry_setup(opts, exec_env):
 
 
 def process_crashfile(crashfile):
-    """Parse the contents of a crashfile and submit sentry messages"""
+    """Parse the contents of a crashfile and submit sentry messages."""
     crash_info = read_crashfile(str(crashfile))
     with sentry_sdk.push_scope() as scope:
         scope.level = 'fatal'
@@ -184,9 +185,10 @@ def before_send(event, hints):
 
 
 def _chunks(string, length=CHUNK_SIZE):
-    """
-    Splits a string into smaller chunks
+    """Split a string into smaller chunks.
 
+    Examples
+    --------
     >>> list(_chunks('some longer string.', length=3))
     ['som', 'e l', 'ong', 'er ', 'str', 'ing', '.']
 

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -156,7 +156,7 @@ def get_maskfiles(bold_file, mni_to_t1w):
 
 
 def get_transformfile(bold_file, mni_to_t1w, t1w_to_native):
-    """"Obtain transforms to warp atlases from MNI space to the same space as the bold file.
+    """Obtain transforms to warp atlases from MNI space to the same space as the bold file.
 
     Since ANTSApplyTransforms takes in the transform files as a stack,
     these are applied in the reverse order of which they are specified.

--- a/xcp_d/utils/write_save.py
+++ b/xcp_d/utils/write_save.py
@@ -142,14 +142,21 @@ def write_ndata(data_matrix, template, filename, mask=None, TR=1, scale=0):
 
 
 def edit_ciftinifti(in_file, out_file, datax):
-    """
-    this function create a fake nifti file from cifti
-    in_file:
-       cifti file. .dstreries etc
-    out_file:
-       output fake nifti file
-    datax: numpy darray
-      data matrix with vertices by timepoints dimension
+    """Create a fake nifti file from cifti.
+
+    Parameters
+    ----------
+    in_file : str
+        cifti file. .dstreries etc
+    out_file : str
+        output fake nifti file
+    datax : numpy.ndarray
+        data matrix with vertices by timepoints dimension
+
+    Returns
+    -------
+    out_file : str
+        The output filename.
     """
     thdata = nb.load(in_file)
     dataxx = thdata.get_fdata()
@@ -162,10 +169,19 @@ def edit_ciftinifti(in_file, out_file, datax):
 
 
 def run_shell(cmd, env=os.environ):
-    """
-    utilities to run shell in python
-    cmd:
-     shell command that wanted to be run
+    """Run shell in python.
+
+    Parameters
+    ----------
+    cmd : str
+        shell command that wanted to be run
+    env
+        Environment variables.
+
+    Returns
+    -------
+    output
+    error
     """
     if type(cmd) is list:
         cmd = ' '.join(cmd)
@@ -184,10 +200,20 @@ def run_shell(cmd, env=os.environ):
 
 
 def write_gii(datat, template, filename, hemi):
-    """
-    datatt : vector
-    template: real file loaded with nibabel to get header and filemap
-    filename ; name of the output
+    """Use nibabel to write surface file.
+
+    Parameters
+    ----------
+    datatt : numpy.ndarray
+        vector
+    template : str
+        real file loaded with nibabel to get header and filemap
+    filename : str
+        name of the output
+
+    Returns
+    -------
+    filename
     """
     datax = np.array(datat, dtype='float32')
     template = str(
@@ -208,9 +234,7 @@ def write_gii(datat, template, filename, hemi):
 
 
 def read_gii(surf_gii):
-    """
-    Using nibabel to read surface file
-    """
+    """Use nibabel to read surface file."""
     bold_data = nb.load(surf_gii)  # load the gifti
     gifti_data = bold_data.agg_data()  # aggregate the data
     if not hasattr(gifti_data, '__shape__'):  # if it doesn't have 'shape', reshape
@@ -221,7 +245,7 @@ def read_gii(surf_gii):
 
 
 def despikedatacifti(cifti, TR, basedir):
-    """ despiking cifti """
+    """Despike CIFTI file."""
     fake_cifti1 = str(basedir + '/fake_niftix.nii.gz')
     fake_cifti1_depike = str(basedir + '/fake_niftix_depike.nii.gz')
     cifti_despike = str(basedir + '/despike_nifti2cifti.dtseries.nii')


### PR DESCRIPTION
Related to, but does not close, https://github.com/PennLINC/xcp_d/issues/471.

## Changes proposed in this pull request
- Make utils imports more specific, to prevent circular imports.
- Run isort on `utils.__init__.py`.
- Work on standardizing docstrings in the `utils` module.

## Documentation that should be reviewed
None.