### PR TITLE
Reduce executive summary figure size

### DIFF
--- a/.circleci/CiftiWithFreeSurferTest.sh
+++ b/.circleci/CiftiWithFreeSurferTest.sh
@@ -30,7 +30,7 @@ XCPD_CMD=$(run_xcpd_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR} ${TEMPDIR})
 
 $XCPD_CMD \
     --despike --head_radius 40 \
-	--smoothing 6 -vvv \
+	--smoothing 6 -v -v \
     --motion-filter-type lp --band-stop-min 6 \
     --warp-surfaces-native2std \
     --cifti \

--- a/.circleci/CiftiWithFreeSurferTest.sh
+++ b/.circleci/CiftiWithFreeSurferTest.sh
@@ -30,7 +30,7 @@ XCPD_CMD=$(run_xcpd_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR} ${TEMPDIR})
 
 $XCPD_CMD \
     --despike --head_radius 40 \
-	--smoothing 6 -v -v \
+	--smoothing 6 -vvv \
     --motion-filter-type lp --band-stop-min 6 \
     --warp-surfaces-native2std \
     --cifti \

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -286,6 +286,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                     initial_volumes_to_drop = 0
                     if dummytime > 0:
                         initial_volumes_to_drop = int(np.ceil(dummytime / TR))
+                    LOGGER.debug("Starting plot_svgx")
                     plot_svgx(
                         dummyvols=initial_volumes_to_drop,
                         tmask=outfile,
@@ -303,6 +304,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                         TR=TR,
                         work_dir=work_dir,
                     )
+                    LOGGER.debug("plot_svgx done")
 
                     # link or copy bb svgs
                     in_fig_entities = preproc_files[0].get_entities()

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -51,6 +51,8 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
     cifti : bool
         Whether xcpd was run on CIFTI files or not.
     """
+    LOGGER.debug("Starting concatenation workflow.")
+
     # NOTE: The config has no effect when derivatives is True :(
     # At least for pybids ~0.15.1.
     # TODO: Find a way to support the xcpd config file in the BIDSLayout.
@@ -77,11 +79,15 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
         if subject.startswith("sub-"):
             subject = subject[4:]
 
+        LOGGER.debug(f"Concatenating subject {subject}")
+
         sessions = layout_xcpd.get_sessions(subject=subject)
         if not sessions:
             sessions = [None]
 
         for session in sessions:
+            LOGGER.debug(f"Concatenating session {session}")
+
             base_entities = {
                 "subject": subject,
                 "session": session,
@@ -94,6 +100,8 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                 **base_entities,
             )
             for task in tasks:
+                LOGGER.debug(f"Concatenating task {task}")
+
                 task_entities = base_entities.copy()
                 task_entities["task"] = task
 
@@ -138,6 +146,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                     make_dcan_df([motion_file.path], dcan_df_file, TR)
 
                 # Concatenate motion files
+                LOGGER.debug("Concatenating motion files")
                 concat_motion_file = _get_concat_name(layout_xcpd, motion_files[0])
                 concatenate_tsv_files(motion_files, concat_motion_file)
 
@@ -146,6 +155,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                 make_dcan_df([concat_motion_file], concat_dcan_df_file, TR)
 
                 # Concatenate outlier files
+                LOGGER.debug("Concatenating outlier files")
                 outlier_files = layout_xcpd.get(
                     desc=None,
                     suffix="outliers",
@@ -165,6 +175,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                 )
 
                 for space in output_spaces:
+                    LOGGER.debug(f"Concatenating files in {space} space")
                     space_entities = task_entities.copy()
                     space_entities["space"] = space
 
@@ -179,6 +190,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                         tempfile.mkdtemp(),
                         f"rawdata{preproc_files[0].extension}",
                     )
+                    LOGGER.debug(f"Concatenating preprocessed file: {concat_preproc_file}")
                     _concatenate_niimgs(preproc_files, concat_preproc_file)
 
                     if not cifti:
@@ -221,6 +233,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                         **space_entities,
                     )
                     concat_bold_file = _get_concat_name(layout_xcpd, bold_files[0])
+                    LOGGER.debug(f"Concatenating postprocessed file: {concat_bold_file}")
                     _concatenate_niimgs(bold_files, concat_bold_file)
 
                     # Calculate DVARS from denoised BOLD
@@ -240,9 +253,13 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                     )
                     if len(smooth_bold_files):
                         concat_file = _get_concat_name(layout_xcpd, smooth_bold_files[0])
+                        LOGGER.debug(
+                            f"Concatenating smoothed postprocessed file: {concat_file}"
+                        )
                         _concatenate_niimgs(smooth_bold_files, concat_file)
 
                     # Carpet plots
+                    LOGGER.debug("Generating carpet plots")
                     carpet_entities = bold_files[0].get_entities()
                     carpet_entities = _sanitize_entities(carpet_entities)
                     carpet_entities["run"] = None
@@ -323,6 +340,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                         **space_entities,
                     )
                     for atlas in atlases:
+                        LOGGER.debug(f"Concatenating time series files for atlas {atlas}")
                         atlas_timeseries_files = layout_xcpd.get(
                             atlas=atlas,
                             suffix="timeseries",
@@ -372,7 +390,7 @@ def make_dcan_df(fds_files, name, TR):
     remaining_frame_mean_FD: a number >= 0 that represents the mean FD of the
     remaining frames
     """
