### PR TITLE
[REF] Rename classes to CamelCase

### DIFF
--- a/.circleci/tests/test_Reg.py
+++ b/.circleci/tests/test_Reg.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import scipy
 
-from xcp_d.interfaces import regress
+from xcp_d.interfaces import Regress
 from xcp_d.utils import read_ndata
 
 
@@ -18,7 +18,7 @@ def test_Reg_Nifti(data_dir):
     mask = data_dir + "/fmriprep/sub-colornest001/ses-1/func/" \
         "sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
     # Run regression
-    test_nifti = regress(mask=mask, in_file=in_file,
+    test_nifti = Regress(mask=mask, in_file=in_file,
                          original_file=in_file, confounds=confounds, TR=TR)
     results = test_nifti.run()
 
@@ -58,7 +58,7 @@ def test_Reg_Cifti(data_dir):
     mask = data_dir + "/fmriprep/sub-colornest001/ses-1/func/" \
         "sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
     # Run regression
-    test_cifti = regress(mask=mask, in_file=in_file,
+    test_cifti = Regress(mask=mask, in_file=in_file,
                          original_file=in_file, confounds=confounds, TR=TR)
     results = test_cifti.run()
 

--- a/.circleci/tests/test_interpolation.py
+++ b/.circleci/tests/test_interpolation.py
@@ -8,7 +8,7 @@ import tempfile
 import numpy as np
 from scipy.fftpack import fft
 
-from xcp_d.interfaces.prepostcleaning import interpolate
+from xcp_d.interfaces.prepostcleaning import Interpolate
 from xcp_d.utils import read_ndata, write_ndata
 
 
@@ -88,7 +88,7 @@ def test_interpolate_cifti(data_dir, tmp_path_factory):
     tmask[100] = 1
     np.savetxt(tmask_file, tmask)
 
-    interpolation = interpolate()
+    interpolation = Interpolate()
     interpolation.inputs.tmask = tmask_file
     interpolation.inputs.in_file = noise_file
     interpolation.inputs.bold_file = boldfile
@@ -195,7 +195,7 @@ def test_interpolate_nifti(data_dir):
     tmask[8] = 1
     np.savetxt("tmask.tsv", tmask)
 
-    interpolation = interpolate()
+    interpolation = Interpolate()
     interpolation.inputs.tmask = "tmask.tsv"
     interpolation.inputs.in_file = "noisy_file.nii.gz"
     interpolation.inputs.bold_file = boldfile

--- a/setup.cfg
+++ b/setup.cfg
@@ -118,7 +118,7 @@ parentdir_prefix =
 max-line-length = 99
 doctests = True
 exclude=*build/,xcp_d/_version.py,versioneer.py
-ignore = D107,E203,E402,E722,W503
+ignore = D107,E203,E402,E722,W503,N803,N806,N815
 putty-ignore =
     */__init__.py : +F401
     docs/conf.py : +E265

--- a/xcp_d/interfaces/__init__.py
+++ b/xcp_d/interfaces/__init__.py
@@ -12,7 +12,7 @@ from xcp_d.interfaces.filtering import FilteringData
 from xcp_d.interfaces.layout_builder import LayoutBuilder
 from xcp_d.interfaces.prepostcleaning import CensorScrub, RemoveTR, Interpolate
 from xcp_d.interfaces.qc_plot import QCPlot
-from xcp_d.interfaces.regression import ciftidespike, regress
+from xcp_d.interfaces.regression import CiftiDespike, regress
 from xcp_d.interfaces.report import AboutSummary, FunctionalSummary, SubjectSummary
 from xcp_d.interfaces.report_core import generate_reports
 from xcp_d.interfaces.resting_state import brainplot, computealff, surfaceReho
@@ -30,7 +30,7 @@ __all__ = [
     'computealff', 'surfaceReho', 'get_atlas_cifti', 'get_atlas_nifti',
     'ApplyTransformsx', 'Interpolate', 'CensorScrub', 'RemoveTR',
     'QCPlot', 'SubjectSummary', 'AboutSummary', 'FunctionalSummary',
-    'generate_reports', 'ciftidespike', 'ConnectPlot', 'brainplot',
+    'generate_reports', 'CiftiDespike', 'ConnectPlot', 'brainplot',
     'SurftoVolume', 'BrainPlotx', 'PlotSVGData', 'RegPlot', 'PlotImage',
     'LayoutBuilder', 'RibbontoStatmap'
 ]

--- a/xcp_d/interfaces/__init__.py
+++ b/xcp_d/interfaces/__init__.py
@@ -10,7 +10,7 @@ from xcp_d.interfaces.connectivity import (
 )
 from xcp_d.interfaces.filtering import FilteringData
 from xcp_d.interfaces.layout_builder import LayoutBuilder
-from xcp_d.interfaces.prepostcleaning import CensorScrub, RemoveTR, interpolate
+from xcp_d.interfaces.prepostcleaning import CensorScrub, RemoveTR, Interpolate
 from xcp_d.interfaces.qc_plot import computeqcplot
 from xcp_d.interfaces.regression import ciftidespike, regress
 from xcp_d.interfaces.report import AboutSummary, FunctionalSummary, SubjectSummary
@@ -28,7 +28,7 @@ from xcp_d.interfaces.surfplotting import (
 __all__ = [
     'regress', 'FilteringData', 'NiftiConnect',
     'computealff', 'surfaceReho', 'get_atlas_cifti', 'get_atlas_nifti',
-    'ApplyTransformsx', 'interpolate', 'CensorScrub', 'RemoveTR',
+    'ApplyTransformsx', 'Interpolate', 'CensorScrub', 'RemoveTR',
     'computeqcplot', 'SubjectSummary', 'AboutSummary', 'FunctionalSummary',
     'generate_reports', 'ciftidespike', 'ConnectPlot', 'brainplot',
     'SurftoVolume', 'BrainPlotx', 'PlotSVGData', 'RegPlot', 'PlotImage',

--- a/xcp_d/interfaces/__init__.py
+++ b/xcp_d/interfaces/__init__.py
@@ -11,7 +11,7 @@ from xcp_d.interfaces.connectivity import (
 from xcp_d.interfaces.filtering import FilteringData
 from xcp_d.interfaces.layout_builder import LayoutBuilder
 from xcp_d.interfaces.prepostcleaning import CensorScrub, RemoveTR, Interpolate
-from xcp_d.interfaces.qc_plot import computeqcplot
+from xcp_d.interfaces.qc_plot import QCPlot
 from xcp_d.interfaces.regression import ciftidespike, regress
 from xcp_d.interfaces.report import AboutSummary, FunctionalSummary, SubjectSummary
 from xcp_d.interfaces.report_core import generate_reports
@@ -29,7 +29,7 @@ __all__ = [
     'regress', 'FilteringData', 'NiftiConnect',
     'computealff', 'surfaceReho', 'get_atlas_cifti', 'get_atlas_nifti',
     'ApplyTransformsx', 'Interpolate', 'CensorScrub', 'RemoveTR',
-    'computeqcplot', 'SubjectSummary', 'AboutSummary', 'FunctionalSummary',
+    'QCPlot', 'SubjectSummary', 'AboutSummary', 'FunctionalSummary',
     'generate_reports', 'ciftidespike', 'ConnectPlot', 'brainplot',
     'SurftoVolume', 'BrainPlotx', 'PlotSVGData', 'RegPlot', 'PlotImage',
     'LayoutBuilder', 'RibbontoStatmap'

--- a/xcp_d/interfaces/__init__.py
+++ b/xcp_d/interfaces/__init__.py
@@ -12,7 +12,7 @@ from xcp_d.interfaces.filtering import FilteringData
 from xcp_d.interfaces.layout_builder import LayoutBuilder
 from xcp_d.interfaces.prepostcleaning import CensorScrub, RemoveTR, Interpolate
 from xcp_d.interfaces.qc_plot import QCPlot
-from xcp_d.interfaces.regression import CiftiDespike, regress
+from xcp_d.interfaces.regression import CiftiDespike, Regress
 from xcp_d.interfaces.report import AboutSummary, FunctionalSummary, SubjectSummary
 from xcp_d.interfaces.report_core import generate_reports
 from xcp_d.interfaces.resting_state import brainplot, computealff, surfaceReho
@@ -26,7 +26,7 @@ from xcp_d.interfaces.surfplotting import (
 )
 
 __all__ = [
-    'regress', 'FilteringData', 'NiftiConnect',
+    'Regress', 'FilteringData', 'NiftiConnect',
     'computealff', 'surfaceReho', 'get_atlas_cifti', 'get_atlas_nifti',
     'ApplyTransformsx', 'Interpolate', 'CensorScrub', 'RemoveTR',
     'QCPlot', 'SubjectSummary', 'AboutSummary', 'FunctionalSummary',

--- a/xcp_d/interfaces/__init__.py
+++ b/xcp_d/interfaces/__init__.py
@@ -4,7 +4,7 @@
 from xcp_d.interfaces.connectivity import (
     ApplyTransformsx,
     NiftiConnect,
-    connectplot,
+    ConnectPlot,
     get_atlas_cifti,
     get_atlas_nifti,
 )
@@ -30,7 +30,7 @@ __all__ = [
     'computealff', 'surfaceReho', 'get_atlas_cifti', 'get_atlas_nifti',
     'ApplyTransformsx', 'interpolate', 'CensorScrub', 'RemoveTR',
     'computeqcplot', 'SubjectSummary', 'AboutSummary', 'FunctionalSummary',
-    'generate_reports', 'ciftidespike', 'connectplot', 'brainplot',
+    'generate_reports', 'ciftidespike', 'ConnectPlot', 'brainplot',
     'SurftoVolume', 'BrainPlotx', 'PlotSVGData', 'RegPlot', 'PlotImage',
     'LayoutBuilder', 'RibbontoStatmap'
 ]

--- a/xcp_d/interfaces/__init__.py
+++ b/xcp_d/interfaces/__init__.py
@@ -15,7 +15,7 @@ from xcp_d.interfaces.qc_plot import QCPlot
 from xcp_d.interfaces.regression import CiftiDespike, Regress
 from xcp_d.interfaces.report import AboutSummary, FunctionalSummary, SubjectSummary
 from xcp_d.interfaces.report_core import generate_reports
-from xcp_d.interfaces.resting_state import BrainPlot, ComputeALFF, surfaceReho
+from xcp_d.interfaces.resting_state import BrainPlot, ComputeALFF, SurfaceReHo
 from xcp_d.interfaces.surfplotting import (
     BrainPlotx,
     PlotImage,
@@ -27,7 +27,7 @@ from xcp_d.interfaces.surfplotting import (
 
 __all__ = [
     'Regress', 'FilteringData', 'NiftiConnect',
-    'ComputeALFF', 'surfaceReho', 'get_atlas_cifti', 'get_atlas_nifti',
+    'ComputeALFF', 'SurfaceReHo', 'get_atlas_cifti', 'get_atlas_nifti',
     'ApplyTransformsx', 'Interpolate', 'CensorScrub', 'RemoveTR',
     'QCPlot', 'SubjectSummary', 'AboutSummary', 'FunctionalSummary',
     'generate_reports', 'CiftiDespike', 'ConnectPlot', 'BrainPlot',

--- a/xcp_d/interfaces/__init__.py
+++ b/xcp_d/interfaces/__init__.py
@@ -15,7 +15,7 @@ from xcp_d.interfaces.qc_plot import QCPlot
 from xcp_d.interfaces.regression import CiftiDespike, Regress
 from xcp_d.interfaces.report import AboutSummary, FunctionalSummary, SubjectSummary
 from xcp_d.interfaces.report_core import generate_reports
-from xcp_d.interfaces.resting_state import brainplot, computealff, surfaceReho
+from xcp_d.interfaces.resting_state import BrainPlot, computealff, surfaceReho
 from xcp_d.interfaces.surfplotting import (
     BrainPlotx,
     PlotImage,
@@ -30,7 +30,7 @@ __all__ = [
     'computealff', 'surfaceReho', 'get_atlas_cifti', 'get_atlas_nifti',
     'ApplyTransformsx', 'Interpolate', 'CensorScrub', 'RemoveTR',
     'QCPlot', 'SubjectSummary', 'AboutSummary', 'FunctionalSummary',
-    'generate_reports', 'CiftiDespike', 'ConnectPlot', 'brainplot',
+    'generate_reports', 'CiftiDespike', 'ConnectPlot', 'BrainPlot',
     'SurftoVolume', 'BrainPlotx', 'PlotSVGData', 'RegPlot', 'PlotImage',
     'LayoutBuilder', 'RibbontoStatmap'
 ]

--- a/xcp_d/interfaces/__init__.py
+++ b/xcp_d/interfaces/__init__.py
@@ -3,14 +3,14 @@
 """Initialize interfaces."""
 from xcp_d.interfaces.connectivity import (
     ApplyTransformsx,
-    NiftiConnect,
     ConnectPlot,
+    NiftiConnect,
     get_atlas_cifti,
     get_atlas_nifti,
 )
 from xcp_d.interfaces.filtering import FilteringData
 from xcp_d.interfaces.layout_builder import LayoutBuilder
-from xcp_d.interfaces.prepostcleaning import CensorScrub, RemoveTR, Interpolate
+from xcp_d.interfaces.prepostcleaning import CensorScrub, Interpolate, RemoveTR
 from xcp_d.interfaces.qc_plot import QCPlot
 from xcp_d.interfaces.regression import CiftiDespike, Regress
 from xcp_d.interfaces.report import AboutSummary, FunctionalSummary, SubjectSummary

--- a/xcp_d/interfaces/__init__.py
+++ b/xcp_d/interfaces/__init__.py
@@ -15,7 +15,7 @@ from xcp_d.interfaces.qc_plot import QCPlot
 from xcp_d.interfaces.regression import CiftiDespike, Regress
 from xcp_d.interfaces.report import AboutSummary, FunctionalSummary, SubjectSummary
 from xcp_d.interfaces.report_core import generate_reports
-from xcp_d.interfaces.resting_state import BrainPlot, computealff, surfaceReho
+from xcp_d.interfaces.resting_state import BrainPlot, ComputeALFF, surfaceReho
 from xcp_d.interfaces.surfplotting import (
     BrainPlotx,
     PlotImage,
@@ -27,7 +27,7 @@ from xcp_d.interfaces.surfplotting import (
 
 __all__ = [
     'Regress', 'FilteringData', 'NiftiConnect',
-    'computealff', 'surfaceReho', 'get_atlas_cifti', 'get_atlas_nifti',
+    'ComputeALFF', 'surfaceReho', 'get_atlas_cifti', 'get_atlas_nifti',
     'ApplyTransformsx', 'Interpolate', 'CensorScrub', 'RemoveTR',
     'QCPlot', 'SubjectSummary', 'AboutSummary', 'FunctionalSummary',
     'generate_reports', 'CiftiDespike', 'ConnectPlot', 'BrainPlot',

--- a/xcp_d/interfaces/ants.py
+++ b/xcp_d/interfaces/ants.py
@@ -47,7 +47,7 @@ class ConvertTransformFile(CommandLine):
     output_spec = _ConvertTransformFileOutputSpec
 
 
-class CompositeInvTransformUtilInputSpec(ANTSCommandInputSpec):
+class _CompositeInvTransformUtilInputSpec(ANTSCommandInputSpec):
     """Input specification for CompositeInvTransformUtil."""
 
     process = traits.Enum(
@@ -80,7 +80,7 @@ class CompositeInvTransformUtilInputSpec(ANTSCommandInputSpec):
     )
 
 
-class CompositeInvTransformUtilOutputSpec(TraitedSpec):
+class _CompositeInvTransformUtilOutputSpec(TraitedSpec):
     """Output specification for CompositeInvTransformUtil."""
 
     affine_transform = File(desc="Affine transform component")
@@ -116,8 +116,8 @@ class CompositeInvTransformUtil(ANTSCommand):
     """
 
     _cmd = "CompositeTransformUtil"
-    input_spec = CompositeInvTransformUtilInputSpec
-    output_spec = CompositeInvTransformUtilOutputSpec
+    input_spec = _CompositeInvTransformUtilInputSpec
+    output_spec = _CompositeInvTransformUtilOutputSpec
 
     def _num_threads_update(self):
         """Do not update the number of threads environment variable.

--- a/xcp_d/interfaces/c3.py
+++ b/xcp_d/interfaces/c3.py
@@ -21,7 +21,7 @@ from xcp_d.utils.filemanip import split_filename
 iflogger = logging.getLogger("interface")
 
 
-class C3dAffineToolInputSpec(CommandLineInputSpec):
+class _C3dAffineToolInputSpec(CommandLineInputSpec):
     """Input specification for C3dAffineTool."""
 
     reference_file = File(exists=True, argstr="-ref %s", position=1)
@@ -38,7 +38,7 @@ class C3dAffineToolInputSpec(CommandLineInputSpec):
     fsl2ras = traits.Bool(argstr="-fsl2ras", position=4)
 
 
-class C3dAffineToolOutputSpec(TraitedSpec):
+class _C3dAffineToolOutputSpec(TraitedSpec):
     """Output specification for C3dAffineTool."""
 
     itk_transform = File(exists=True)
@@ -58,14 +58,14 @@ class C3dAffineTool(SEMLikeCommandLine):
     'c3d_affine_tool -src cmatrix.mat -fsl2ras -oitk affine.txt'
     """
 
-    input_spec = C3dAffineToolInputSpec
-    output_spec = C3dAffineToolOutputSpec
+    input_spec = _C3dAffineToolInputSpec
+    output_spec = _C3dAffineToolOutputSpec
 
     _cmd = "c3d_affine_tool"
     _outputs_filenames = {"itk_transform": "affine.txt"}
 
 
-class C3dInputSpec(CommandLineInputSpec):
+class _C3dInputSpec(CommandLineInputSpec):
     """Input specification for C3d."""
 
     in_file = InputMultiPath(
@@ -166,7 +166,7 @@ class C3dInputSpec(CommandLineInputSpec):
     )
 
 
-class C3dOutputSpec(TraitedSpec):
+class _C3dOutputSpec(TraitedSpec):
     """Output specification for C3d."""
 
     out_files = OutputMultiPath(File(exists=False))
@@ -198,8 +198,8 @@ class C3d(CommandLine):
     'c4d epi.nii -type short -o epi.img'
     """
 
-    input_spec = C3dInputSpec
-    output_spec = C3dOutputSpec
+    input_spec = _C3dInputSpec
+    output_spec = _C3dOutputSpec
 
     _cmd = "c3d"
 

--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -183,7 +183,7 @@ def get_atlas_cifti(atlasname):
     return atlasfile
 
 
-class _connectplotInputSpec(BaseInterfaceInputSpec):
+class _ConnectPlotInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc="bold file")
     sc217_timeseries = File(exists=True, mandatory=True, desc="sc217 atlas")
     sc417_timeseries = File(exists=True, mandatory=True, desc="sc417 atlas")
@@ -191,18 +191,18 @@ class _connectplotInputSpec(BaseInterfaceInputSpec):
     gs360_timeseries = File(exists=True, mandatory=True, desc="glasser atlas")
 
 
-class _connectplotOutputSpec(TraitedSpec):
+class _ConnectPlotOutputSpec(TraitedSpec):
     connectplot = File(
         exists=True,
         manadatory=True,
     )
 
 
-class connectplot(SimpleInterface):
+class ConnectPlot(SimpleInterface):
     """Extract timeseries and compute connectivity matrices."""
 
-    input_spec = _connectplotInputSpec
-    output_spec = _connectplotOutputSpec
+    input_spec = _ConnectPlotInputSpec
+    output_spec = _ConnectPlotOutputSpec
 
     def _run_interface(self, runtime):
 

--- a/xcp_d/interfaces/filtering.py
+++ b/xcp_d/interfaces/filtering.py
@@ -22,7 +22,7 @@ from xcp_d.utils.write_save import read_ndata, write_ndata
 LOGGER = logging.getLogger('nipype.interface')
 
 
-class _filterdataInputSpec(BaseInterfaceInputSpec):
+class _FilteringDataInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True,
                    mandatory=True,
                    desc="Bold file")
@@ -47,7 +47,7 @@ class _filterdataInputSpec(BaseInterfaceInputSpec):
                                   desc="To apply bandpass or not")
 
 
-class _filterdataOutputSpec(TraitedSpec):
+class _FilteringDataOutputSpec(TraitedSpec):
     filtered_file = File(exists=True, manadatory=True, desc="Filtered file")
 
 

--- a/xcp_d/interfaces/filtering.py
+++ b/xcp_d/interfaces/filtering.py
@@ -69,8 +69,8 @@ class FilteringData(SimpleInterface):
     tmpdir.cleanup()
     """
 
-    input_spec = _filterdataInputSpec
-    output_spec = _filterdataOutputSpec
+    input_spec = _FilteringDataInputSpec
+    output_spec = _FilteringDataOutputSpec
 
     def _run_interface(self, runtime):
 

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -333,7 +333,7 @@ class CensorScrub(SimpleInterface):
         return runtime
 
 
-class _interpolateInputSpec(BaseInterfaceInputSpec):
+class _InterpolateInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc=" censored or clean bold")
     bold_file = File(exists=True,
                      mandatory=True,
@@ -345,13 +345,13 @@ class _interpolateInputSpec(BaseInterfaceInputSpec):
                       desc="repetition time in TR")
 
 
-class _interpolateOutputSpec(TraitedSpec):
+class _InterpolateOutputSpec(TraitedSpec):
     bold_interpolated = File(exists=True,
                              manadatory=True,
                              desc=" fmriprep censored")
 
 
-class interpolate(SimpleInterface):
+class Interpolate(SimpleInterface):
     """Interpolates scrubbed/regressed BOLD data based on temporal mask.
 
     Interpolation takes in the scrubbed/regressed bold file and temporal mask,
@@ -360,8 +360,8 @@ class interpolate(SimpleInterface):
     It outputs the interpolated file.
     """
 
-    input_spec = _interpolateInputSpec
-    output_spec = _interpolateOutputSpec
+    input_spec = _InterpolateInputSpec
+    output_spec = _InterpolateOutputSpec
 
     def _run_interface(self, runtime):
         # Read in regressed bold data and temporal mask

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -28,7 +28,7 @@ from xcp_d.utils.write_save import read_ndata, write_ndata
 LOGGER = logging.getLogger('nipype.interface')
 
 
-class _computeqcplotInputSpec(BaseInterfaceInputSpec):
+class _QCPlotInputSpec(BaseInterfaceInputSpec):
     bold_file = File(exists=True,
                      mandatory=True,
                      desc="Raw bold file from fMRIPrep")
@@ -64,7 +64,7 @@ class _computeqcplotInputSpec(BaseInterfaceInputSpec):
         desc='High frequency for Notch filter in BPM')
 
 
-class _computeqcplotOutputSpec(TraitedSpec):
+class _QCPlotOutputSpec(TraitedSpec):
     qc_file = File(exists=True, manadatory=True, desc="qc file in tsv")
     raw_qcplot = File(exists=True,
                       manadatory=True,
@@ -74,7 +74,7 @@ class _computeqcplotOutputSpec(TraitedSpec):
                         desc="qc plot after regression")
 
 
-class computeqcplot(SimpleInterface):
+class QCPlot(SimpleInterface):
     """Generate a quality control (QC) figure.
 
     Examples
@@ -84,7 +84,7 @@ class computeqcplot(SimpleInterface):
     >>> tmpdir = TemporaryDirectory()
     >>> os.chdir(tmpdir.name)
     .. doctest::
-    computeqcwf = computeqcplot()
+    computeqcwf = QCPlot()
     computeqcwf.inputs.cleaned_file = datafile
     computeqcwf.inputs.bold_file = rawbold
     computeqcwf.inputs.TR = TR
@@ -96,8 +96,8 @@ class computeqcplot(SimpleInterface):
     >>> tmpdir.cleanup()
     """
 
-    input_spec = _computeqcplotInputSpec
-    output_spec = _computeqcplotOutputSpec
+    input_spec = _QCPlotInputSpec
+    output_spec = _QCPlotOutputSpec
 
     def _run_interface(self, runtime):
         # Load confound matrix and load motion with motion filtering

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -28,7 +28,7 @@ from xcp_d.utils.write_save import read_ndata, write_ndata
 LOGGER = logging.getLogger('nipype.interface')
 
 
-class _qcInputSpec(BaseInterfaceInputSpec):
+class _computeqcplotInputSpec(BaseInterfaceInputSpec):
     bold_file = File(exists=True,
                      mandatory=True,
                      desc="Raw bold file from fMRIPrep")
@@ -64,7 +64,7 @@ class _qcInputSpec(BaseInterfaceInputSpec):
         desc='High frequency for Notch filter in BPM')
 
 
-class _qcOutputSpec(TraitedSpec):
+class _computeqcplotOutputSpec(TraitedSpec):
     qc_file = File(exists=True, manadatory=True, desc="qc file in tsv")
     raw_qcplot = File(exists=True,
                       manadatory=True,
@@ -96,8 +96,8 @@ class computeqcplot(SimpleInterface):
     >>> tmpdir.cleanup()
     """
 
-    input_spec = _qcInputSpec
-    output_spec = _qcOutputSpec
+    input_spec = _computeqcplotInputSpec
+    output_spec = _computeqcplotOutputSpec
 
     def _run_interface(self, runtime):
         # Load confound matrix and load motion with motion filtering

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -265,10 +265,12 @@ class QCPlot(SimpleInterface):
         qc_dictionary.update(qc_values)
         if self.inputs.bold2T1w_mask:  # If a bold mask in T1w is provided
             # Compute quality of registration
-            registration_qc = compute_registration_qc(bold2t1w_mask=self.inputs.bold2T1w_mask,
-                                     t1w_mask=self.inputs.t1w_mask,
-                                     bold2template_mask=self.inputs.bold2temp_mask,
-                                     template_mask=self.inputs.template_mask)
+            registration_qc = compute_registration_qc(
+                bold2t1w_mask=self.inputs.bold2T1w_mask,
+                t1w_mask=self.inputs.t1w_mask,
+                bold2template_mask=self.inputs.bold2temp_mask,
+                template_mask=self.inputs.template_mask,
+            )
             qc_dictionary.update(registration_qc)  # Add values to dictionary
 
         # Convert dictionary to df and write out the qc file

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -22,7 +22,7 @@ from xcp_d.utils.write_save import despikedatacifti, read_ndata, write_ndata
 LOGGER = logging.getLogger('nipype.interface')
 
 
-class _regressInputSpec(BaseInterfaceInputSpec):
+class _RegressInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True,
                    mandatory=True,
                    desc="The bold file to be regressed")
@@ -42,7 +42,7 @@ class _regressInputSpec(BaseInterfaceInputSpec):
                                      mandatory=False)
 
 
-class _regressOutputSpec(TraitedSpec):
+class _RegressOutputSpec(TraitedSpec):
     res_file = File(exists=True,
                     mandatory=True,
                     desc="Residual file after regression")
@@ -51,7 +51,7 @@ class _regressOutputSpec(TraitedSpec):
                            desc="Confounds matrix returned for testing purposes only")
 
 
-class regress(SimpleInterface):
+class Regress(SimpleInterface):
     """Takes in the confound tsv, turns it to a matrix and expands it.
 
     Custom confounds are added in during this step if present.
@@ -62,8 +62,8 @@ class regress(SimpleInterface):
     the bold files and returns the residual image, as well as the confounds for testing.
     """
 
-    input_spec = _regressInputSpec
-    output_spec = _regressOutputSpec
+    input_spec = _RegressInputSpec
+    output_spec = _RegressOutputSpec
 
     def _run_interface(self, runtime):
 

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -170,20 +170,20 @@ def demean_detrend_data(data):
     return detrended  # Subtract these predicted values from the demeaned data
 
 
-class _ciftidespikeInputSpec(BaseInterfaceInputSpec):
+class _CiftiDespikeInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc=" cifti  file ")
     TR = traits.Float(exists=True, mandatory=True, desc="repetition time")
 
 
-class _ciftidespikeOutputSpec(TraitedSpec):
+class _CiftiDespikeOutputSpec(TraitedSpec):
     des_file = File(exists=True, manadatory=True, desc=" despike cifti")
 
 
-class ciftidespike(SimpleInterface):
+class CiftiDespike(SimpleInterface):
     """Despike a CIFTI file."""
 
-    input_spec = _ciftidespikeInputSpec
-    output_spec = _ciftidespikeOutputSpec
+    input_spec = _CiftiDespikeInputSpec
+    output_spec = _CiftiDespikeOutputSpec
 
     def _run_interface(self, runtime):
 

--- a/xcp_d/interfaces/report.py
+++ b/xcp_d/interfaces/report.py
@@ -46,7 +46,7 @@ ABOUT_TEMPLATE = """\t<ul>
 """
 
 
-class SummaryOutputSpec(TraitedSpec):
+class _SummaryInterfaceOutputSpec(TraitedSpec):
     """Output specification for SummaryInterface."""
 
     out_report = File(exists=True, desc='HTML segment containing summary')
@@ -58,7 +58,7 @@ class SummaryInterface(SimpleInterface):
     This is used as a base class for other summary interfaces.
     """
 
-    output_spec = SummaryOutputSpec
+    output_spec = _SummaryInterfaceOutputSpec
 
     def _run_interface(self, runtime):
         # Open a file to write information to
@@ -73,7 +73,7 @@ class SummaryInterface(SimpleInterface):
         raise NotImplementedError
 
 
-class SubjectSummaryInputSpec(BaseInterfaceInputSpec):
+class _SubjectSummaryInputSpec(BaseInterfaceInputSpec):
     """Input specification for SubjectSummaryInterface."""
 
     subject_id = Str(desc='Subject ID')
@@ -82,7 +82,7 @@ class SubjectSummaryInputSpec(BaseInterfaceInputSpec):
                             desc='BOLD or CIFTI functional series')
 
 
-class SubjectSummaryOutputSpec(SummaryOutputSpec):
+class _SubjectSummaryOutputSpec(_SummaryInterfaceOutputSpec):
     """Output specification for SubjectSummaryInterface."""
 
     # This exists to ensure that the summary is run prior to the first ReconAll
@@ -93,8 +93,8 @@ class SubjectSummaryOutputSpec(SummaryOutputSpec):
 class SubjectSummary(SummaryInterface):
     """A subject-level summary interface."""
 
-    input_spec = SubjectSummaryInputSpec
-    output_spec = SubjectSummaryOutputSpec
+    input_spec = _SubjectSummaryInputSpec
+    output_spec = _SubjectSummaryOutputSpec
 
     def _run_interface(self, runtime):
         if isdefined(self.inputs.subject_id):
@@ -109,7 +109,7 @@ class SubjectSummary(SummaryInterface):
                                        num_bold_files=num_bold_files)
 
 
-class FunctionalSummaryInputSpec(BaseInterfaceInputSpec):
+class _FunctionalSummaryInputSpec(BaseInterfaceInputSpec):
     """Input specification for FunctionalSummary."""
 
     bold_file = traits.File(True, True, desc='cifti or bold File')
@@ -123,7 +123,7 @@ class FunctionalSummaryInputSpec(BaseInterfaceInputSpec):
 class FunctionalSummary(SummaryInterface):
     """A functional MRI summary interface."""
 
-    input_spec = FunctionalSummaryInputSpec
+    input_spec = _FunctionalSummaryInputSpec
     #   Get information from the QC file and return it
 
     def _generate_segment(self):
@@ -150,7 +150,7 @@ class FunctionalSummary(SummaryInterface):
                                   volcensored=num_vols_censored)
 
 
-class AboutSummaryInputSpec(BaseInterfaceInputSpec):
+class _AboutSummaryInputSpec(BaseInterfaceInputSpec):
     """Input specification for AboutSummary."""
 
     version = Str(desc='xcp_d version')
@@ -161,7 +161,7 @@ class AboutSummaryInputSpec(BaseInterfaceInputSpec):
 class AboutSummary(SummaryInterface):
     """A summary of the xcp_d software used."""
 
-    input_spec = AboutSummaryInputSpec
+    input_spec = _AboutSummaryInputSpec
 
     def _generate_segment(self):
         return ABOUT_TEMPLATE.format(

--- a/xcp_d/interfaces/resting_state.py
+++ b/xcp_d/interfaces/resting_state.py
@@ -161,23 +161,23 @@ class computealff(SimpleInterface):
         return runtime
 
 
-class _brainplotInputSpec(BaseInterfaceInputSpec):
+class _BrainPlotInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc="alff or reho")
     mask_file = File(exists=True, mandatory=True, desc="mask file ")
 
 
-class _brainplotOutputSpec(TraitedSpec):
+class _BrainPlotOutputSpec(TraitedSpec):
     nifti_html = File(exists=True, manadatory=True, desc="zscore html")
 
 
-class brainplot(SimpleInterface):
+class BrainPlot(SimpleInterface):
     """Create a brainsprite figure from a NIFTI file.
 
     The image will first be normalized (z-scored) before the figure is generated.
     """
 
-    input_spec = _brainplotInputSpec
-    output_spec = _brainplotOutputSpec
+    input_spec = _BrainPlotInputSpec
+    output_spec = _BrainPlotOutputSpec
 
     def _run_interface(self, runtime):
 

--- a/xcp_d/interfaces/resting_state.py
+++ b/xcp_d/interfaces/resting_state.py
@@ -85,7 +85,7 @@ class surfaceReho(SimpleInterface):
         return runtime
 
 
-class _computealffInputSpec(BaseInterfaceInputSpec):
+class _ComputeALFFInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc="nifti, cifti or gifti")
     TR = traits.Float(exists=True, mandatory=True, desc="repetition time")
     lowpass = traits.Float(exists=True,
@@ -101,11 +101,11 @@ class _computealffInputSpec(BaseInterfaceInputSpec):
                 desc=" brain mask for nifti file")
 
 
-class _computealffOutputSpec(TraitedSpec):
+class _ComputeALFFOutputSpec(TraitedSpec):
     alff_out = File(exists=True, manadatory=True, desc=" alff")
 
 
-class computealff(SimpleInterface):
+class ComputeALFF(SimpleInterface):
     """Compute ALFF.
 
     Examples
@@ -115,7 +115,7 @@ class computealff(SimpleInterface):
     >>> tmpdir = TemporaryDirectory()
     >>> os.chdir(tmpdir.name)
     .. doctest::
-    computealffwf = computealff()
+    computealffwf = ComputeALFF()
     computealffwf.inputs.in_file = datafile
     computealffwf.inputs.lowpass = 0.1
     computealffwf.inputs.highpass = 0.01
@@ -126,8 +126,8 @@ class computealff(SimpleInterface):
     >>> tmpdir.cleanup()
     """
 
-    input_spec = _computealffInputSpec
-    output_spec = _computealffOutputSpec
+    input_spec = _ComputeALFFInputSpec
+    output_spec = _ComputeALFFOutputSpec
 
     def _run_interface(self, runtime):
 

--- a/xcp_d/interfaces/resting_state.py
+++ b/xcp_d/interfaces/resting_state.py
@@ -29,18 +29,18 @@ LOGGER = logging.getLogger('nipype.interface')
 
 
 # compute 2D reho
-class _surfaceRehoInputSpec(BaseInterfaceInputSpec):
+class _SurfaceReHoInputSpec(BaseInterfaceInputSpec):
     surf_bold = File(exists=True,
                      mandatory=True,
                      desc="left or right hemisphere gii ")
     surf_hemi = traits.Str(exists=True, mandatory=True, desc="L or R ")
 
 
-class _surfaceRehoOutputSpec(TraitedSpec):
+class _SurfaceReHoOutputSpec(TraitedSpec):
     surf_gii = File(exists=True, manadatory=True, desc=" lh hemisphere reho")
 
 
-class surfaceReho(SimpleInterface):
+class SurfaceReHo(SimpleInterface):
     """Calculate regional homogeneity (ReHo) on a surface file.
 
     Examples
@@ -50,16 +50,16 @@ class surfaceReho(SimpleInterface):
     >>> tmpdir = TemporaryDirectory()
     >>> os.chdir(tmpdir.name)
     .. doctest::
-    >>> surfaceRehowf = surfaceReho()
-    >>> surfaceRehowf.inputs.surf_bold = 'rhhemi.func.gii'
-    >>> surfaceRehowf.inputs.surf_hemi = 'R'
-    >>> surfaceRehowf.run()
+    >>> surfacereho_wf = SurfaceReHo()
+    >>> surfacereho_wf.inputs.surf_bold = 'rhhemi.func.gii'
+    >>> surfacereho_wf.inputs.surf_hemi = 'R'
+    >>> surfacereho_wf.run()
     .. testcleanup::
     >>> tmpdir.cleanup()
     """
 
-    input_spec = _surfaceRehoInputSpec
-    output_spec = _surfaceRehoOutputSpec
+    input_spec = _SurfaceReHoInputSpec
+    output_spec = _SurfaceReHoOutputSpec
 
     def _run_interface(self, runtime):
 

--- a/xcp_d/interfaces/resting_state.py
+++ b/xcp_d/interfaces/resting_state.py
@@ -85,7 +85,7 @@ class surfaceReho(SimpleInterface):
         return runtime
 
 
-class _alffInputSpec(BaseInterfaceInputSpec):
+class _computealffInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc="nifti, cifti or gifti")
     TR = traits.Float(exists=True, mandatory=True, desc="repetition time")
     lowpass = traits.Float(exists=True,
@@ -101,7 +101,7 @@ class _alffInputSpec(BaseInterfaceInputSpec):
                 desc=" brain mask for nifti file")
 
 
-class _alffOutputSpec(TraitedSpec):
+class _computealffOutputSpec(TraitedSpec):
     alff_out = File(exists=True, manadatory=True, desc=" alff")
 
 
@@ -126,8 +126,8 @@ class computealff(SimpleInterface):
     >>> tmpdir.cleanup()
     """
 
-    input_spec = _alffInputSpec
-    output_spec = _alffOutputSpec
+    input_spec = _computealffInputSpec
+    output_spec = _computealffOutputSpec
 
     def _run_interface(self, runtime):
 

--- a/xcp_d/interfaces/surfplotting.py
+++ b/xcp_d/interfaces/surfplotting.py
@@ -23,19 +23,19 @@ from xcp_d.utils.plot import plot_svgx, plotimage
 LOGGER = logging.getLogger('nipype.interface')
 
 
-class _plotimgInputSpec(BaseInterfaceInputSpec):
+class _PlotImageInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc='plot image')
 
 
-class _plotimgOutputSpec(TraitedSpec):
+class _PlotImageOutputSpec(TraitedSpec):
     out_file = File(exists=True, desc='out image')
 
 
 class PlotImage(SimpleInterface):
     """Python class to plot x,y, and z of image data."""
 
-    input_spec = _plotimgInputSpec
-    output_spec = _plotimgOutputSpec
+    input_spec = _PlotImageInputSpec
+    output_spec = _PlotImageOutputSpec
 
     def _run_interface(self, runtime):
         self._results['out_file'] = fname_presuffix(self.inputs.in_file,
@@ -49,22 +49,22 @@ class PlotImage(SimpleInterface):
         return runtime
 
 
-class _surf2volInputSpec(BaseInterfaceInputSpec):
+class _SurftoVolumeInputSpec(BaseInterfaceInputSpec):
     template = File(exists=True, mandatory=True, desc="t1 image")
     left_surf = File(exists=True, mandatory=True, desc="left hemipshere")
     right_surf = File(exists=True, mandatory=True, desc="right hemipshere")
     scale = traits.Int(default_value=1, desc="scale factor for the surface")
 
 
-class _surf2volOutputSpec(TraitedSpec):
+class _SurftoVolumeOutputSpec(TraitedSpec):
     out_file = File(exists=True, manadatory=True, desc=" t1image")
 
 
 class SurftoVolume(SimpleInterface):
     """This class converts the freesurfer/gifti surface to volume using ras2vox transform."""
 
-    input_spec = _surf2volInputSpec
-    output_spec = _surf2volOutputSpec
+    input_spec = _SurftoVolumeInputSpec
+    output_spec = _SurftoVolumeOutputSpec
 
     def _run_interface(self, runtime):
 
@@ -83,20 +83,20 @@ class SurftoVolume(SimpleInterface):
         return runtime
 
 
-class _brainplotxInputSpec(BaseInterfaceInputSpec):
+class _BrainPlotxInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc="stats file")
     template = File(exists=True, mandatory=True, desc="mask file ")
 
 
-class _brainplotxOutputSpec(TraitedSpec):
+class _BrainPlotxOutputSpec(TraitedSpec):
     out_html = File(exists=True, manadatory=True, desc="zscore html")
 
 
 class BrainPlotx(SimpleInterface):
     """This class create brainsprite with overlay as stats image."""
 
-    input_spec = _brainplotxInputSpec
-    output_spec = _brainplotxOutputSpec
+    input_spec = _BrainPlotxInputSpec
+    output_spec = _BrainPlotxOutputSpec
 
     def _run_interface(self, runtime):
 
@@ -115,13 +115,13 @@ class BrainPlotx(SimpleInterface):
         return runtime
 
 
-class _regplotInputSpec(BaseInterfaceInputSpec):
+class _RegPlotInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc="brain file")
     overlay = File(exists=True, mandatory=True, desc="overlay ")
     n_cuts = traits.Int(default_value=3, desc="number of cuts")
 
 
-class _regplotOutputSpec(TraitedSpec):
+class _RegPlotOutputSpec(TraitedSpec):
     out_file = File(exists=True, manadatory=True, desc="svg file")
 
 
@@ -133,8 +133,8 @@ class RegPlot(SimpleInterface):
     This class may have been abandoned.
     """
 
-    input_spec = _regplotInputSpec
-    output_spec = _regplotOutputSpec
+    input_spec = _RegPlotInputSpec
+    output_spec = _RegPlotOutputSpec
 
     def _run_interface(self, runtime):
 
@@ -153,7 +153,7 @@ class RegPlot(SimpleInterface):
         return runtime
 
 
-class _plotsvgInputSpec(BaseInterfaceInputSpec):
+class _PlotSVGDataInputSpec(BaseInterfaceInputSpec):
     rawdata = File(exists=True, mandatory=True, desc="Raw data")
     regressed_data = File(exists=True,
                           mandatory=True,
@@ -165,7 +165,7 @@ class _plotsvgInputSpec(BaseInterfaceInputSpec):
     TR = traits.Float(default_value=1, desc="Repetition time")
 
 
-class _plotsvgOutputSpec(TraitedSpec):
+class _PlotSVGDataOutputSpec(TraitedSpec):
     before_process = File(exists=True,
                           manadatory=True,
                           desc=".SVG file before processing")
@@ -183,8 +183,8 @@ class PlotSVGData(SimpleInterface):
     It outputs the .SVG files before after processing has taken place.
     """
 
-    input_spec = _plotsvgInputSpec
-    output_spec = _plotsvgOutputSpec
+    input_spec = _PlotSVGDataInputSpec
+    output_spec = _PlotSVGDataOutputSpec
 
     def _run_interface(self, runtime):
 
@@ -213,12 +213,12 @@ class PlotSVGData(SimpleInterface):
         return runtime
 
 
-class _ribbonstatmapInputSpec(BaseInterfaceInputSpec):
+class _RibbontoStatmapInputSpec(BaseInterfaceInputSpec):
     ribbon = File(exists=True, mandatory=True, desc="ribbon ")
     # other settings or files will be added later from T2 ##
 
 
-class _ribbonstatmapOutputSpec(TraitedSpec):
+class _RibbontoStatmapOutputSpec(TraitedSpec):
     out_file = File(exists=True,
                     manadatory=True,
                     desc="ribbon > pial and white")
@@ -227,8 +227,8 @@ class _ribbonstatmapOutputSpec(TraitedSpec):
 class RibbontoStatmap(SimpleInterface):
     """Plot of fd, dvars, carpet plots of bold data before and after regression/filtering."""
 
-    input_spec = _ribbonstatmapInputSpec
-    output_spec = _ribbonstatmapOutputSpec
+    input_spec = _RibbontoStatmapInputSpec
+    output_spec = _RibbontoStatmapOutputSpec
 
     def _run_interface(self, runtime):
 

--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -15,7 +15,7 @@ from xcp_d.utils.filemanip import fname_presuffix
 iflogger = logging.getLogger("nipype.interface")
 
 
-class ConvertWarpfieldInputSpec(CommandLineInputSpec):
+class _ConvertWarpfieldInputSpec(CommandLineInputSpec):
     """Input specification for ConvertWarpfield."""
 
     fromwhat = traits.Str(
@@ -55,7 +55,7 @@ class ConvertWarpfieldInputSpec(CommandLineInputSpec):
     )
 
 
-class ConvertWarpfieldOutputSpec(TraitedSpec):
+class _ConvertWarpfieldOutputSpec(TraitedSpec):
     """Output specification for ConvertWarpfield."""
 
     out_file = File(exists=True, desc="output file")
@@ -64,12 +64,12 @@ class ConvertWarpfieldOutputSpec(TraitedSpec):
 class ConvertWarpfield(WBCommand):
     """Interface for wb_command's -convert-warpfield command."""
 
-    input_spec = ConvertWarpfieldInputSpec
-    output_spec = ConvertWarpfieldOutputSpec
+    input_spec = _ConvertWarpfieldInputSpec
+    output_spec = _ConvertWarpfieldOutputSpec
     _cmd = "wb_command -convert-warpfield "
 
 
-class ConvertAffineInputSpec(CommandLineInputSpec):
+class _ConvertAffineInputSpec(CommandLineInputSpec):
     """Input specification for ConvertAffine."""
 
     fromwhat = traits.Str(
@@ -102,7 +102,7 @@ class ConvertAffineInputSpec(CommandLineInputSpec):
     )
 
 
-class ConvertAffineOutputSpec(TraitedSpec):
+class _ConvertAffineOutputSpec(TraitedSpec):
     """Output specification for ConvertAffine."""
 
     out_file = File(exists=True, desc="output file")
@@ -111,12 +111,12 @@ class ConvertAffineOutputSpec(TraitedSpec):
 class ConvertAffine(WBCommand):
     """Interface for wb_command's -convert-affine command."""
 
-    input_spec = ConvertAffineInputSpec
-    output_spec = ConvertAffineOutputSpec
+    input_spec = _ConvertAffineInputSpec
+    output_spec = _ConvertAffineOutputSpec
     _cmd = "wb_command -convert-affine "
 
 
-class ApplyAffineInputSpec(CommandLineInputSpec):
+class _ApplyAffineInputSpec(CommandLineInputSpec):
     """Input specification for ApplyAffine."""
 
     in_file = File(
@@ -144,7 +144,7 @@ class ApplyAffineInputSpec(CommandLineInputSpec):
     )
 
 
-class ApplyAffineOutputSpec(TraitedSpec):
+class _ApplyAffineOutputSpec(TraitedSpec):
     """Output specification for ApplyAffine."""
 
     out_file = File(exists=True, desc="output file")
@@ -169,12 +169,12 @@ class ApplyAffine(WBCommand):
     command, or aff_conv from the 4dfp suite.
     """
 
-    input_spec = ApplyAffineInputSpec
-    output_spec = ApplyAffineOutputSpec
+    input_spec = _ApplyAffineInputSpec
+    output_spec = _ApplyAffineOutputSpec
     _cmd = "wb_command -surface-apply-affine "
 
 
-class ApplyWarpfieldInputSpec(CommandLineInputSpec):
+class _ApplyWarpfieldInputSpec(CommandLineInputSpec):
     """Input specification for ApplyWarpfield."""
 
     in_file = File(
@@ -208,7 +208,7 @@ class ApplyWarpfieldInputSpec(CommandLineInputSpec):
     )
 
 
-class ApplyWarpfieldOutputSpec(TraitedSpec):
+class _ApplyWarpfieldOutputSpec(TraitedSpec):
     """Output specification for ApplyWarpfield."""
 
     out_file = File(exists=True, desc="output file")
@@ -234,12 +234,12 @@ class ApplyWarpfield(WBCommand):
     which can be obtained with the -convert-warpfield command.
     """
 
-    input_spec = ApplyWarpfieldInputSpec
-    output_spec = ApplyWarpfieldOutputSpec
+    input_spec = _ApplyWarpfieldInputSpec
+    output_spec = _ApplyWarpfieldOutputSpec
     _cmd = "wb_command -surface-apply-warpfield "
 
 
-class SurfaceSphereProjectUnprojectInputSpec(CommandLineInputSpec):
+class _SurfaceSphereProjectUnprojectInputSpec(CommandLineInputSpec):
     """Input specification for SurfaceSphereProjectUnproject."""
 
     in_file = File(
@@ -276,7 +276,7 @@ class SurfaceSphereProjectUnprojectInputSpec(CommandLineInputSpec):
     )
 
 
-class SurfaceSphereProjectUnprojectOutputSpec(TraitedSpec):
+class _SurfaceSphereProjectUnprojectOutputSpec(TraitedSpec):
     """Input specification for SurfaceSphereProjectUnproject."""
 
     out_file = File(exists=True, desc="output file")
@@ -292,8 +292,8 @@ class SurfaceSphereProjectUnproject(WBCommand):
     <sphere-out> - output - the output sphere
     """
 
-    input_spec = SurfaceSphereProjectUnprojectInputSpec
-    output_spec = SurfaceSphereProjectUnprojectOutputSpec
+    input_spec = _SurfaceSphereProjectUnprojectInputSpec
+    output_spec = _SurfaceSphereProjectUnprojectOutputSpec
     _cmd = "wb_command -surface-sphere-project-unproject "
 
 
@@ -329,7 +329,7 @@ class ChangeXfmType(SimpleInterface):
         return runtime
 
 
-class SurfaceAverageInputSpec(CommandLineInputSpec):
+class _SurfaceAverageInputSpec(CommandLineInputSpec):
     """Input specification for SurfaceAverage."""
 
     surface_in1 = File(
@@ -358,7 +358,7 @@ class SurfaceAverageInputSpec(CommandLineInputSpec):
     )
 
 
-class SurfaceAverageOutputSpec(TraitedSpec):
+class _SurfaceAverageOutputSpec(TraitedSpec):
     """Output specification for SurfaceAverage."""
 
     out_file = File(exists=True, desc="output file")
@@ -389,12 +389,12 @@ class SurfaceAverage(WBCommand):
     reliability weights.
     """
 
-    input_spec = SurfaceAverageInputSpec
-    output_spec = SurfaceAverageOutputSpec
+    input_spec = _SurfaceAverageInputSpec
+    output_spec = _SurfaceAverageOutputSpec
     _cmd = "wb_command -surface-average "
 
 
-class SurfaceGenerateInflatedInputSpec(CommandLineInputSpec):
+class _SurfaceGenerateInflatedInputSpec(CommandLineInputSpec):
     """Input specification for SurfaceGenerateInflated."""
 
     anatomical_surface_in = File(
@@ -431,7 +431,7 @@ class SurfaceGenerateInflatedInputSpec(CommandLineInputSpec):
     )
 
 
-class SurfaceGenerateInflatedOutputSpec(TraitedSpec):
+class _SurfaceGenerateInflatedOutputSpec(TraitedSpec):
     """Output specification for SurfaceGenerateInflated."""
 
     inflated_out_file = File(exists=True, desc="inflated output file")
@@ -456,6 +456,6 @@ class SurfaceGenerateInflated(WBCommand):
        iterations-scale of 2.5.
     """
 
-    input_spec = SurfaceGenerateInflatedInputSpec
-    output_spec = SurfaceGenerateInflatedOutputSpec
+    input_spec = _SurfaceGenerateInflatedInputSpec
+    output_spec = _SurfaceGenerateInflatedOutputSpec
     _cmd = "wb_command -surface-generate-inflated "

--- a/xcp_d/notebooks/restingstate.ipynb
+++ b/xcp_d/notebooks/restingstate.ipynb
@@ -25,7 +25,7 @@
    ],
    "source": [
     "import nibabel as nb\n",
-    "from xcp_d.interfaces import computealff\n",
+    "from xcp_d.interfaces import ComputeALFF\n",
     "\n",
     "\n",
     "def get_ciftiTR(cifti_file):\n",
@@ -60,7 +60,7 @@
     "# get TR\n",
     "tr = get_ciftiTR(dtseries)\n",
     "\n",
-    "computealff_wf = computealff()\n",
+    "computealff_wf = ComputeALFF()\n",
     "computealff_wf.inputs.in_file= dtseries\n",
     "computealff_wf.inputs.lowpass = 0.10\n",
     "computealff_wf.inputs.highpass = 0.01\n",

--- a/xcp_d/utils/__init__.py
+++ b/xcp_d/utils/__init__.py
@@ -1,7 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """A range of utility functions for xcp_d interfaces and workflows."""
-from xcp_d.utils.bids import DerivativesDataSink as bid_derivative
 from xcp_d.utils.bids import (
     collect_data,
     collect_participants,

--- a/xcp_d/utils/cifticonnectivity.py
+++ b/xcp_d/utils/cifticonnectivity.py
@@ -9,7 +9,7 @@ from nipype.interfaces.workbench.base import WBCommand
 iflogger = logging.getLogger("nipype.interface")
 
 
-class CiftiCorrelationInputSpec(CommandLineInputSpec):
+class _CiftiCorrelationInputSpec(CommandLineInputSpec):
     in_file = File(
         exists=True,
         mandatory=True,
@@ -90,7 +90,7 @@ class CiftiCorrelationInputSpec(CommandLineInputSpec):
     )
 
 
-class CiftiCorrelationOutputSpec(TraitedSpec):
+class _CiftiCorrelationOutputSpec(TraitedSpec):
     out_file = File(exists=True, desc="output CIFTI file")
 
 
@@ -110,6 +110,6 @@ class CiftiCorrelation(WBCommand):
         'sub_01XX_task-rest.pconn.nii'
     """
 
-    input_spec = CiftiCorrelationInputSpec
-    output_spec = CiftiCorrelationOutputSpec
+    input_spec = _CiftiCorrelationInputSpec
+    output_spec = _CiftiCorrelationOutputSpec
     _cmd = "wb_command  -cifti-correlation"

--- a/xcp_d/utils/ciftiparcellation.py
+++ b/xcp_d/utils/ciftiparcellation.py
@@ -9,7 +9,7 @@ from nipype.interfaces.workbench.base import WBCommand
 iflogger = logging.getLogger("nipype.interface")
 
 
-class CiftiParcellateInputSpec(CommandLineInputSpec):
+class _CiftiParcellateInputSpec(CommandLineInputSpec):
     in_file = File(
         exists=True,
         mandatory=True,
@@ -100,7 +100,7 @@ class CiftiParcellateInputSpec(CommandLineInputSpec):
     )
 
 
-class CiftiParcellateOutputSpec(TraitedSpec):
+class _CiftiParcellateOutputSpec(TraitedSpec):
     out_file = File(exists=True, desc="output CIFTI file")
 
 
@@ -123,6 +123,6 @@ class CiftiParcellate(WBCommand):
     sub_01XX_task-rest.ptseries.nii
     """
 
-    input_spec = CiftiParcellateInputSpec
-    output_spec = CiftiParcellateOutputSpec
+    input_spec = _CiftiParcellateInputSpec
+    output_spec = _CiftiParcellateOutputSpec
     _cmd = "wb_command -cifti-parcellate"

--- a/xcp_d/utils/ciftiresample.py
+++ b/xcp_d/utils/ciftiresample.py
@@ -9,7 +9,7 @@ from nipype.interfaces.workbench.base import WBCommand
 iflogger = logging.getLogger("nipype.interface")
 
 
-class CiftiSurfaceResampleInputSpec(CommandLineInputSpec):
+class _CiftiSurfaceResampleInputSpec(CommandLineInputSpec):
     in_file = File(
         exists=True,
         mandatory=True,
@@ -47,7 +47,7 @@ class CiftiSurfaceResampleInputSpec(CommandLineInputSpec):
     )
 
 
-class CiftiSurfaceResampleOutputSpec(TraitedSpec):
+class _CiftiSurfaceResampleOutputSpec(TraitedSpec):
     out_file = File(exists=True, desc="output gifti file")
 
 
@@ -57,6 +57,6 @@ class CiftiSurfaceResample(WBCommand):
     TODO: Improve documentation.
     """
 
-    input_spec = CiftiSurfaceResampleInputSpec
-    output_spec = CiftiSurfaceResampleOutputSpec
+    input_spec = _CiftiSurfaceResampleInputSpec
+    output_spec = _CiftiSurfaceResampleOutputSpec
     _cmd = "wb_command  -surface-resample"

--- a/xcp_d/utils/ciftiseparatemetric.py
+++ b/xcp_d/utils/ciftiseparatemetric.py
@@ -9,7 +9,7 @@ from nipype.interfaces.workbench.base import WBCommand
 iflogger = logging.getLogger("nipype.interface")
 
 
-class CiftiSeparateMetricInputSpec(CommandLineInputSpec):
+class _CiftiSeparateMetricInputSpec(CommandLineInputSpec):
     in_file = File(
         exists=True,
         mandatory=True,
@@ -42,7 +42,7 @@ class CiftiSeparateMetricInputSpec(CommandLineInputSpec):
     )
 
 
-class CiftiSeparateMetricOutputSpec(TraitedSpec):
+class _CiftiSeparateMetricOutputSpec(TraitedSpec):
     out_file = File(exists=True, desc="output CIFTI file")
 
 
@@ -65,6 +65,6 @@ class CiftiSeparateMetric(WBCommand):
       -metric CORTEX_LEFT 'sub_01XX_task-rest_hemi-L.func.gii'
     """
 
-    input_spec = CiftiSeparateMetricInputSpec
-    output_spec = CiftiSeparateMetricOutputSpec
+    input_spec = _CiftiSeparateMetricInputSpec
+    output_spec = _CiftiSeparateMetricOutputSpec
     _cmd = "wb_command  -cifti-separate "

--- a/xcp_d/workflow/anatomical.py
+++ b/xcp_d/workflow/anatomical.py
@@ -36,12 +36,12 @@ from xcp_d.interfaces.workbench import (  # MB,TM
     SurfaceGenerateInflated,
     SurfaceSphereProjectUnproject,
 )
-from xcp_d.utils.bids import DerivativesDataSink as bids_derivative
+from xcp_d.utils.bids import DerivativesDataSink as BIDSDerivativesDataSink
 from xcp_d.utils.bids import collect_data
 from xcp_d.utils.ciftiresample import CiftiSurfaceResample
 
 
-class DerivativesDataSink(bids_derivative):
+class DerivativesDataSink(BIDSDerivativesDataSink):
     """An updated data-sink for xcp_d derivatives."""
 
     out_path_base = "xcp_d"

--- a/xcp_d/workflow/base.py
+++ b/xcp_d/workflow/base.py
@@ -22,7 +22,7 @@ from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
 from xcp_d.__about__ import __version__
 from xcp_d.interfaces.report import AboutSummary, SubjectSummary
-from xcp_d.utils.bids import DerivativesDataSink as bids_derivative
+from xcp_d.utils.bids import DerivativesDataSink as BIDSDerivativesDataSink
 from xcp_d.utils.bids import (
     collect_data,
     extract_t1w_seg,
@@ -468,7 +468,7 @@ def _pop(inlist):
 
 
 # RF: this shouldn't be in this file
-class DerivativesDataSink(bids_derivative):
+class DerivativesDataSink(BIDSDerivativesDataSink):
     """Defines the data sink for the workflow."""
 
     out_path_base = 'xcp_d'

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -21,7 +21,7 @@ from num2words import num2words
 from templateflow.api import get as get_template
 
 from xcp_d.interfaces.filtering import FilteringData
-from xcp_d.interfaces.prepostcleaning import CensorScrub, RemoveTR, Interpolate
+from xcp_d.interfaces.prepostcleaning import CensorScrub, Interpolate, RemoveTR
 from xcp_d.interfaces.qc_plot import QCPlot
 from xcp_d.interfaces.regression import Regress
 from xcp_d.interfaces.report import FunctionalSummary

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -24,7 +24,7 @@ from xcp_d.interfaces import (
     FilteringData,
     FunctionalSummary,
     RemoveTR,
-    computeqcplot,
+    QCPlot,
     Interpolate,
     regress,
 )
@@ -389,23 +389,28 @@ Residual timeseries from this regression were then band-pass filtered to retain 
         n_procs=omp_nthreads,
         mem_gb=mem_gbx['timeseries'])
 
-    qcreport = pe.Node(computeqcplot(TR=TR,
-                                     bold_file=bold_file,
-                                     dummytime=dummytime,
-                                     t1w_mask=t1w_mask,
-                                     template_mask=str(
-                                         get_template(
-                                             'MNI152NLin2009cAsym',
-                                             resolution=2,
-                                             desc='brain',
-                                             suffix='mask',
-                                             extension=['.nii', '.nii.gz'])),
-                                     head_radius=head_radius,
-                                     low_freq=band_stop_max,
-                                     high_freq=band_stop_min),
-                       name="qc_report",
-                       mem_gb=mem_gbx['timeseries'],
-                       n_procs=omp_nthreads)
+    qcreport = pe.Node(
+        QCPlot(
+            TR=TR,
+            bold_file=bold_file,
+            dummytime=dummytime,
+            t1w_mask=t1w_mask,
+            template_mask=str(
+                get_template(
+                    'MNI152NLin2009cAsym',
+                    resolution=2,
+                    desc='brain',
+                    suffix='mask',
+                    extension=['.nii', '.nii.gz']
+                )
+            ),
+            head_radius=head_radius,
+            low_freq=band_stop_max,
+            high_freq=band_stop_min),
+        name="qc_report",
+        mem_gb=mem_gbx['timeseries'],
+        n_procs=omp_nthreads,
+    )
 
 # Remove TR first:
     if dummytime > 0:

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -26,7 +26,7 @@ from xcp_d.interfaces import (
     RemoveTR,
     QCPlot,
     Interpolate,
-    regress,
+    Regress,
 )
 from xcp_d.utils.utils import (
     get_maskfiles,
@@ -319,7 +319,7 @@ Residual timeseries from this regression were then band-pass filtered to retain 
         n_procs=omp_nthreads)
 
     regression_wf = pe.Node(
-        regress(TR=TR,
+        Regress(TR=TR,
                 original_file=bold_file),
         name="regression_wf",
         mem_gb=mem_gbx['timeseries'],

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -25,7 +25,7 @@ from xcp_d.interfaces import (
     FunctionalSummary,
     RemoveTR,
     computeqcplot,
-    interpolate,
+    Interpolate,
     regress,
 )
 from xcp_d.utils.utils import (
@@ -326,7 +326,7 @@ Residual timeseries from this regression were then band-pass filtered to retain 
         n_procs=omp_nthreads)
 
     interpolate_wf = pe.Node(
-        interpolate(TR=TR),
+        Interpolate(TR=TR),
         name="interpolation_wf",
         mem_gb=mem_gbx['timeseries'],
         n_procs=omp_nthreads)

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -25,7 +25,7 @@ from xcp_d.interfaces.prepostcleaning import CensorScrub, Interpolate, RemoveTR
 from xcp_d.interfaces.qc_plot import QCPlot
 from xcp_d.interfaces.regression import Regress
 from xcp_d.interfaces.report import FunctionalSummary
-from xcp_d.utils.bids import DerivativesDataSink as bids_derivative
+from xcp_d.utils.bids import DerivativesDataSink as BIDSDerivativesDataSink
 from xcp_d.utils.restingstate import DespikePatch
 from xcp_d.utils.utils import (
     get_maskfiles,
@@ -717,7 +717,7 @@ def _t12native(fname):  # TODO: Update names and refactor
     return t12ref
 
 
-class DerivativesDataSink(bids_derivative):
+class DerivativesDataSink(BIDSDerivativesDataSink):
     """Defines the data sink for the workflow."""
 
     out_path_base = 'xcp_d'

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -23,7 +23,7 @@ from xcp_d.interfaces import (
     FunctionalSummary,
     RemoveTR,
     ciftidespike,
-    computeqcplot,
+    QCPlot,
     Interpolate,
     regress,
 )
@@ -318,7 +318,7 @@ Residual timeseries from this regression were then band-pass filtered to retain 
         n_procs=omp_nthreads)
 
     qcreport = pe.Node(
-        computeqcplot(
+        QCPlot(
             TR=TR,
             bold_file=cifti_file,
             dummytime=dummytime,

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -24,7 +24,7 @@ from xcp_d.interfaces import (
     RemoveTR,
     ciftidespike,
     computeqcplot,
-    interpolate,
+    Interpolate,
     regress,
 )
 from xcp_d.utils import bid_derivative
@@ -312,7 +312,7 @@ Residual timeseries from this regression were then band-pass filtered to retain 
         n_procs=omp_nthreads)
 
     interpolate_wf = pe.Node(
-        interpolate(TR=TR),
+        Interpolate(TR=TR),
         name="interpolation_wf",
         mem_gb=mem_gbx['timeseries'],
         n_procs=omp_nthreads)

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -22,7 +22,7 @@ from xcp_d.interfaces import (
     FilteringData,
     FunctionalSummary,
     RemoveTR,
-    ciftidespike,
+    CiftiDespike,
     QCPlot,
     Interpolate,
     regress,
@@ -364,7 +364,7 @@ Residual timeseries from this regression were then band-pass filtered to retain 
             ])])
 
     if despike:  # If we despike
-        despike3d = pe.Node(ciftidespike(TR=TR),
+        despike3d = pe.Node(CiftiDespike(TR=TR),
                             name="cifti_despike",
                             mem_gb=mem_gbx['timeseries'],
                             n_procs=omp_nthreads)

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -25,7 +25,7 @@ from xcp_d.interfaces import (
     CiftiDespike,
     QCPlot,
     Interpolate,
-    regress,
+    Regress,
 )
 from xcp_d.utils import bid_derivative
 from xcp_d.utils.utils import stringforparams
@@ -305,7 +305,7 @@ Residual timeseries from this regression were then band-pass filtered to retain 
         n_procs=omp_nthreads)
 
     regression_wf = pe.Node(
-        regress(TR=TR,
+        Regress(TR=TR,
                 original_file=cifti_file),
         name="regression_wf",
         mem_gb=mem_gbx['timeseries'],

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -19,7 +19,7 @@ from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from num2words import num2words
 
 from xcp_d.interfaces.filtering import FilteringData
-from xcp_d.interfaces.prepostcleaning import CensorScrub, RemoveTR, Interpolate
+from xcp_d.interfaces.prepostcleaning import CensorScrub, Interpolate, RemoveTR
 from xcp_d.interfaces.qc_plot import QCPlot
 from xcp_d.interfaces.regression import CiftiDespike, Regress
 from xcp_d.interfaces.report import FunctionalSummary

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -23,7 +23,7 @@ from xcp_d.interfaces.prepostcleaning import CensorScrub, Interpolate, RemoveTR
 from xcp_d.interfaces.qc_plot import QCPlot
 from xcp_d.interfaces.regression import CiftiDespike, Regress
 from xcp_d.interfaces.report import FunctionalSummary
-from xcp_d.utils.bids import DerivativesDataSink as bids_derivative
+from xcp_d.utils.bids import DerivativesDataSink as BIDSDerivativesDataSink
 from xcp_d.utils.utils import stringforparams
 from xcp_d.workflow.connectivity import init_cifti_conts_wf
 from xcp_d.workflow.execsummary import init_execsummary_wf
@@ -566,7 +566,7 @@ def _create_mem_gb(bold_fname):
 
 
 # RF: shouldn't be here
-class DerivativesDataSink(bids_derivative):
+class DerivativesDataSink(BIDSDerivativesDataSink):
     """Defines the data sink for the workflow."""
 
     out_path_base = 'xcp_d'

--- a/xcp_d/workflow/connectivity.py
+++ b/xcp_d/workflow/connectivity.py
@@ -13,7 +13,7 @@ from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
-from xcp_d.interfaces import connectplot
+from xcp_d.interfaces import ConnectPlot
 from xcp_d.interfaces.connectivity import (
     ApplyTransformsx,
     NiftiConnect,
@@ -246,7 +246,7 @@ Pearson's correlation of each parcel's (unsmoothed) timeseries.
                              n_procs=omp_nthreads)
 
     # Create a node to plot the matrixes
-    matrix_plot = pe.Node(connectplot(in_file=bold_file),
+    matrix_plot = pe.Node(ConnectPlot(in_file=bold_file),
                           name="matrix_plot_wf",
                           mem_gb=mem_gb)
 
@@ -528,7 +528,7 @@ timeseries with the Connectome Workbench.
                          n_procs=omp_nthreads)
 
     # Create a node for plotting the matrixes
-    matrix_plot = pe.Node(connectplot(), name="matrix_plot_wf", mem_gb=mem_gb)
+    matrix_plot = pe.Node(ConnectPlot(), name="matrix_plot_wf", mem_gb=mem_gb)
 
     # Compute correlation matrixes via Connectome Workbench
     sc117corr = pe.Node(CiftiCorrelation(),

--- a/xcp_d/workflow/connectivity.py
+++ b/xcp_d/workflow/connectivity.py
@@ -15,8 +15,8 @@ from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
 from xcp_d.interfaces.connectivity import (
     ApplyTransformsx,
-    NiftiConnect,
     ConnectPlot,
+    NiftiConnect,
     get_atlas_cifti,
     get_atlas_nifti,
 )

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -12,11 +12,11 @@ from templateflow.api import get as get_template
 
 from xcp_d.interfaces.connectivity import ApplyTransformsx
 from xcp_d.interfaces.surfplotting import PlotImage, PlotSVGData
-from xcp_d.utils.bids import DerivativesDataSink as bids_derivative
+from xcp_d.utils.bids import DerivativesDataSink as BIDSDerivativesDataSink
 from xcp_d.utils.utils import get_transformfile
 
 
-class DerivativesDataSink(bids_derivative):
+class DerivativesDataSink(BIDSDerivativesDataSink):
     """Defines the data sink for the workflow."""
 
     out_path_base = 'xcp_d'

--- a/xcp_d/workflow/outputs.py
+++ b/xcp_d/workflow/outputs.py
@@ -6,11 +6,11 @@ from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
-from xcp_d.utils.bids import DerivativesDataSink as bids_derivative
+from xcp_d.utils.bids import DerivativesDataSink as BIDSDerivativesDataSink
 
 
 # RF: Not here
-class DerivativesDataSink(bids_derivative):
+class DerivativesDataSink(BIDSDerivativesDataSink):
     """Defines the data sink for the workflow."""
 
     out_path_base = 'xcp_d'

--- a/xcp_d/workflow/restingstate.py
+++ b/xcp_d/workflow/restingstate.py
@@ -13,7 +13,7 @@ from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from templateflow.api import get as get_template
 
-from xcp_d.interfaces import BrainPlot, ComputeALFF, surfaceReho
+from xcp_d.interfaces import BrainPlot, ComputeALFF, SurfaceReHo
 from xcp_d.utils import CiftiSeparateMetric
 from xcp_d.utils.utils import fwhm2sigma
 
@@ -228,11 +228,11 @@ vertices to yield ReHo.
                       mem_gb=mem_gb,
                       n_procs=omp_nthreads)
     # Calculate the reho by hemipshere
-    lh_reho = pe.Node(surfaceReho(surf_hemi='L'),
+    lh_reho = pe.Node(SurfaceReHo(surf_hemi='L'),
                       name="reho_lh",
                       mem_gb=mem_gb,
                       n_procs=omp_nthreads)
-    rh_reho = pe.Node(surfaceReho(surf_hemi='R'),
+    rh_reho = pe.Node(SurfaceReHo(surf_hemi='R'),
                       name="reho_rh",
                       mem_gb=mem_gb,
                       n_procs=omp_nthreads)

--- a/xcp_d/workflow/restingstate.py
+++ b/xcp_d/workflow/restingstate.py
@@ -13,7 +13,7 @@ from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from templateflow.api import get as get_template
 
-from xcp_d.interfaces import BrainPlot, computealff, surfaceReho
+from xcp_d.interfaces import BrainPlot, ComputeALFF, surfaceReho
 from xcp_d.utils import CiftiSeparateMetric
 from xcp_d.utils.utils import fwhm2sigma
 
@@ -96,7 +96,7 @@ calculated at each voxel to yield voxel-wise ALFF measures.
         name='outputnode')
 
     # compute alff
-    alff_compt = pe.Node(computealff(TR=TR, lowpass=lowpass,
+    alff_compt = pe.Node(ComputeALFF(TR=TR, lowpass=lowpass,
                                      highpass=highpass),
                          mem_gb=mem_gb,
                          name='alff_compt',

--- a/xcp_d/workflow/restingstate.py
+++ b/xcp_d/workflow/restingstate.py
@@ -13,7 +13,7 @@ from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from templateflow.api import get as get_template
 
-from xcp_d.interfaces import brainplot, computealff, surfaceReho
+from xcp_d.interfaces import BrainPlot, computealff, surfaceReho
 from xcp_d.utils import CiftiSeparateMetric
 from xcp_d.utils.utils import fwhm2sigma
 
@@ -102,7 +102,7 @@ calculated at each voxel to yield voxel-wise ALFF measures.
                          name='alff_compt',
                          n_procs=omp_nthreads)
     # create a node for the Nifti HTML
-    brain_plot = pe.Node(brainplot(),
+    brain_plot = pe.Node(BrainPlot(),
                          mem_gb=mem_gb,
                          name='brain_plot',
                          n_procs=omp_nthreads)
@@ -307,7 +307,7 @@ Regional homogeneity (ReHo) was computed with neighborhood voxels using *3dReHo*
                            mem_gb=mem_gb,
                            n_procs=omp_nthreads)
     # Get the HTML
-    brain_plot = pe.Node(brainplot(),
+    brain_plot = pe.Node(BrainPlot(),
                          mem_gb=mem_gb,
                          name='brain_plot',
                          n_procs=omp_nthreads)


### PR DESCRIPTION
Related to, but does not close, #471.

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
- Add leading underscore to all Nipype InputSpecs and OutputSpecs.
- Rename any non-CamelCase class names to CamelCase.
    - connectplot --> ConnectPlot
    - interpolate --> Interpolate
    - computeqcplot --> QCPlot
    - ciftidespike --> CiftiDespike
    - regress --> Regress
    - brainplot --> BrainPlot
    - computealff --> ComputeALFF
    - surfaceReho --> SurfaceReHo
- Ignore some variable-naming style checks. I'd like to re-enable these in the future, but I think we can skip them for now.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None.
