### PR TITLE
Output all filtered motion parameters

### DIFF
--- a/.circleci/cifti_with_freesurfer_outputs.txt
+++ b/.circleci/cifti_with_freesurfer_outputs.txt
@@ -24,7 +24,7 @@ xcp_d/sub-colornest001/ses-1/anat/sub-colornest001_ses-1_rec-refaced_space-fsLR_
 xcp_d/sub-colornest001/ses-1/anat/sub-colornest001_ses-1_rec-refaced_space-fsLR_den-32k_hemi-R_pial.surf.gii
 xcp_d/sub-colornest001/ses-1/anat/sub-colornest001_ses-1_rec-refaced_space-fsLR_den-32k_hemi-R_smoothwm.surf.gii
 xcp_d/sub-colornest001/ses-1/func
-xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_desc-framewisedisplacement_motion.tsv
+xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_desc-filtered_motion.tsv
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_outliers.tsv
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-fsLR_atlas-Glasser_den-91k_measure-pearsoncorrelation_conmat.pconn.nii
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-fsLR_atlas-Glasser_den-91k_timeseries.ptseries.nii
@@ -62,7 +62,7 @@ xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-f
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-fsLR_den-91k_desc-denoisedSmoothed_bold.dtseries.nii
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-fsLR_den-91k_desc-denoisedSmoothed_bold.json
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-fsLR_den-91k_qc.csv
-xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_desc-framewisedisplacement_motion.tsv
+xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_desc-filtered_motion.tsv
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_outliers.tsv
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_space-fsLR_atlas-Glasser_den-91k_measure-pearsoncorrelation_conmat.pconn.nii
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_space-fsLR_atlas-Glasser_den-91k_timeseries.ptseries.nii

--- a/.circleci/nifti_with_freesurfer_outputs.txt
+++ b/.circleci/nifti_with_freesurfer_outputs.txt
@@ -24,7 +24,7 @@ xcp_d/sub-colornest001/ses-1/anat/sub-colornest001_ses-1_rec-refaced_space-fsLR_
 xcp_d/sub-colornest001/ses-1/anat/sub-colornest001_ses-1_rec-refaced_space-fsLR_den-32k_hemi-R_pial.surf.gii
 xcp_d/sub-colornest001/ses-1/anat/sub-colornest001_ses-1_rec-refaced_space-fsLR_den-32k_hemi-R_smoothwm.surf.gii
 xcp_d/sub-colornest001/ses-1/func
-xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_desc-framewisedisplacement_motion.tsv
+xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_desc-filtered_motion.tsv
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_outliers.tsv
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_atlas-Glasser_measure-pearsoncorrelation_conmat.tsv
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_atlas-Glasser_timeseries.tsv
@@ -63,7 +63,7 @@ xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-M
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-denoised_bold.nii.gz
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-denoisedSmoothed_bold.json
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-denoisedSmoothed_bold.nii.gz
-xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_desc-framewisedisplacement_motion.tsv
+xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_desc-filtered_motion.tsv
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_outliers.tsv
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_space-MNI152NLin2009cAsym_atlas-Glasser_measure-pearsoncorrelation_conmat.tsv
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_space-MNI152NLin2009cAsym_atlas-Glasser_timeseries.tsv

--- a/.circleci/nifti_without_freesurfer_outputs.txt
+++ b/.circleci/nifti_without_freesurfer_outputs.txt
@@ -11,7 +11,7 @@ xcp_d/sub-01/anat
 xcp_d/sub-01/anat/sub-01_space-MNI152NLin6Asym_desc-preproc_T1w.nii.gz
 xcp_d/sub-01/anat/sub-01_space-MNI152NLin6Asym_dseg.nii.gz
 xcp_d/sub-01/func
-xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_desc-framewisedisplacement_motion.tsv
+xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_motion.tsv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_outliers.tsv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_atlas-Glasser_measure-pearsoncorrelation_conmat.tsv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_atlas-Glasser_timeseries.tsv
@@ -50,7 +50,7 @@ xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_d
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_desc-denoised_bold.nii.gz
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_desc-denoisedSmoothed_bold.json
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_desc-denoisedSmoothed_bold.nii.gz
-xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_desc-framewisedisplacement_motion.tsv
+xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_motion.tsv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_outliers.tsv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_atlas-Glasser_measure-pearsoncorrelation_conmat.tsv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_atlas-Glasser_timeseries.tsv

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -95,15 +95,17 @@ The  ``xcp_d`` outputs are written out in BIDS format and consist of three main 
 
         # Nifti
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-<label>_qc.csv
-        xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_desc-framewisedisplacement_motion.tsv
+        xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>[_desc-filtered]_motion.tsv
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_outliers.tsv
 
         # Cifti
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-fsLR_qc.csv
-        xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_desc-framewisedisplacement_motion.tsv
+        xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>[_desc-filtered]_motion.tsv
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_outliers.tsv
 
