### PR TITLE
[REF] Rename functions to snake_case

### DIFF
--- a/xcp_d/interfaces/layout_builder.py
+++ b/xcp_d/interfaces/layout_builder.py
@@ -256,7 +256,7 @@ class TasksSection(Section):
 
         self.run(tasks)
 
-    def write_T1_reg_rows(self, task_name, task_num):
+    def write_t1_reg_rows(self, task_name, task_num):
         """Write T1w rows."""
         # Write the header for the next few rows.
         self.section += constants.TASK_LABEL_ROW.format(task_name=task_name,
@@ -361,7 +361,7 @@ class TasksSection(Section):
             else:
                 task_num = 'ALL'
 
-            self.write_T1_reg_rows(task_name, task_num)
+            self.write_t1_reg_rows(task_name, task_num)
             self.write_bold_gray_row(task_name, task_num)
 
         # Add the end of the tasks section.

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -14,7 +14,7 @@ from nipype.interfaces.base import (
 
 from xcp_d.utils.confounds import load_motion
 from xcp_d.utils.filemanip import fname_presuffix
-from xcp_d.utils.modified_data import compute_FD, generate_mask, interpolate_masked_data
+from xcp_d.utils.modified_data import compute_fd, generate_mask, interpolate_masked_data
 from xcp_d.utils.write_save import read_ndata, write_ndata
 
 
@@ -238,7 +238,7 @@ class CensorScrub(SimpleInterface):
                                      "rot_x", "rot_y", "rot_z", "trans_x",
                                      "trans_y", "trans_z"
                                  ])
