### PR TITLE
[FIX] Deprecate nuissance-regressors in favor of nuisance-regressors

### DIFF
--- a/.circleci/NiftiWithoutFreeSurferTest.sh
+++ b/.circleci/NiftiWithoutFreeSurferTest.sh
@@ -33,4 +33,5 @@ XCPD_CMD=$(run_xcpd_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR} ${TEMPDIR})
 
 $XCPD_CMD \
     --despike  --head_radius 40 \
-	--smoothing 6  -f 100 -v -v
+	--smoothing 6  -f 100 -v -v \
+    --nuissance-regressors 27P

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -45,7 +45,8 @@ class DeprecatedStoreAction(Action):
     Based off of https://gist.github.com/bsolomon1124/44f77ed2f15062c614ef6e102bc683a5.
     """
 
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, parser, namespace, values, option_string=None):  # noqa: U100
+        """Call the argument."""
         NIWORKFLOWS_LOG.warn(
             f"Argument '{option_string}' is deprecated and will be removed in version 0.1.6. "
             "Please use '--nuisance-regressors' or '-p'."

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -40,11 +40,15 @@ def check_deps(workflow):
 
 
 class DeprecatedStoreAction(Action):
+    """A custom argparse "store" action to raise a DeprecationWarning.
+
+    Based off of https://gist.github.com/bsolomon1124/44f77ed2f15062c614ef6e102bc683a5.
+    """
+
     def __call__(self, parser, namespace, values, option_string=None):
-        warnings.warn(
-            f"Argument {self.option_string} is deprecated and will be removed in version 0.1.6. "
-            "Please use '--nuisance-regressors' or '-p'.",
-            DeprecationWarning,
+        NIWORKFLOWS_LOG.warn(
+            f"Argument '{option_string}' is deprecated and will be removed in version 0.1.6. "
+            "Please use '--nuisance-regressors' or '-p'."
         )
         setattr(namespace, self.dest, values)
 

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -160,7 +160,7 @@ def get_parser():
         help=(
             'Nuisance parameters to be selected, other options include 24P and 36P acompcor and '
             'aroma, see Ciric etal 2007. '
-            'This parameter is deprecated. '
+            'This parameter is deprecated and will be removed in version 0.1.6. '
             'Please use "-p" or "--nuisance-regressors".'
         )
     )

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -148,18 +148,33 @@ def get_parser():
                          action='store_true',
                          default=False,
                          help='despike the nifti/cifti before postprocessing')
-    g_param.add_argument(
-        '-p',
+
+    nuisance_params = g_param.add_mutually_exclusive_group()
+    nuisance_params.add_argument(
         '--nuissance-regressors',
+        dest="nuisance_regressors",
         required=False,
         default='36P',
-        choices=[
-            '27P', '36P', '24P', 'acompcor', 'aroma', 'acompcor_gsr',
-            'aroma_gsr', 'custom'
-        ],
+        choices=['27P', '36P', '24P', 'acompcor', 'aroma', 'acompcor_gsr', 'aroma_gsr', 'custom'],
         type=str,
-        help='nuissance parameters to be selected, other options include 24P and 36P \
-                                           acompcor and aroma, see Ciric etal 2007'
+        help=(
+            'Nuisance parameters to be selected, other options include 24P and 36P acompcor and '
+            'aroma, see Ciric etal 2007. '
+            'This parameter is deprecated. '
+            'Please use "-p" or "--nuisance-regressors".'
+        )
+    )
+    nuisance_params.add_argument(
+        '-p',
+        '--nuisance-regressors',
+        dest="nuisance_regressors",
+        required=False,
+        choices=['27P', '36P', '24P', 'acompcor', 'aroma', 'acompcor_gsr', 'aroma_gsr', 'custom'],
+        type=str,
+        help=(
+            'Nuisance parameters to be selected, other options include 24P and 36P acompcor and '
+            'aroma, see Ciric etal 2007.'
+        )
     )
     g_param.add_argument(
         '-c',
@@ -176,8 +191,7 @@ def get_parser():
         help='first volume in seconds to be removed or skipped before postprocessing'
     )
 
-    g_filter = parser.add_argument_group(
-        'Filtering parameters and default value')
+    g_filter = parser.add_argument_group('Filtering parameters and default value')
 
     g_filter.add_argument('--bandpass_filter',
                           action='store',

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -172,8 +172,7 @@ def get_parser():
         choices=['27P', '36P', '24P', 'acompcor', 'aroma', 'acompcor_gsr', 'aroma_gsr', 'custom'],
         type=str,
         help=(
-            'Nuisance parameters to be selected, other options include 24P and 36P acompcor and '
-            'aroma, see Ciric etal 2007.'
+            'Nuisance parameters to be selected. See Ciric etal 2007.'
         )
     )
     g_param.add_argument(
@@ -182,7 +181,7 @@ def get_parser():
         required=False,
         default=None,
         type=Path,
-        help='custom confound to be added to nuissance regressors')
+        help='Custom confound to be added to nuisance regressors.')
     g_param.add_argument(
         '-d',
         '--dummytime',
@@ -640,7 +639,7 @@ def build_workflow(opts, retval):
         task_id=opts.task_id,
         despike=opts.despike,
         smoothing=opts.smoothing,
-        params=opts.nuissance_regressors,
+        params=opts.nuisance_regressors,
         cifti=opts.cifti,
         analysis_level=opts.analysis_level,
         output_dir=str(output_dir),

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -12,7 +12,7 @@ import os
 import sys
 import uuid
 import warnings
-from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from argparse import Action, ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path
 from time import strftime
 
@@ -37,6 +37,16 @@ def check_deps(workflow):
                   for node in workflow._get_all_nodes()
                   if (hasattr(node.interface, '_cmd') and which
                   (node.interface._cmd.split()[0]) is None))
+
+
+class DeprecatedStoreAction(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        warnings.warn(
+            f"Argument {self.option_string} is deprecated and will be removed in version 0.1.6. "
+            "Please use '--nuisance-regressors' or '-p'.",
+            DeprecationWarning,
+        )
+        setattr(namespace, self.dest, values)
 
 
 def get_parser():
@@ -153,6 +163,7 @@ def get_parser():
     nuisance_params.add_argument(
         '--nuissance-regressors',
         dest="nuisance_regressors",
+        action=DeprecatedStoreAction,
         required=False,
         default='36P',
         choices=['27P', '36P', '24P', 'acompcor', 'aroma', 'acompcor_gsr', 'aroma_gsr', 'custom'],

--- a/xcp_d/notebooks/hcp2fmriprep.py
+++ b/xcp_d/notebooks/hcp2fmriprep.py
@@ -480,7 +480,7 @@ def regression(data, confound):
     data:
         numpy ndarray- vertices by timepoints
     confound:
-        nuissance regressors reg by timepoints
+        nuisance regressors reg by timepoints
     return:
         residual matrix
     """

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -151,7 +151,7 @@ def load_global_signal(confounds_df):
 
 
 def load_wm_csf(confounds_df):
