### PR TITLE
[TST] Make local tests stricter

### DIFF
--- a/.circleci/get_data.sh
+++ b/.circleci/get_data.sh
@@ -119,7 +119,7 @@ The results of running a colornest subject through fmriprep
 freesurfer_colornest:
 ---------------------
 
-The freesurfer results for the same data as in `fmriprep_colornest`
+The freesurfer results for the same data as in "fmriprep_colornest"
 
 fsaverage*:
 -----------

--- a/.circleci/get_data.sh
+++ b/.circleci/get_data.sh
@@ -1,5 +1,5 @@
 
-if [[ "$SHELL" =~ zsh ]]; then
+if [[ "$SHELL" == zsh ]]; then
   setopt SH_WORD_SPLIT
 fi
 

--- a/.circleci/get_data.sh
+++ b/.circleci/get_data.sh
@@ -5,22 +5,32 @@ fi
 
 # Edit these for project-wide testing
 WGET="wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 0 -q"
-LOCAL_PATCH= ~/projects/xcp_d/xcp_d  # Change to your local patch 
-IMAGE=pennlinc/xcp_d:unstable
+LOCAL_PATCH="~/projects/xcp_d/xcp_d"  # Change to your local patch
+IMAGE="pennlinc/xcp_d:unstable"
 
 # Determine if we're in a CI test
 if [[ "${CIRCLECI}" = "true" ]]; then
-  IN_CI=true
+  IN_CI="true"
   NTHREADS=2
   OMP_NTHREADS=2
+
   if [[ -n "${CIRCLE_CPUS}" ]]; then
     NTHREADS=${CIRCLE_CPUS}
     OMP_NTHREADS=$(expr $NTHREADS - 1)
   fi
+
 else
   IN_CI="false"
   NTHREADS=2
   OMP_NTHREADS=2
+
+  # check that the local xcp_d path exists
+  if [ ! -d $LOCAL_PATCH ]
+  then
+    echo "Path $LOCAL_PATCH DNE"
+    exit 125
+  fi
+
 fi
 export IN_CI NTHREADS OMP_NTHREADS
 


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
- Ensure that the local xcp_d path exists, and raise an error if it doesn't. Previous it would just raise a warning, then continue on using the version in the Docker file.
- Don't call `setopt` unless the shell is zsh, instead of the opposite.
- Make sure a few other things in `get_data.sh` are treated as strings.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None.