-      The ``desc-framewisedisplacement_motion.tsv`` is a tab-delimited file with one column: "framewise_displacement".
+      The ``[desc-filtered]_motion.tsv`` is a tab-delimited file with seven columns;
+      one for each of the six filtered motion parameters, as well as "framewise_displacement".
+      If no motion filtering was applied, this file will not have the ``desc-filtered`` entity.
 
    e. DCAN style scrubbing file.
       This file is in hdf5 format (readable by h5py), and contains binary scrubbing masks from 0.0 to 1mm FD in 0.01 steps.

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -227,7 +227,7 @@ class _CensorScrubOutputSpec(TraitedSpec):
             "This is a TSV file with one column: 'framewise_displacement'."
         ),
     )
-    fd_timeseries = File(
+    filtered_motion = File(
         exists=True,
         mandatory=True,
         desc=(
@@ -271,6 +271,7 @@ class CensorScrub(SimpleInterface):
             confound=motion_df,
             head_radius=self.inputs.head_radius,
         )
+        motion_df["framewise_displacement"] = fd_timeseries_uncensored
 
         # Read in custom confounds file (if any) and bold file to be censored
         bold_file_uncensored = nb.load(self.inputs.in_file).get_fdata()
@@ -360,9 +361,9 @@ class CensorScrub(SimpleInterface):
             newpath=runtime.cwd,
             use_ext=False,
         )
-        self._results["fd_timeseries"] = fname_presuffix(
+        self._results["filtered_motion"] = fname_presuffix(
             self.inputs.in_file,
-            suffix="_desc-fd_motion.tsv",
+            suffix="_desc-filtered_motion.tsv",
             newpath=runtime.cwd,
             use_ext=False,
         )
@@ -383,12 +384,8 @@ class CensorScrub(SimpleInterface):
             sep="\t",
         )
 
-        motion_df = pd.DataFrame(
-            data=fd_timeseries_uncensored,
-            columns=["framewise_displacement"],
-        )
         motion_df.to_csv(
-            self._results["fd_timeseries"],
+            self._results["filtered_motion"],
             index=False,
             header=True,
             sep="\t",

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -283,7 +283,7 @@ class QCPlot(SimpleInterface):
 
         if self.inputs.tmask:  # If a tmask is provided, find # vols censored
             tmask_df = pd.read_table(self.inputs.tmask)
-            tmask_arr = tmask_df["framewise_displacement"]
+            tmask_arr = tmask_df["framewise_displacement"].values
             num_censored_volumes = np.sum(tmask_arr)
         else:
             num_censored_volumes = 0

--- a/xcp_d/interfaces/surfplotting.py
+++ b/xcp_d/interfaces/surfplotting.py
@@ -159,7 +159,11 @@ class _PlotSVGDataInputSpec(BaseInterfaceInputSpec):
                           mandatory=True,
                           desc="Data after regression")
     residual_data = File(exists=True, mandatory=True, desc="Data after filtering")
-    fd = File(exists=True, mandatory=True, desc="Framewise displacement")
+    filtered_motion = File(
+        exists=True,
+        mandatory=True,
+        desc="TSV file with filtered motion parameters.",
+    )
     mask = File(exists=False, mandatory=False, desc="Bold mask")
     seg_data = File(exists=False, mandatory=False, desc="Segmentation file")
     TR = traits.Float(default_value=1, desc="Repetition time")
@@ -205,7 +209,7 @@ class PlotSVGData(SimpleInterface):
                 residual_data=self.inputs.residual_data,
                 TR=self.inputs.TR,
                 mask=self.inputs.mask,
-                fd=self.inputs.fd,
+                filtered_motion=self.inputs.filtered_motion,
                 seg_data=self.inputs.seg_data,
                 processed_filename=self._results['after_process'],
                 unprocessed_filename=self._results['before_process'])

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -456,7 +456,7 @@ def confoundplotx(time_series,
 def plot_svgx(rawdata,
               regressed_data,
               residual_data,
-              fd,
+              filtered_motion,
               unprocessed_filename,
               processed_filename,
               mask=None,
@@ -482,8 +482,8 @@ def plot_svgx(rawdata,
         3 tissues seg_data files
     TR : float, optional
         repetition times
-    fd :
-        framewise displacement in a TSV file.
+    filtered_motion :
+       Filtered motion parameters, including framewise displacement, in a TSV file.
     unprocessed_filename :
         output file svg before processing
     processed_filename :
@@ -527,7 +527,7 @@ def plot_svgx(rawdata,
     })
 
     FD_timeseries = pd.DataFrame({
-        'FD': pd.read_table(fd)["framewise_displacement"].values,
+        'FD': pd.read_table(filtered_motion)["framewise_displacement"].values,
     })
 
     # The mean and standard deviation of raw data

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -254,7 +254,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
                 'timeseries',
                 'correlations',
                 'qc_file',
-                'fd',
+                'filtered_motion',
                 'tmask',
             ],
         ),
