### PR TITLE
[ENH/FIX] Update required pybids ver

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     nilearn ~= 0.6.0
     brainsprite ~= 0.14.2
     psutil >= 5.4
-    pybids >= 0.14.0
+    pybids ~= 0.15.1
     matplotlib ~= 3.3.4
     pyyaml
     templateflow ~= 0.6.1


### PR DESCRIPTION


<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

Follow-up to #320-- changes pybids req from >= 0.14.0 to ~=0.15.1. 

pybids 0.15.0 and up retain zero-padding of BIDS run indices (when the indices are read in as int type), whereas in < 0.15.0 zero-padding is removed. This fixes an error where filenames of residual BOLD files and their corresponding figures would be mismatched (due to removal of zero-padding in the BOLD files, but not the figures since the figures are never read in with pybids)
## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
