### PR TITLE
Add correlation heatmaps plot to HTML report

### DIFF
--- a/xcp_d/data/reports.yml
+++ b/xcp_d/data/reports.yml
@@ -4,15 +4,21 @@ sections:
   ordering: session,task,acquisition,ceagent,reconstruction,direction,run,echo
   reportlets:
   - bids: {datatype: figures, desc: summary, suffix: bold}
-  - bids: {datatype: figures, desc: qualitycontrol,suffix: bold}
-  - bids: {datatype: figures, desc: preprocessing,suffix: bold}
+  - bids: {datatype: figures, desc: qualitycontrol, suffix: bold}
+  - bids: {datatype: figures, desc: preprocessing, suffix: bold}
     caption: FD and DVARS are two measures of in-scanner motion. This plot shows standardized FD, DVARS,
              and then a carpet plot for the time series of each voxel/vertex’s time series of activity.
     subtitle: Carpet Plot before Postprocessing
-  - bids: {datatype: figures, desc: postprocessing,suffix: bold}
+  - bids: {datatype: figures, desc: postprocessing, suffix: bold}
     caption: FD and DVARS are two measures of in-scanner motion. This plot shows standardized FD, DVARS,
             and then a carpet plot for the time series of each voxel/vertex’s time series of activity..
     subtitle: Carpet Plot after postprocessing
+- name: Resting State Outputs
+  ordering: session,task,acquisition,ceagent,reconstruction,direction,run,echo
+  reportlets:
+  - bids: {datatype: figures, desc: connectivityplot, suffix: bold}
+    caption: This plot shows heatmaps from ROI-to-ROI correlations from four atlases.
+    subtitle: Correlation Heatmaps from Four Atlases
 - name: About
   reportlets:
   - bids: {datatype: figures, desc: about, suffix: bold}

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -639,7 +639,7 @@ Residual timeseries from this regression were then band-pass filtered to retain 
     ds_report_connectivity = pe.Node(DerivativesDataSink(
         base_directory=output_dir,
         source_file=bold_file,
-        desc='connectvityplot',
+        desc='connectivityplot',
         datatype="figures"),
         name='ds_report_connectivity',
         run_without_submitting=False)

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -490,7 +490,7 @@ Residual timeseries from this regression were then band-pass filtered to retain 
     ds_report_connectivity = pe.Node(DerivativesDataSink(
         base_directory=output_dir,
         source_file=bold_file,
-        desc='connectvityplot',
+        desc='connectivityplot',
         datatype="figures"),
         name='ds_report_connectivity',
         run_without_submitting=True)


### PR DESCRIPTION
Related to #519 and other reporting issues. 

I noticed that the bbregister plot that exists in the executive summary is just copied from fMRIPrep. Do we want to include it in the xcpd report? Users could just refer back to their fMRIPrep derivatives, and anything they'd catch from the bbregister plot should probably have been caught before running xcpd, IMHO.

I would love to add the ReHo and ALFF plots to the report, but #578 still holds.

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
- Add the `connectivityplot` to the HTML report.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