@@ -292,8 +292,10 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         dummytime=dummytime,
         lowpass=upper_bpf,
         highpass=lower_bpf,
+        motion_filter_type=motion_filter_type,
         TR=TR,
-        name="write_derivative_wf")
+        name="write_derivative_wf",
+    )
 
     censor_scrub = pe.Node(CensorScrub(
         TR=TR,
@@ -457,7 +459,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
 
     workflow.connect([
         (filtering_wf, outputnode, [('filtered_file', 'processed_bold')]),
-        (censor_scrub, outputnode, [('fd_timeseries', 'fd'),
+        (censor_scrub, outputnode, [('filtered_motion', 'filtered_motion'),
                                     ('tmask', 'tmask')]),
         (resdsmoothing_wf, outputnode, [('outputnode.smoothed_bold',
                                          'smoothed_bold')]),
@@ -475,7 +477,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
                                               'inputnode.processed_bold')]),
         (resdsmoothing_wf, write_derivative_wf, [('outputnode.smoothed_bold',
                                                   'inputnode.smoothed_bold')]),
-        (censor_scrub, write_derivative_wf, [('fd_timeseries', 'inputnode.fd'),
+        (censor_scrub, write_derivative_wf, [('filtered_motion', 'inputnode.filtered_motion'),
                                              ('tmask', 'inputnode.tmask')]),
         (alff_compute_wf, write_derivative_wf,
          [('outputnode.alff_out', 'inputnode.alff_out'),
@@ -558,8 +560,8 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
                                               ]),
         (filtering_wf, executivesummary_wf, [('filtered_file',
                                               'inputnode.residual_data')]),
-        (censor_scrub, executivesummary_wf, [('fd_timeseries',
-                                              'inputnode.fd')]),
+        (censor_scrub, executivesummary_wf, [('filtered_motion',
+                                              'inputnode.filtered_motion')]),
     ])
 
     return workflow

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -172,7 +172,7 @@ def init_execsummary_wf(omp_nthreads,
     t1seg
     regressed_data
     residual_data
-    fd
+    filtered_motion
     rawdata
     mask
     %(mni_to_t1w)s
@@ -180,7 +180,14 @@ def init_execsummary_wf(omp_nthreads,
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(niu.IdentityInterface(fields=[
-        't1w', 't1seg', 'regressed_data', 'residual_data', 'fd', 'rawdata', 'mask', 'mni_to_t1w'
+        't1w',
+        't1seg',
+        'regressed_data',
+        'residual_data',
+        'filtered_motion',
+        'rawdata',
+        'mask',
+        'mni_to_t1w',
     ]),
         name='inputnode')
     inputnode.inputs.bold_file = bold_file
@@ -283,7 +290,8 @@ def init_execsummary_wf(omp_nthreads,
     # Connect all the workflows
     workflow.connect([
         (plotrefbold_wf, ds_plot_bold_reference_file_wf, [('out_file', 'in_file')]),
-        (inputnode, plot_svgx_wf, [('fd', 'fd'), ('regressed_data', 'regressed_data'),
+        (inputnode, plot_svgx_wf, [('filtered_motion', 'filtered_motion'),
+                                   ('regressed_data', 'regressed_data'),
                                    ('residual_data', 'residual_data'), ('mask', 'mask'),
                                    ('bold_file', 'rawdata')]),
         (inputnode, get_std2native_transform, [('mni_to_t1w', 'mni_to_t1w')]),

--- a/xcp_d/workflow/outputs.py
+++ b/xcp_d/workflow/outputs.py
@@ -141,7 +141,7 @@ def init_writederivatives_wf(
         DerivativesDataSink(
             base_directory=output_dir,
             source_file=bold_file,
-            dismiss_entities=["atlas", "den", "res", "space"],
+            dismiss_entities=["atlas", "den", "res", "space", "desc"],
             desc="filtered" if motion_filter_type else None,
             suffix="motion",
             extension='.tsv',

--- a/xcp_d/workflow/outputs.py
+++ b/xcp_d/workflow/outputs.py
@@ -15,6 +15,7 @@ def init_writederivatives_wf(
     bold_file,
     lowpass,
     highpass,
+    motion_filter_type,
     smoothing,
     params,
     cifti,
@@ -52,6 +53,7 @@ def init_writederivatives_wf(
         low pass filter
     highpass : float
         high pass filter
+    %(motion_filter_type)s
     %(smoothing)s
     %(params)s
     %(cifti)s
@@ -87,7 +89,7 @@ def init_writederivatives_wf(
     reho_rh
         reho right hemisphere
     reho_out
-    fd
+    filtered_motion
     tmask
     """
     workflow = Workflow(name=name)
@@ -106,7 +108,7 @@ def init_writederivatives_wf(
                 "reho_lh",
                 "reho_rh",
                 "reho_out",
-                "fd",
+                "filtered_motion",
                 "tmask",
             ],
         ),
@@ -135,8 +137,23 @@ def init_writederivatives_wf(
         mem_gb=1,
     )
 
+    ds_filtered_motion = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            source_file=bold_file,
+            dismiss_entities=["atlas", "den", "res", "space"],
+            desc="filtered" if motion_filter_type else None,
+            suffix="motion",
+            extension='.tsv',
+        ),
+        name='ds_filtered_motion',
+        run_without_submitting=True,
+        mem_gb=1,
+    )
+
     workflow.connect([
         (inputnode, write_derivative_tmask_wf, [('tmask', 'in_file')]),
+        (inputnode, ds_filtered_motion, [('filtered_motion', 'in_file')]),
     ])
 
     # Write out detivatives via DerivativesDataSink
@@ -220,20 +237,6 @@ def init_writederivatives_wf(
                 compression=True,
             ),
             name='write_derivative_reho_wf',
-            run_without_submitting=True,
-            mem_gb=1,
-        )
-
-        write_derivative_fd_wf = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                source_file=bold_file,
-                dismiss_entities=["atlas", "res", "space"],
-                desc='framewisedisplacement',
-                suffix="motion",
-                extension='.tsv',
-            ),
-            name='write_derivative_fd_wf',
             run_without_submitting=True,
             mem_gb=1,
         )
@@ -382,20 +385,6 @@ def init_writederivatives_wf(
             mem_gb=1,
         )
 
-        write_derivative_fd_wf = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                source_file=bold_file,
-                dismiss_entities=["atlas", "den", "res", "space"],
-                desc='framewisedisplacement',
-                suffix="motion",
-                extension='.tsv',
-            ),
-            name='write_derivative_fd_wf',
-            run_without_submitting=True,
-            mem_gb=1,
-        )
-
         workflow.connect([
             (inputnode, write_derivative_reholh_wf, [('reho_lh', 'in_file')]),
             (inputnode, write_derivative_rehorh_wf, [('reho_rh', 'in_file')]),
@@ -442,7 +431,6 @@ def init_writederivatives_wf(
         (inputnode, write_derivative_qcfile_wf, [('qc_file', 'in_file')]),
         (inputnode, timeseries_wf, [('timeseries', 'in_file'), ('atlas_names', 'atlas')]),
         (inputnode, correlations_wf, [('correlations', 'in_file'), ('atlas_names', 'atlas')]),
-        (inputnode, write_derivative_fd_wf, [('fd', 'in_file')]),
     ])
 
     if smoothing:


### PR DESCRIPTION
Closes None. I realized that, since we now output the filtered framewise displacement time series in a TSV with a header, there's no reason we shouldn't output the other filtered motion parameters as well.

## Changes proposed in this pull request

- Include the other filtered motion parameters in the `motion.tsv` output.
- Rename `desc-framewisedisplacement_motion.tsv` to `desc-filtered_motion.tsv` or `motion.tsv`, depending on if filtering was done or not.
