### PR TITLE
[FIX] Change "hpc" in CLI to "hcp"

### DIFF
--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -115,7 +115,7 @@ def get_parser():
                          action='store_true',
                          default=False,
                          help='postprocess cifti instead of nifti'
-                         'this is set default for dcan and hpc')
+                         'this is set default for dcan and hcp')
 
     g_perfm = parser.add_argument_group('Options to for resource management ')
     g_perfm.add_argument('--nthreads',
@@ -155,7 +155,7 @@ def get_parser():
         required=False,
         default='fmriprep',
         type=str,
-        choices=['fmriprep', 'dcan', 'hpc'],
+        choices=['fmriprep', 'dcan', 'hcp'],
         help='fMRIPprep/nibabies are default structures, DCAN and HCP are optional')
 
     g_param = parser.add_argument_group('Parameters for postprocessing')


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->
Closes #554. AFAICT, running `xcp_d` with `--input-type hcp` would currently raise an error, but `--input-type hpc` wouldn't reach any of the necessary code, because `hcp` is used in all of the rest of the codebase, so I'm not counting this PR as a breaking change.

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
- Change "hpc" (a typo) in the command-line interface to "hcp" (Human Connectome Project).

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None.