### PR TITLE
[REF] Centralize DerivativesDataSink definition

### DIFF
--- a/xcp_d/interfaces/bids.py
+++ b/xcp_d/interfaces/bids.py
@@ -96,7 +96,7 @@ class _DerivativesDataSinkOutputSpec(TraitedSpec):
     fixed_hdr = traits.List(traits.Bool, desc="whether derivative header was fixed")
 
 
-class DerivativesDataSink(SimpleInterface):
+class BaseDerivativesDataSink(SimpleInterface):
     """Store derivative files.
 
     Saves the ``in_file`` into a BIDS-Derivatives folder provided
@@ -330,3 +330,9 @@ class DerivativesDataSink(SimpleInterface):
                 sidecar.write_text(dumps(self._metadata, sort_keys=True, indent=2))
                 self._results["out_meta"] = str(sidecar)
         return runtime
+
+
+class DerivativesDataSink(BaseDerivativesDataSink):
+    """An updated data-sink for xcp_d derivatives."""
+
+    out_path_base = "xcp_d"

--- a/xcp_d/workflow/anatomical.py
+++ b/xcp_d/workflow/anatomical.py
@@ -17,7 +17,7 @@ from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from templateflow.api import get as get_template
 
 from xcp_d.interfaces.ants import CompositeInvTransformUtil, ConvertTransformFile
-from xcp_d.interfaces.bids import DerivativesDataSink as BIDSDerivativesDataSink
+from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.c3 import C3d  # TM
 from xcp_d.interfaces.connectivity import ApplyTransformsx
 from xcp_d.interfaces.surfplotting import BrainPlotx, RibbontoStatmap
@@ -32,12 +32,6 @@ from xcp_d.interfaces.workbench import (  # MB,TM
     SurfaceSphereProjectUnproject,
 )
 from xcp_d.utils.bids import collect_data
-
-
-class DerivativesDataSink(BIDSDerivativesDataSink):
-    """An updated data-sink for xcp_d derivatives."""
-
-    out_path_base = "xcp_d"
 
 
 def init_anatomical_wf(

--- a/xcp_d/workflow/base.py
+++ b/xcp_d/workflow/base.py
@@ -14,7 +14,7 @@ from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
 from xcp_d.__about__ import __version__
-from xcp_d.interfaces.bids import DerivativesDataSink as BIDSDerivativesDataSink
+from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.report import AboutSummary, SubjectSummary
 from xcp_d.utils.bids import (
     collect_data,
@@ -486,13 +486,6 @@ def _pop(inlist):
     if isinstance(inlist, (list, tuple)):
         return inlist[0]
     return inlist
-
-
-# RF: this shouldn't be in this file
-class DerivativesDataSink(BIDSDerivativesDataSink):
-    """Defines the data sink for the workflow."""
-
-    out_path_base = 'xcp_d'
 
 
 def getfmriprepv(fmri_dir):

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -14,7 +14,7 @@ from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransf
 from num2words import num2words
 from templateflow.api import get as get_template
 
-from xcp_d.interfaces.bids import DerivativesDataSink as BIDSDerivativesDataSink
+from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.filtering import FilteringData
 from xcp_d.interfaces.prepostcleaning import CensorScrub, Interpolate, RemoveTR
 from xcp_d.interfaces.qc_plot import QCPlot
@@ -714,9 +714,3 @@ def _t12native(fname):  # TODO: Update names and refactor
     t12ref = directx + '/' + fileup + 'from-T1w_to-scanner_mode-image_xfm.txt'
 
     return t12ref
-
-
-class DerivativesDataSink(BIDSDerivativesDataSink):
-    """Defines the data sink for the workflow."""
-
-    out_path_base = 'xcp_d'

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -12,7 +12,7 @@ from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from num2words import num2words
 
-from xcp_d.interfaces.bids import DerivativesDataSink as BIDSDerivativesDataSink
+from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.filtering import FilteringData
 from xcp_d.interfaces.prepostcleaning import CensorScrub, Interpolate, RemoveTR
 from xcp_d.interfaces.qc_plot import QCPlot
@@ -560,13 +560,6 @@ def _create_mem_gb(bold_fname):
     }
 
     return mem_gbz
-
-
-# RF: shouldn't be here
-class DerivativesDataSink(BIDSDerivativesDataSink):
-    """Defines the data sink for the workflow."""
-
-    out_path_base = 'xcp_d'
 
 
 def get_cifti_tr(cifti_file):

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -10,16 +10,10 @@ from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from templateflow.api import get as get_template
 
-from xcp_d.interfaces.bids import DerivativesDataSink as BIDSDerivativesDataSink
+from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.connectivity import ApplyTransformsx
 from xcp_d.interfaces.surfplotting import PlotImage, PlotSVGData
 from xcp_d.utils.utils import get_transformfile
-
-
-class DerivativesDataSink(BIDSDerivativesDataSink):
-    """Defines the data sink for the workflow."""
-
-    out_path_base = 'xcp_d'
 
 
 def init_execsummary_wf(omp_nthreads,

--- a/xcp_d/workflow/outputs.py
+++ b/xcp_d/workflow/outputs.py
@@ -6,14 +6,7 @@ from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
-from xcp_d.interfaces.bids import DerivativesDataSink as BIDSDerivativesDataSink
-
-
-# RF: Not here
-class DerivativesDataSink(BIDSDerivativesDataSink):
-    """Defines the data sink for the workflow."""
-
-    out_path_base = 'xcp_d'
+from xcp_d.interfaces.bids import DerivativesDataSink
 
 
 def init_writederivatives_wf(


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->
Closes #449. I don't think this is the best solution long-term (e.g., we could just import DerivativesDataSink from `niworkflows` and change the `out_path_base` in `xcp_d`- see #488), but it's a good solution for now.

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
- Rename the main definition of DerivativesDataSink to BaseDerivativesDataSink.
- Define DerivativesDataSink (inheriting from BaseDerivativesDataSink), with the appropriate `out_path_base`, in `interfaces.bids`.
- Import the new DerivativesDataSink, without modifying it, throughout the rest of the package.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None.