-    """Select white matter and CSF nuissance regressors from confounds DataFrame.
+    """Select white matter and CSF nuisance regressors from confounds DataFrame.
 
     Parameters
     ----------

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -469,7 +469,7 @@ def plot_svgx(rawdata,
     rawdata :
         nifti or cifti before processing
     regressed_data :
-        nifti or cifti after nuissance regression
+        nifti or cifti after nuisance regression
     residual_data :
         nifti or cifti after regression and filtering
     mask :

--- a/xcp_d/workflow/base.py
+++ b/xcp_d/workflow/base.py
@@ -138,11 +138,11 @@ def init_xcpd_wf(
     head_radius : float
         radius of the head for FD computation
     params: str
-        nuissance regressors to be selected from fmriprep regressors
+        nuisance regressors to be selected from fmriprep regressors
     smoothing: float
         smooth the derivatives output with kernel size (fwhm)
     custom_confounds: str
-        path to cusrtom nuissance regressors
+        path to cusrtom nuisance regressors
     dummytime: float
         the first vols in seconds to be removed before postprocessing
     """
@@ -283,11 +283,11 @@ def init_subject_wf(
     head_radius : float
         radius of the head for FD computation
     params: str
-        nuissance regressors to be selected from fmriprep regressors
+        nuisance regressors to be selected from fmriprep regressors
     smoothing: float
         smooth the derivatives output with kernel size (fwhm)
     custom_confounds: str
-        path to custom nuissance regressors
+        path to custom nuisance regressors
     dummytime: float
         the first vols in seconds to be removed before postprocessing
     """

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -117,9 +117,9 @@ def init_boldpostprocess_wf(
     head_radius : float
         radius of the head for FD computation
     params: str
-        nuissance regressors to be selected from fmriprep regressors
+        nuisance regressors to be selected from fmriprep regressors
     custom_confounds: str
-        path to cusrtom nuissance regressors
+        path to cusrtom nuisance regressors
     omp_nthreads : int
         Maximum number of threads an individual process may use
     dummytime: float

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -108,11 +108,11 @@ def init_ciftipostprocess_wf(
     head_radius : float
         radius of the head for FD computation
     params: str
-        nuissance regressors to be selected from fmriprep regressors
+        nuisance regressors to be selected from fmriprep regressors
     output_dir : str
         Directory in which to save xcp_d output
     custom_confounds: str
-        path to cusrtom nuissance regressors
+        path to cusrtom nuisance regressors
     omp_nthreads : int
         Maximum number of threads an individual process may use
     dummytime: float
@@ -199,9 +199,9 @@ flagged as outliers and excluded from nuisance regression.
 
     else:
         workflow.__desc__ = workflow.__desc__ + f""" \
-before nuissance regression and filtering,both the nuisance regressors and volumes were demeaned
+before nuisance regression and filtering,both the nuisance regressors and volumes were demeaned
 and detrended. Volumes with framewise-displacement greater than {fd_thresh} mm
-[@power_fd_dvars;@satterthwaite_2013] were flagged as outliers and excluded from nuissance
+[@power_fd_dvars;@satterthwaite_2013] were flagged as outliers and excluded from nuisance
 regression.
 """
 

--- a/xcp_d/workflow/outputs.py
+++ b/xcp_d/workflow/outputs.py
@@ -121,7 +121,7 @@ def init_writederivatives_wf(
     cleaned_data_dictionary = {
         'RepetitionTime': TR,
         'Freq Band': [highpass, lowpass],
-        'nuissance parameters': params,
+        'nuisance parameters': params,
         'dummy vols': int(np.ceil(dummytime / TR))
     }
     smoothed_data_dictionary = {'FWHM': smoothing}  # Separate dictionary for smoothing

--- a/xcp_d/workflow/postprocessing.py
+++ b/xcp_d/workflow/postprocessing.py
@@ -67,7 +67,7 @@ def init_post_process_wf(
     bold_file: str
         bold file for post processing
     params: str
-        nuissance regressors to be selected from fmriprep regressors
+        nuisance regressors to be selected from fmriprep regressors
     cifti : bool
     dummytime: float
         the first few seconds to be removed before postprocessing
@@ -101,24 +101,24 @@ def init_post_process_wf(
     if dummytime > 0:
         nvolx = str(np.floor(dummytime / TR))
         workflow.__desc__ = workflow.__desc__ + f""" \
-Before nuissance regression and filtering of the data, the first {nvolx} were
+Before nuisance regression and filtering of the data, the first {nvolx} were
 discarded. Furthermore, any volumes with framewise-displacement greater than
 {fd_thresh} [@satterthwaite2;@power_fd_dvars;@satterthwaite_2013] were flagged
-as outliers and excluded from nuissance regression.
+as outliers and excluded from nuisance regression.
 """
 
     else:
         workflow.__desc__ = workflow.__desc__ + f""" \
-Before nuissance regression and filtering any volumes with
+Before nuisance regression and filtering any volumes with
 framewise-displacement greater than {fd_thresh}
 [@satterthwaite2;@power_fd_dvars;@satterthwaite_2013] were  flagged as outlier
 and excluded from further analyses.
 """
 
     workflow.__desc__ = workflow.__desc__ + f""" \
-The following nuissance regressors {stringforparams(params=params)}
-[@mitigating_2018;@benchmarkp;@satterthwaite_2013] were selected from nuissance
-confound matrices of fMRIPrep output.  These nuissance regressors were regressed
+The following nuisance regressors {stringforparams(params=params)}
+[@mitigating_2018;@benchmarkp;@satterthwaite_2013] were selected from nuisance
+confound matrices of fMRIPrep output.  These nuisance regressors were regressed
 out from the bold data with *LinearRegression* as implemented in Scikit-Learn
 {sklearn.__version__} [@scikit-learn].  The residual were then  band pass filtered within the
 frequency band {lower_bpf}-{upper_bpf} Hz.


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
- Create a new command-line argument, `--nuisance-regressors`, that is mutually exclusive with the existing `--nuissance-regressors` parameter.
- Raise a warning when users use `--nuissance-regressors`, with a note that the parameter will be removed in 0.1.6 (two releases from next).

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None.