### PR TITLE
[REF] Address remaining linter warnings

### DIFF
--- a/xcp_d/interfaces/layout_builder.py
+++ b/xcp_d/interfaces/layout_builder.py
@@ -284,7 +284,7 @@ class TasksSection(Section):
                 self.section += constants.PLACEHOLDER_ROW.format(
                     row_label=values['title'])
 
-    def write_bold_gray_row(self, task_name,task_num):
+    def write_bold_gray_row(self, task_name):
         """Write BOLD row."""
         bold_data = {}
         bold_data['row_modal'] = self.img_modal.get_modal_id()

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -21,7 +21,7 @@ from xcp_d.utils.concantenation import compute_dvars
 from xcp_d.utils.confounds import load_confound, load_motion
 from xcp_d.utils.filemanip import fname_presuffix
 from xcp_d.utils.modified_data import compute_fd
-from xcp_d.utils.plot import fMRIPlot
+from xcp_d.utils.plot import FMRIPlot
 from xcp_d.utils.qcmetrics import compute_registration_qc
 from xcp_d.utils.write_save import read_ndata, write_ndata
 
@@ -173,7 +173,7 @@ class QCPlot(SimpleInterface):
 
         confounds = pd.DataFrame({'FD': fd_timeseries, 'DVARS': dvars_before_processing})
 
-        fig = fMRIPlot(func_file=temporary_file,
+        fig = FMRIPlot(func_file=temporary_file,
                        seg_file=self.inputs.seg_file,
                        data=confounds,
                        mask_file=self.inputs.mask_file).plot(labelsize=8)
@@ -215,7 +215,7 @@ class QCPlot(SimpleInterface):
                         filename=temporary_file,
                         TR=self.inputs.TR)
 
-            figure = fMRIPlot(func_file=temporary_file,
+            figure = FMRIPlot(func_file=temporary_file,
                               seg_file=self.inputs.seg_file,
                               data=confounds,
                               mask_file=self.inputs.mask_file).plot(labelsize=8)
@@ -234,7 +234,7 @@ class QCPlot(SimpleInterface):
                                              maskfile=self.inputs.mask_file)
             confounds = pd.DataFrame({'FD': fd_timeseries, 'DVARS': dvars_after_processing})
 
-            figure = fMRIPlot(func_file=self.inputs.cleaned_file,
+            figure = FMRIPlot(func_file=self.inputs.cleaned_file,
                               seg_file=self.inputs.seg_file,
                               data=confounds,
                               mask_file=self.inputs.mask_file).plot(labelsize=8)

--- a/xcp_d/utils/filemanip.py
+++ b/xcp_d/utils/filemanip.py
@@ -635,15 +635,13 @@ def load_json(filename):
     return data
 
 
-def loadcrash(infile, *args):
+def loadcrash(infile):
     """Load pickled Nipype crashfile.
 
     Parameters
     ----------
     infile : str
         Path to the pickle file to load.
-    args : dict
-        These don't appear to be used.
 
     Returns
     -------

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -650,7 +650,7 @@ def plot_svgx(rawdata,
     return unprocessed_filename, processed_filename
 
 
-class fMRIPlot:
+class FMRIPlot:
     """Generates the fMRI Summary Plot."""
 
     __slots__ = ("func_file", "mask_data", "TR", "seg_data", "confounds",

--- a/xcp_d/workflow/anatomical.py
+++ b/xcp_d/workflow/anatomical.py
@@ -13,12 +13,10 @@ from pathlib import Path
 
 from nipype.interfaces import utility as niu
 from nipype.interfaces.ants import CompositeTransformUtil  # MB
-from nipype.interfaces.ants.resampling import (
-    ApplyTransforms as antsapplytransforms,  # TM
-)
+from nipype.interfaces.ants.resampling import ApplyTransforms  # TM
 from nipype.interfaces.freesurfer import MRIsConvert
-from nipype.interfaces.fsl import Merge as fslmerge  # TM
-from nipype.interfaces.fsl.maths import BinaryMaths as fslbinarymaths  # TM
+from nipype.interfaces.fsl import Merge as FSLMerge  # TM
+from nipype.interfaces.fsl.maths import BinaryMaths  # TM
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from templateflow.api import get as get_template
@@ -447,7 +445,7 @@ def init_anatomical_wf(
             #
 
             combine_xfms = pe.Node(
-                antsapplytransforms(
+                ApplyTransforms(
                     reference_image=mnitemplate,
                     interpolation="LanczosWindowedSinc",
                     print_out_composite_warp_file=True,
@@ -458,7 +456,7 @@ def init_anatomical_wf(
                 n_procs=omp_nthreads,
             )
             combine_inv_xfms = pe.Node(
-                antsapplytransforms(
+                ApplyTransforms(
                     reference_image=mnitemplate,
                     interpolation="LanczosWindowedSinc",
                     print_out_composite_warp_file=True,
@@ -542,13 +540,13 @@ def init_anatomical_wf(
             # for use with wb_command -surface-apply-warpfield)
 
             reverse_y_component = pe.Node(
-                fslbinarymaths(operation="mul", operand_value=-1.0),
+                BinaryMaths(operation="mul", operand_value=-1.0),
                 name="reverse_y_component",
                 mem_gb=mem_gb,
                 n_procs=omp_nthreads,
             )
             reverse_inv_y_component = pe.Node(
-                fslbinarymaths(operation="mul", operand_value=-1.0),
+                BinaryMaths(operation="mul", operand_value=-1.0),
                 name="reverse_inv_y_component",
                 mem_gb=mem_gb,
                 n_procs=omp_nthreads,
@@ -570,13 +568,13 @@ def init_anatomical_wf(
 
             # re-merge warpfield in FSL FNIRT format, with the reversed y-component from above
             remerge_warpfield = pe.Node(
-                fslmerge(dimension="t"),
+                FSLMerge(dimension="t"),
                 name="remerge_warpfield",
                 mem_gb=mem_gb,
                 n_procs=omp_nthreads,
             )
             remerge_inv_warpfield = pe.Node(
-                fslmerge(dimension="t"),
+                FSLMerge(dimension="t"),
                 name="remerge_inv_warpfield",
                 mem_gb=mem_gb,
                 n_procs=omp_nthreads,


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->
Closes #471.

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
- Rename fMRIPlot to FMRIPlot.
- Do not import classes as lower-case variables.
- Remove unused `*args` argument in `utils.filemanip.loadcrash`.
- Remove lingering unused argument from `interfaces.layout_builder.TaskSection.write_bold_gray_row`.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None.