### PR TITLE
Use user-requested parameters in regression

### DIFF
--- a/.circleci/tests/test_Reg.py
+++ b/.circleci/tests/test_Reg.py
@@ -10,16 +10,28 @@ from xcp_d.utils.write_save import read_ndata
 def test_Reg_Nifti(data_dir):
     """Test NIFTI regression."""
     #  Specify inputs
-    in_file = data_dir + "/fmriprep/sub-colornest001/ses-1/func/" \
+    in_file = (
+        data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz"
-    confounds = data_dir + "/fmriprep/sub-colornest001/ses-1/func/" \
+    )
+    confounds = (
+        data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-2_desc-confounds_timeseries.tsv"
+    )
     TR = 0.5
-    mask = data_dir + "/fmriprep/sub-colornest001/ses-1/func/" \
+    mask = (
+        data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
+    )
     # Run regression
-    test_nifti = Regress(mask=mask, in_file=in_file,
-                         original_file=in_file, confounds=confounds, TR=TR)
+    test_nifti = Regress(
+        mask=mask,
+        in_file=in_file,
+        original_file=in_file,
+        confounds=confounds,
+        TR=TR,
+        params="36P",
+    )
     results = test_nifti.run()
 
     # Read in_file and regression results in, but ignore the 'Unnamed:0' column if present
@@ -50,16 +62,28 @@ def test_Reg_Nifti(data_dir):
 def test_Reg_Cifti(data_dir):
     """Test CIFTI regression."""
     # Specify inputs
-    in_file = data_dir + "/fmriprep/sub-colornest001/ses-1/func/" \
+    in_file = (
+        data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-1_space-fsLR_den-91k_bold.dtseries.nii"
-    confounds = data_dir + "/fmriprep/sub-colornest001/ses-1/func/" \
+    )
+    confounds = (
+        data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-1_desc-confounds_timeseries.tsv"
+    )
     TR = 0.5
-    mask = data_dir + "/fmriprep/sub-colornest001/ses-1/func/" \
+    mask = (
+        data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
+    )
     # Run regression
-    test_cifti = Regress(mask=mask, in_file=in_file,
-                         original_file=in_file, confounds=confounds, TR=TR)
+    test_cifti = Regress(
+        mask=mask,
+        in_file=in_file,
+        original_file=in_file,
+        confounds=confounds,
+        TR=TR,
+        params="36P",
+    )
     results = test_cifti.run()
 
     # Read in_file and regression results in, but ignore the 'Unnamed:0' column if present

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -29,6 +29,8 @@ class _RegressInputSpec(BaseInterfaceInputSpec):
         exists=True,
         mandatory=True,
         desc="The fMRIPrep confounds tsv after censoring")
+    # TODO: Use Enum maybe?
+    params = traits.Str(exists=True, mandatory=True, desc="Parameter set to use.")
     TR = traits.Float(exists=True, mandatory=True, desc="Repetition time")
     mask = File(exists=False, mandatory=False, desc="Brain mask for nifti files")
     original_file = traits.Str(exists=True, mandatory=False,
@@ -69,14 +71,20 @@ class Regress(SimpleInterface):
         # Get the confound matrix
         # Do we have custom confounds?
         if self.inputs.custom_confounds and exists(self.inputs.custom_confounds):
-            confound = load_confound_matrix(original_file=self.inputs.original_file,
-                                            datafile=self.inputs.in_file,
-                                            custom_confounds=self.inputs.custom_confounds,
-                                            confound_tsv=self.inputs.confounds)
+            confound = load_confound_matrix(
+                original_file=self.inputs.original_file,
+                datafile=self.inputs.in_file,
+                custom_confounds=self.inputs.custom_confounds,
+                confound_tsv=self.inputs.confounds,
+                params=self.inputs.params,
+            )
         else:  # No custom confounds
-            confound = load_confound_matrix(original_file=self.inputs.original_file,
-                                            datafile=self.inputs.in_file,
-                                            confound_tsv=self.inputs.confounds)
+            confound = load_confound_matrix(
+                original_file=self.inputs.original_file,
+                datafile=self.inputs.in_file,
+                confound_tsv=self.inputs.confounds,
+                params=self.inputs.params,
+            )
         # for testing, let's write out the confounds file:
         confounds_file_output_name = fname_presuffix(
             self.inputs.confounds,

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -300,7 +300,7 @@ def square_confound(confound):
 
 @fill_doc
 def load_confound_matrix(
-    datafile, original_file, custom_confounds=None, confound_tsv=None, params="36P"
+    datafile, original_file, params, custom_confounds=None, confound_tsv=None
 ):
     """Load a subset of the confounds associated with a given file.
 
@@ -310,11 +310,11 @@ def load_confound_matrix(
         BOLD file whose confounds we want.
     original_file :
        File used to find confounds json.
+    %(params)s
     custom_confounds : str or None, optional
         Custom confounds TSV if there is one. Default is None.
     confound_tsv : str or None, optional
         The path to the confounds TSV file. Default is None.
-    %(params)s
 
     Returns
     -------

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -353,8 +353,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         n_procs=omp_nthreads)
 
     regression_wf = pe.Node(
-        Regress(TR=TR,
-                original_file=bold_file),
+        Regress(TR=TR, original_file=bold_file, params=params),
         name="regression_wf",
         mem_gb=mem_gbx['timeseries'],
         n_procs=omp_nthreads)

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -329,8 +329,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         n_procs=omp_nthreads)
 
     regression_wf = pe.Node(
-        Regress(TR=TR,
-                original_file=bold_file),
+        Regress(TR=TR, original_file=bold_file, params=params),
         name="regression_wf",
         mem_gb=mem_gbx['timeseries'],
         n_procs=omp_nthreads)


### PR DESCRIPTION
We noticed a substantial bug in which the requested parameters were not being used in the regression step. Instead, the default parameter set (36P) was used no matter what.

We will still want to either output the selected regressors in a file _or_ combine the confound loading and confound description generation code in one step, so there isn't any chance of undocumented mismatch between them in the future. That will have to go in a separate PR though.

## Changes proposed in this pull request

- Make parameter string a required argument in `load_confound_matrix`.
- Connect the parameter string to the regression node.
- Feed the parameter string to `load_confound_matrix` within the regression node.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
