### PR TITLE
Use nipype Despike instead of xcpd DespikePatch

### DIFF
--- a/xcp_d/interfaces/resting_state.py
+++ b/xcp_d/interfaces/resting_state.py
@@ -11,7 +11,6 @@ import shutil
 import tempita
 from brainsprite import viewer_substitute
 from nipype import logging
-from nipype.interfaces.afni.preprocess import AFNICommandOutputSpec, DespikeInputSpec
 from nipype.interfaces.afni.utils import (
     ReHoInputSpec,
     ReHoOutputSpec,
@@ -254,33 +253,6 @@ class ReHoNamePatch(SimpleInterface):
         os.system(
             "3dReHo -inset inset.nii.gz -mask mask.nii.gz -nneigh 27 -prefix reho.nii.gz"
         )
-        self._results['out_file'] = outfile
-
-
-class DespikePatch(SimpleInterface):
-    """Remove 'spikes' from the 3D+time input dataset.
-
-    For complete details, see the `3dDespike Documentation.
-    <https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dDespike.html>`_
-
-    Examples
-    --------
-    >>> from nipype.interfaces import afni
-    >>> despike = afni.Despike()
-    >>> despike.inputs.in_file = 'functional.nii'
-    >>> despike.cmdline
-    '3dDespike -prefix functional_despike functional.nii'
-    >>> res = despike.run()  # doctest: +SKIP
-    """
-
-    _cmd = "3dDespike"
-    input_spec = DespikeInputSpec
-    output_spec = AFNICommandOutputSpec
-
-    def _run_interface(self, runtime):
-        outfile = runtime.cwd + "/3despike.nii.gz"
-        shutil.copyfile(self.inputs.in_file, runtime.cwd + "/inset.nii.gz")
-        os.system("3dDespike -NEW -prefix  3despike.nii.gz inset.nii.gz")
         self._results['out_file'] = outfile
 
 

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -8,7 +8,7 @@ import numpy as np
 import sklearn
 from nipype import Function, logging
 from nipype.interfaces import utility as niu
-from nipype.interfaces.afni.preprocessing import Despike
+from nipype.interfaces.afni import Despike
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->
Closes None, but is related to #488.

The DespikePatch exists because AFNI has had trouble with long filenames in the past. However, newer versions of AFNI should not have this issue. Alternatively, we could explicitly set the output filename in order to reduce the filename length.

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
- Remove `xcp_d.interfaces.resting_state.DespikePatch`.
- Use `nipype.interfaces.afni.preprocessing.Despike` within `init_boldpostprocess_wf` instead of `DespikePatch`.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