-    print("making dcan")
+    LOGGER.debug(f"Generating DCAN file: {name}")
 
     # Load filtered framewise_displacement values from files and concatenate
     filtered_motion_dfs = [pd.read_table(fds_file) for fds_file in fds_files]

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -586,7 +586,7 @@ def plot_svgx(rawdata,
     plt.cla()
     plt.clf()
     LOGGER.debug("Test 11")
-    unprocessed_figure = plt.figure(constrained_layout=True, figsize=(45, 60))
+    unprocessed_figure = plt.figure(constrained_layout=True, figsize=(22.5, 30))
     grid = mgs.GridSpec(5,
                         1,
                         wspace=0.0,

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -14,12 +14,9 @@ from matplotlib.colors import ListedColormap
 from nilearn._utils import check_niimg_4d
 from nilearn._utils.niimg import _safe_get_data
 from nilearn.signal import clean
-from nipype import logging
 
 from xcp_d.utils.qcmetrics import compute_dvars
 from xcp_d.utils.write_save import read_ndata, write_ndata
-
-LOGGER = logging.getLogger("nipype.utils")
 
 
 def _decimate_data(data, seg_data, size):
@@ -578,7 +575,7 @@ def plot_svgx(rawdata,
                   ylims=[0, 1],
                   ylabel='FD[mm]',
                   FD=True)
-    LOGGER.debug(unprocessed_filename)
+
     # Save out the before processing file
     unprocessed_figure.savefig(unprocessed_filename, bbox_inches="tight", pad_inches=None, dpi=300)
 

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -616,6 +616,7 @@ def plot_svgx(rawdata,
                   ylabel='FD[mm]',
                   FD=True)
     LOGGER.debug("Test 16")
+    LOGGER.debug(unprocessed_filename)
     # Save out the before processing file
     unprocessed_figure.savefig(unprocessed_filename, bbox_inches="tight", pad_inches=None, dpi=300)
     LOGGER.debug("Test 17")

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -626,7 +626,7 @@ def plot_svgx(rawdata,
 
     # Plot the data and confounds, plus the carpet plot
     LOGGER.debug("Test 18")
-    processed_figure = plt.figure(constrained_layout=True, figsize=(45, 60))
+    processed_figure = plt.figure(constrained_layout=True, figsize=(22.5, 30))
     grid = mgs.GridSpec(5,
                         1,
                         wspace=0.0,

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -465,66 +465,41 @@ def plot_svgx(rawdata,
     processed_filename :
         output file svg after processing
     """
-    LOGGER.debug("Test 1")
     # Compute dvars correctly if not already done
     residual_data_file = residual_data
     raw_data_file = rawdata
-    LOGGER.debug("Test 1a")
     raw_data = read_ndata(datafile=rawdata, maskfile=mask)
-    LOGGER.debug("Test 1b")
     regressed_data = read_ndata(datafile=regressed_data, maskfile=mask)
-    LOGGER.debug("Test 1c")
     filtered_data = read_ndata(datafile=residual_data, maskfile=mask)
-    LOGGER.debug("Test 2")
     tmask_df = pd.read_table(tmask)
     tmask_arr = tmask_df["framewise_displacement"].values
     tmask_bool = ~tmask_arr.astype(bool)
 
-    LOGGER.debug("Test 3")
     # Let's remove dummy time from the raw_data if needed
     if dummyvols > 1:
         raw_data = raw_data[dummyvols:]
 
-    LOGGER.debug("Test 4")
     # Let's censor the interpolated data and raw_data:
     if sum(tmask_arr) > 0:
         raw_data = raw_data[:, tmask_bool]
         filtered_data = filtered_data[:, tmask_bool]
 
-    LOGGER.debug("Test 5")
     if type(raw_dvars) != np.ndarray:
         raw_dvars = compute_dvars(raw_data)
-    LOGGER.debug("Test 5a")
     if type(regressed_dvars) != np.ndarray:
         regressed_dvars = compute_dvars(regressed_data)
-    LOGGER.debug("Test 5b")
     if type(filtered_dvars) != np.ndarray:
         filtered_dvars = compute_dvars(filtered_data)
-    LOGGER.debug("Test 5c")
     # For ease of reference later
 
     # Formatting & setting of files
-    LOGGER.debug("Test 6")
     sns.set_style('whitegrid')
     regressed_dvars_data = regressed_dvars
     residual_dvars_data = filtered_dvars
     raw_dvars_data = raw_dvars
     # Load files
-    LOGGER.debug("Test 6a")
     raw_data = read_ndata(datafile=raw_data_file, maskfile=mask)
-    LOGGER.debug("Test 6b")
     residual_data = read_ndata(datafile=residual_data_file, maskfile=mask)
-    LOGGER.debug("Test 6c")
-
-    # Remove first N deleted from raw_data so it's same length as censored files
-    if len(raw_dvars_data) > len(residual_dvars_data):
-        LOGGER.debug("Test 7")
-        # TODO: Should this be [-len(residual_dvars_data):] ?
-        # ... Seems to grab first N, not last N.
-        raw_dvars_data = raw_dvars_data[0:len(residual_dvars_data)]
-        raw_data = raw_data[:, 0:len(residual_dvars_data)]
-        # TODO: Figure out how to slice the regressed DVARS instead of just overwriting it
-        regressed_dvars_data = raw_dvars_data
 
     # Create dataframes for the bold_data DVARS, FD
     DVARS_timeseries = pd.DataFrame({
@@ -548,17 +523,13 @@ def plot_svgx(rawdata,
         'Std': np.nanstd(residual_data, axis=0)
     })
     if seg_data is not None:
-        LOGGER.debug("Test 8")
         atlaslabels = nb.load(seg_data).get_fdata()
     else:
         atlaslabels = None
 
     # The plot going to carpet plot will be rescaled to [-600,600]
-    LOGGER.debug("Test 9")
     scaled_raw_data = read_ndata(datafile=raw_data_file, maskfile=mask, scale=600)
-    LOGGER.debug("Test 9a")
     scaled_residual_data = read_ndata(datafile=residual_data_file, maskfile=mask, scale=600)
-    LOGGER.debug("Test 9b")
 
     # Make a temporary file for niftis and ciftis
     if rawdata.endswith('.nii.gz'):
@@ -569,45 +540,37 @@ def plot_svgx(rawdata,
         scaledresdata = tempfile.mkdtemp() + '/filex_red.dtseries.nii'
 
     # Write out the scaled data
-    LOGGER.debug("Test 10")
     scaledrawdata = write_ndata(data_matrix=scaled_raw_data,
                                 template=raw_data_file,
                                 filename=scaledrawdata,
                                 mask=mask,
                                 TR=TR)
-    LOGGER.debug("Test 10a")
     scaledresdata = write_ndata(data_matrix=scaled_residual_data,
                                 template=residual_data_file,
                                 filename=scaledresdata,
                                 mask=mask,
                                 TR=TR)
-    LOGGER.debug("Test 10b")
     # Plot the data and confounds, plus the carpet plot
     plt.cla()
     plt.clf()
-    LOGGER.debug("Test 11")
     unprocessed_figure = plt.figure(constrained_layout=True, figsize=(22.5, 30))
     grid = mgs.GridSpec(5,
                         1,
                         wspace=0.0,
                         hspace=0.05,
                         height_ratios=[1, 1, 0.2, 2.5, 1])
-    LOGGER.debug("Test 12")
     confoundplotx(time_series=DVARS_timeseries,
                   grid_spec_ts=grid[0],
                   TR=TR,
                   ylabel='DVARS',
                   hide_x=True)
-    LOGGER.debug("Test 13")
     confoundplotx(time_series=unprocessed_data_timeseries,
                   grid_spec_ts=grid[1], TR=TR, hide_x=True, ylabel='WB')
-    LOGGER.debug("Test 14")
     plot_carpet(func=scaledrawdata,
                 atlaslabels=atlaslabels,
                 TR=TR,
                 subplot=grid[3],
                 legend=False)
-    LOGGER.debug("Test 15")
     confoundplotx(time_series=FD_timeseries,
                   grid_spec_ts=grid[4],
                   TR=TR,
@@ -615,24 +578,20 @@ def plot_svgx(rawdata,
                   ylims=[0, 1],
                   ylabel='FD[mm]',
                   FD=True)
-    LOGGER.debug("Test 16")
     LOGGER.debug(unprocessed_filename)
     # Save out the before processing file
     unprocessed_figure.savefig(unprocessed_filename, bbox_inches="tight", pad_inches=None, dpi=300)
-    LOGGER.debug("Test 17")
 
     plt.cla()
     plt.clf()
 
     # Plot the data and confounds, plus the carpet plot
-    LOGGER.debug("Test 18")
     processed_figure = plt.figure(constrained_layout=True, figsize=(22.5, 30))
     grid = mgs.GridSpec(5,
                         1,
                         wspace=0.0,
                         hspace=0.05,
                         height_ratios=[1, 1, 0.2, 2.5, 1])
-    LOGGER.debug("Test 19")
 
     confoundplotx(time_series=DVARS_timeseries,
                   grid_spec_ts=grid[0],
@@ -640,21 +599,18 @@ def plot_svgx(rawdata,
                   ylabel='DVARS',
                   hide_x=True,
                   work_dir=work_dir)
-    LOGGER.debug("Test 20")
     confoundplotx(time_series=processed_data_timeseries,
                   grid_spec_ts=grid[1],
                   TR=TR,
                   hide_x=True,
                   ylabel='WB',
                   work_dir=work_dir)
-    LOGGER.debug("Test 21")
 
     plot_carpet(func=scaledresdata,
                 atlaslabels=atlaslabels,
                 TR=TR,
                 subplot=grid[3],
                 legend=True)
-    LOGGER.debug("Test 22")
     confoundplotx(time_series=FD_timeseries,
                   grid_spec_ts=grid[4],
                   TR=TR,
@@ -663,9 +619,7 @@ def plot_svgx(rawdata,
                   ylabel='FD[mm]',
                   FD=True,
                   work_dir=work_dir)
-    LOGGER.debug("Test 23")
     processed_figure.savefig(processed_filename, bbox_inches="tight", pad_inches=None, dpi=300)
-    LOGGER.debug("Test 24")
     # Save out the after processing file
     return unprocessed_filename, processed_filename
 


### PR DESCRIPTION
Closes #620.

## Changes proposed in this pull request
- Cut executive summary carpet plot figure sizes in half. The ratios are the same, so, unless there are hardcoded font sizes, it should be fine.
- Remove step in executive summary where DVARS time series are reduced to be the same length across files. @kahinimehta's fix in #614 should mean that code is unnecessary.
- Add logging messages to concatenation code.

## Documentation that should be reviewed
None.