-        fd_timeseries_uncensored = compute_FD(confound=motion_df,
+        fd_timeseries_uncensored = compute_fd(confound=motion_df,
                                               head_radius=self.inputs.head_radius)
 
         # Read in custom confounds file (if any) and bold file to be censored

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -22,7 +22,7 @@ from xcp_d.utils.confounds import load_confound, load_motion
 from xcp_d.utils.filemanip import fname_presuffix
 from xcp_d.utils.modified_data import compute_fd
 from xcp_d.utils.plot import fMRIPlot
-from xcp_d.utils.qcmetrics import regisQ
+from xcp_d.utils.qcmetrics import compute_registration_qc
 from xcp_d.utils.write_save import read_ndata, write_ndata
 
 LOGGER = logging.getLogger('nipype.interface')
@@ -265,7 +265,7 @@ class computeqcplot(SimpleInterface):
         qc_dictionary.update(qc_values)
         if self.inputs.bold2T1w_mask:  # If a bold mask in T1w is provided
             # Compute quality of registration
-            registration_qc = regisQ(bold2t1w_mask=self.inputs.bold2T1w_mask,
+            registration_qc = compute_registration_qc(bold2t1w_mask=self.inputs.bold2T1w_mask,
                                      t1w_mask=self.inputs.t1w_mask,
                                      bold2template_mask=self.inputs.bold2temp_mask,
                                      template_mask=self.inputs.template_mask)

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -20,7 +20,7 @@ from nipype.interfaces.base import (
 from xcp_d.utils.concantenation import compute_dvars
 from xcp_d.utils.confounds import load_confound, load_motion
 from xcp_d.utils.filemanip import fname_presuffix
-from xcp_d.utils.modified_data import compute_FD
+from xcp_d.utils.modified_data import compute_fd
 from xcp_d.utils.plot import fMRIPlot
 from xcp_d.utils.qcmetrics import regisQ
 from xcp_d.utils.write_save import read_ndata, write_ndata
@@ -115,7 +115,7 @@ class computeqcplot(SimpleInterface):
                                      "trans_y", "trans_z"
                                  ])
         # Compute fd_timeseries from motion_confounds df
-        fd_timeseries = compute_FD(confound=motion_df,
+        fd_timeseries = compute_fd(confound=motion_df,
                                    head_radius=self.inputs.head_radius)
 
         # Get rmsd

--- a/xcp_d/notebooks/restingstate.ipynb
+++ b/xcp_d/notebooks/restingstate.ipynb
@@ -28,7 +28,7 @@
     "from xcp_d.interfaces import computealff\n",
     "\n",
     "\n",
-    "def get_ciftiTR(cifti_file):\n",
+    "def get_cifti_tr(cifti_file):\n",
     "    import nibabel as nb\n",
     "    ciaxis = nb.load(cifti_file).header.get_axis(0)\n",
     "    return ciaxis.step"
@@ -58,7 +58,7 @@
     "dtseries = datadir + '/sub-colornest001_ses-1_task-rest_run-1_space-fsLR_den-91k_residual_bold.dtseries.nii'\n",
     " \n",
     "# get TR\n",
-    "tr = get_ciftiTR(dtseries)\n",
+    "tr = get_cifti_tr(dtseries)\n",
     "\n",
     "computealff_wf = computealff()\n",
     "computealff_wf.inputs.in_file= dtseries\n",

--- a/xcp_d/utils/__init__.py
+++ b/xcp_d/utils/__init__.py
@@ -30,7 +30,7 @@ from xcp_d.utils.fcon import (
     mesh_adjacency,
 )
 from xcp_d.utils.hcp2fmriprep import hcp2fmriprep
-from xcp_d.utils.modified_data import compute_FD, generate_mask, interpolate_masked_data
+from xcp_d.utils.modified_data import compute_fd, generate_mask, interpolate_masked_data
 from xcp_d.utils.plot import (
     compute_dvars,
     confoundplot,
@@ -77,7 +77,7 @@ __all__ = [
     'mesh_adjacency',
     'interpolate_masked_data',
     'generate_mask',
-    'compute_FD',
+    'compute_fd',
     'bid_derivative',
     'sentry_setup',
     'despikedatacifti',

--- a/xcp_d/utils/__init__.py
+++ b/xcp_d/utils/__init__.py
@@ -39,7 +39,7 @@ from xcp_d.utils.plot import (
     plot_svgx,
     plotimage,
 )
-from xcp_d.utils.qcmetrics import regisQ
+from xcp_d.utils.qcmetrics import compute_registration_qc
 from xcp_d.utils.restingstate import ContrastEnhancement, DespikePatch, ReHoNamePatch
 from xcp_d.utils.sentry import sentry_setup
 from xcp_d.utils.utils import (
@@ -81,7 +81,7 @@ __all__ = [
     'bid_derivative',
     'sentry_setup',
     'despikedatacifti',
-    'regisQ',
+    'compute_registration_qc',
     'get_maskfiles',
     'get_transformfile',
     'get_transformfilex',

--- a/xcp_d/utils/concantenation.py
+++ b/xcp_d/utils/concantenation.py
@@ -83,7 +83,7 @@ def concatenatebold(subjlist, fmridir, outputdir, work_dir):
                                   work_dir=work_dir)
 
 
-def make_DCAN_DF(fds_files, name):
+def make_dcan_df(fds_files, name):
     """Create an HDF5-format file containing a DCAN-format dataset.
 
     Parameters
@@ -240,7 +240,7 @@ def concatenate_nifti(subid, fmridir, outputdir, ses=None, work_dir=None):
                     combine_fd(filex, outfile)
                 if j.endswith('_desc-framewisedisplacement_bold.tsv'):
                     name = f"{fileid}{j.split('.')[0]}-DCAN.hdf5"
-                    make_DCAN_DF(filex, name)
+                    make_dcan_df(filex, name)
                 elif j.endswith('nii.gz'):
                     combinefile = "  ".join(filex)
                     mask = natsorted(
@@ -419,7 +419,7 @@ def concatenate_cifti(subid, fmridir, outputdir, ses=None, work_dir=None):
                         glob.glob(res.split('run-')[0] + '*run*' + j))
                     combine_fd(filex, outfile)
                     name = f"{fileid}{j.split('.')[0]}-DCAN.hdf5"
-                    make_DCAN_DF(filex, name)
+                    make_dcan_df(filex, name)
                 if j.endswith('dtseries.nii'):
                     filex = natsorted(
                         glob.glob(

--- a/xcp_d/utils/concantenation.py
+++ b/xcp_d/utils/concantenation.py
@@ -445,7 +445,7 @@ def concatenate_cifti(subid, fmridir, outputdir, ses=None, work_dir=None):
                 dvar = compute_dvars(read_ndata(f))
                 dvar[0] = np.mean(dvar)
                 raw_dvars.append(dvar)
-            TR = get_ciftiTR(filey[0])
+            TR = get_cifti_tr(filey[0])
             rawdata = tempfile.mkdtemp() + '/den-91k_bold.dtseries.nii'
             combinefile = " -cifti ".join(filey)
             os.system('wb_command -cifti-merge ' + rawdata + ' -cifti '
@@ -587,7 +587,7 @@ def combine_fd(fds_file, fileout):
     np.savetxt(fileout, df, fmt='%.5f', delimiter=',')
 
 
-def get_ciftiTR(cifti_file):
+def get_cifti_tr(cifti_file):
     """Extract repetition time from a CIFTI file.
 
     Parameters

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -150,7 +150,7 @@ def load_global_signal(confounds_df):
     return confounds_df["global_signal"]
 
 
-def load_WM_CSF(confounds_df):
+def load_wm_csf(confounds_df):
     """Select white matter and CSF nuissance regressors from confounds DataFrame.
 
     Parameters
@@ -312,7 +312,7 @@ def load_confound_matrix(datafile,
         trans_values = confoundtsv[["trans_x", "trans_y", "trans_z"]]
         motion = pd.concat([rot_values, trans_values], axis=1)
         derivative_rot_trans = pd.concat([motion, derivative(motion)], axis=1)
-        whitematter_csf = load_WM_CSF(confoundtsv)
+        whitematter_csf = load_wm_csf(confoundtsv)
         global_signal = load_global_signal(confoundtsv)
         confound = pd.concat([derivative_rot_trans, square_confound(
             derivative_rot_trans), whitematter_csf, global_signal], axis=1)
@@ -326,7 +326,7 @@ def load_confound_matrix(datafile,
         square_confounds = pd.concat(
             [derivative_rot_trans, square_confound(derivative_rot_trans)], axis=1)
         global_signal_whitematter_csf = pd.concat(
-            [load_WM_CSF(confoundtsv),
+            [load_wm_csf(confoundtsv),
              load_global_signal(confoundtsv)], axis=1)
         global_signal_whitematter_csf_derivative = pd.concat(
             [global_signal_whitematter_csf, derivative(global_signal_whitematter_csf)], axis=1)
@@ -343,11 +343,11 @@ def load_confound_matrix(datafile,
         cosine = load_cosine(confoundtsv)
         confound = pd.concat([derivative_rot_trans, acompcor, cosine], axis=1)
     elif params == 'aroma':  # Get the WM, CSF, and aroma values
-        whitematter_csf = load_WM_CSF(confoundtsv)
+        whitematter_csf = load_wm_csf(confoundtsv)
         aroma = load_aroma(datafile=datafile)
         confound = pd.concat([whitematter_csf, aroma], axis=1)
     elif params == 'aroma_gsr':  # Get the WM, CSF, and aroma values, as well as global signal
-        whitematter_csf = load_WM_CSF(confoundtsv)
+        whitematter_csf = load_wm_csf(confoundtsv)
         aroma = load_aroma(datafile=datafile)
         global_signal = load_global_signal(confoundtsv)
         confound = pd.concat([whitematter_csf, aroma, global_signal], axis=1)

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 
-def compute_FD(confound, head_radius=50):
+def compute_fd(confound, head_radius=50):
     """Compute framewise displacement.
 
     NOTE: TS- Which kind of FD? Power?

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -672,7 +672,7 @@ class fMRIPlot:
         #  Load in the necessary information
         func_img = nb.load(func_file)
         self.func_file = func_file
-        self.TR = TR or _get_TR(func_img)
+        self.TR = TR or _get_tr(func_img)
         self.mask_data = None
         self.seg_data = None
         sns.set_style("whitegrid")
@@ -1062,15 +1062,15 @@ def display_cb(grid_spec_ts):
     return ax2, grid_specification
 
 
-def _get_TR(img):
+def _get_tr(img):
     """Attempt to extract repetition time from NIfTI/CIFTI header.
 
     Examples
     --------
-    _get_TR(nb.load(Path(test_data) /
+    _get_tr(nb.load(Path(test_data) /
     ...    'sub-ds205s03_task-functionallocalizer_run-01_bold_volreg.nii.gz'))
     2.2
-     _get_TR(nb.load(Path(test_data) /
+     _get_tr(nb.load(Path(test_data) /
     ...    'sub-01_task-mixedgamblestask_run-02_space-fsLR_den-91k_bold.dtseries.nii'))
     2.0
     """

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -3,7 +3,7 @@ import nibabel as nb
 import numpy as np
 
 
-def regisQ(bold2t1w_mask, t1w_mask, bold2template_mask, template_mask):
+def compute_registration_qc(bold2t1w_mask, t1w_mask, bold2template_mask, template_mask):
     """Compute quality of registration metrics.
 
     This function will calculate a series of metrics, including Dice's similarity index,

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -174,7 +174,7 @@ For each of the {num2words(num_cifti)} CIFTI runs found per subject (across all
 tasks and sessions), the following post-processing was performed:
 """
 
-    TR = get_ciftiTR(cifti_file)
+    TR = get_cifti_tr(cifti_file)
     if TR is None:
         metadata = layout.get_metadata(cifti_file)
         TR = metadata['RepetitionTime']
@@ -185,7 +185,7 @@ tasks and sessions), the following post-processing was performed:
     except Exception:
         raise Exception(f"Unable to find confounds file for {cifti_file}.")
 
-    # TR = get_ciftiTR(cifti_file=cifti_file)
+    # TR = get_cifti_tr(cifti_file=cifti_file)
     initial_volumes_to_drop = 0
     if dummytime > 0:
         initial_volumes_to_drop = int(np.floor(dummytime / TR))
@@ -572,7 +572,7 @@ class DerivativesDataSink(bids_derivative):
     out_path_base = 'xcp_d'
 
 
-def get_ciftiTR(cifti_file):
+def get_cifti_tr(cifti_file):
     """Extract TR from CIFTI file."""
     ciaxis = nb.load(cifti_file).header.get_axis(0)
     return ciaxis.step


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->
Related to, but does not close, https://github.com/PennLINC/xcp_d/issues/471.

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
- Rename any non-snake_case function names to snake_case.
    - write_T1_reg_rows --> write_T1_reg_rows
    - compute_FD --> compute_fd
    - regisQ --> compute_registration_qc
    - get_ciftiTR --> get_cifti_tr
    - _get_TR --> _get_tr
    - make_DCAN_DF --> make_dcan_df
    - load_WM_CSF --> load_wm_csf

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None.