### PR TITLE
[FIX] Fix "manadatory" typo in interfaces

### DIFF
--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -34,10 +34,10 @@ class _NiftiConnectInputSpec(BaseInterfaceInputSpec):
 
 class _NiftiConnectOutputSpec(TraitedSpec):
     time_series_tsv = File(exists=True,
-                           manadatory=True,
+                           mandatory=True,
                            desc=" time series file")
     fcon_matrix_tsv = File(exists=True,
-                           manadatory=True,
+                           mandatory=True,
                            desc=" time series file")
 
 
@@ -110,7 +110,7 @@ class _ConnectPlotInputSpec(BaseInterfaceInputSpec):
 class _ConnectPlotOutputSpec(TraitedSpec):
     connectplot = File(
         exists=True,
-        manadatory=True,
+        mandatory=True,
     )
 
 

--- a/xcp_d/interfaces/filtering.py
+++ b/xcp_d/interfaces/filtering.py
@@ -47,7 +47,7 @@ class _FilteringDataInputSpec(BaseInterfaceInputSpec):
 
 
 class _FilteringDataOutputSpec(TraitedSpec):
-    filtered_file = File(exists=True, manadatory=True, desc="Filtered file")
+    filtered_file = File(exists=True, mandatory=True, desc="Filtered file")
 
 
 class FilteringData(SimpleInterface):

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -193,7 +193,7 @@ class _CensorScrubInputSpec(BaseInterfaceInputSpec):
 
 class _CensorScrubOutputSpec(TraitedSpec):
     bold_censored = File(exists=True,
-                         manadatory=True,
+                         mandatory=True,
                          desc="FD-censored bold file")
 
     fmriprep_confounds_censored = File(exists=True,
@@ -347,7 +347,7 @@ class _InterpolateInputSpec(BaseInterfaceInputSpec):
 
 class _InterpolateOutputSpec(TraitedSpec):
     bold_interpolated = File(exists=True,
-                             manadatory=True,
+                             mandatory=True,
                              desc=" fmriprep censored")
 
 

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -65,12 +65,12 @@ class _QCPlotInputSpec(BaseInterfaceInputSpec):
 
 
 class _QCPlotOutputSpec(TraitedSpec):
-    qc_file = File(exists=True, manadatory=True, desc="qc file in tsv")
+    qc_file = File(exists=True, mandatory=True, desc="qc file in tsv")
     raw_qcplot = File(exists=True,
-                      manadatory=True,
+                      mandatory=True,
                       desc="qc plot before regression")
     clean_qcplot = File(exists=True,
-                        manadatory=True,
+                        mandatory=True,
                         desc="qc plot after regression")
 
 

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -131,7 +131,7 @@ class _CiftiDespikeInputSpec(BaseInterfaceInputSpec):
 
 
 class _CiftiDespikeOutputSpec(TraitedSpec):
-    des_file = File(exists=True, manadatory=True, desc=" despike cifti")
+    des_file = File(exists=True, mandatory=True, desc=" despike cifti")
 
 
 class CiftiDespike(SimpleInterface):

--- a/xcp_d/interfaces/resting_state.py
+++ b/xcp_d/interfaces/resting_state.py
@@ -44,7 +44,7 @@ class _SurfaceReHoInputSpec(BaseInterfaceInputSpec):
 
 
 class _SurfaceReHoOutputSpec(TraitedSpec):
-    surf_gii = File(exists=True, manadatory=True, desc=" lh hemisphere reho")
+    surf_gii = File(exists=True, mandatory=True, desc=" lh hemisphere reho")
 
 
 class SurfaceReHo(SimpleInterface):
@@ -109,7 +109,7 @@ class _ComputeALFFInputSpec(BaseInterfaceInputSpec):
 
 
 class _ComputeALFFOutputSpec(TraitedSpec):
-    alff_out = File(exists=True, manadatory=True, desc=" alff")
+    alff_out = File(exists=True, mandatory=True, desc=" alff")
 
 
 class ComputeALFF(SimpleInterface):
@@ -174,7 +174,7 @@ class _BrainPlotInputSpec(BaseInterfaceInputSpec):
 
 
 class _BrainPlotOutputSpec(TraitedSpec):
-    nifti_html = File(exists=True, manadatory=True, desc="zscore html")
+    nifti_html = File(exists=True, mandatory=True, desc="zscore html")
 
 
 class BrainPlot(SimpleInterface):

--- a/xcp_d/interfaces/surfplotting.py
+++ b/xcp_d/interfaces/surfplotting.py
@@ -57,7 +57,7 @@ class _SurftoVolumeInputSpec(BaseInterfaceInputSpec):
 
 
 class _SurftoVolumeOutputSpec(TraitedSpec):
-    out_file = File(exists=True, manadatory=True, desc=" t1image")
+    out_file = File(exists=True, mandatory=True, desc=" t1image")
 
 
 class SurftoVolume(SimpleInterface):
@@ -89,7 +89,7 @@ class _BrainPlotxInputSpec(BaseInterfaceInputSpec):
 
 
 class _BrainPlotxOutputSpec(TraitedSpec):
-    out_html = File(exists=True, manadatory=True, desc="zscore html")
+    out_html = File(exists=True, mandatory=True, desc="zscore html")
 
 
 class BrainPlotx(SimpleInterface):
@@ -122,7 +122,7 @@ class _RegPlotInputSpec(BaseInterfaceInputSpec):
 
 
 class _RegPlotOutputSpec(TraitedSpec):
-    out_file = File(exists=True, manadatory=True, desc="svg file")
+    out_file = File(exists=True, mandatory=True, desc="svg file")
 
 
 class RegPlot(SimpleInterface):
@@ -167,10 +167,10 @@ class _PlotSVGDataInputSpec(BaseInterfaceInputSpec):
 
 class _PlotSVGDataOutputSpec(TraitedSpec):
     before_process = File(exists=True,
-                          manadatory=True,
+                          mandatory=True,
                           desc=".SVG file before processing")
     after_process = File(exists=True,
-                         manadatory=True,
+                         mandatory=True,
                          desc=".SVG file after processing")
 
 
@@ -220,7 +220,7 @@ class _RibbontoStatmapInputSpec(BaseInterfaceInputSpec):
 
 class _RibbontoStatmapOutputSpec(TraitedSpec):
     out_file = File(exists=True,
-                    manadatory=True,
+                    mandatory=True,
                     desc="ribbon > pial and white")
 
 


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
- In several files, the field "manadatory" is used instead of "mandatory". This replaces all uses of the former with the latter.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None.