### PR TITLE
Only generate ALFF derivatives if bandpass filtering is enabled

### DIFF
--- a/.circleci/NiftiWithoutFreeSurferTest.sh
+++ b/.circleci/NiftiWithoutFreeSurferTest.sh
@@ -27,8 +27,9 @@ BIDS_INPUT_DIR=${TESTDIR}/data/fmriprepwithoutfreesurfer/fmriprep
 XCPD_CMD=$(run_xcpd_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR} ${TEMPDIR})
 
 $XCPD_CMD \
-    --despike  --head_radius 40 \
-    --smoothing 6  -f 100 -v -v \
-    --nuissance-regressors 27P
+    --despike --head_radius 40 \
+    --smoothing 6 -f 100 -vv \
+    --nuissance-regressors 27P \
+    --disable-bandpass-filter
 
 echo $XCPD_CMD

--- a/.circleci/nifti_without_freesurfer_outputs.txt
+++ b/.circleci/nifti_without_freesurfer_outputs.txt
@@ -39,10 +39,6 @@ xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_a
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_atlas-Schaefer917_timeseries.tsv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_atlas-subcortical_measure-pearsoncorrelation_conmat.tsv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_atlas-subcortical_timeseries.tsv
-xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_alff.json
-xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_alff.nii.gz
-xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_desc-smooth_alff.json
-xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_desc-smooth_alff.nii.gz
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_qc.csv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_reho.json
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_reho.nii.gz
@@ -78,10 +74,6 @@ xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_a
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_atlas-Schaefer917_timeseries.tsv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_atlas-subcortical_measure-pearsoncorrelation_conmat.tsv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_atlas-subcortical_timeseries.tsv
-xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_alff.json
-xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_alff.nii.gz
-xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_desc-smooth_alff.json
-xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_desc-smooth_alff.nii.gz
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_qc.csv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_reho.json
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_space-MNI152NLin2009cAsym_reho.nii.gz

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -85,10 +85,20 @@ The  ``xcp_d`` outputs are written out in BIDS format and consist of three main 
         # Nifti
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-<label>_reho.nii.gz
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-<label>_alff.nii.gz
+        xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-<label>_desc-smoothed_alff.nii.gz
 
         # Cifti
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-fsLR_den-91k_reho.dscalar.nii
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-fsLR_den-91k_alff.dscalar.nii
+        xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-fsLR_den-91k_desc-smoothed_alff.dscalar.nii
+
+     .. important::
+          The smoothed ALFF image will only be generated is smoothing is enabled
+          (e.g., with the ``--smoothing parameter``).
+
+     .. important::
+          ALFF images will not be generated if bandpass filtering is disabled
+          (e.g., with the ``--disable-bandpass-filtering`` parameter).
 
    d. Other outputs include quality control and framewise  displacement::
 

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -85,12 +85,12 @@ The  ``xcp_d`` outputs are written out in BIDS format and consist of three main 
         # Nifti
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-<label>_reho.nii.gz
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-<label>_alff.nii.gz
-        xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-<label>_desc-smoothed_alff.nii.gz
+        xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-<label>_desc-smooth_alff.nii.gz
 
         # Cifti
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-fsLR_den-91k_reho.dscalar.nii
         xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-fsLR_den-91k_alff.dscalar.nii
-        xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-fsLR_den-91k_desc-smoothed_alff.dscalar.nii
+        xcp_d/sub-<label>/[ses-<label>/]func/<source_entities>_space-fsLR_den-91k_desc-smooth_alff.dscalar.nii
 
      .. important::
           The smoothed ALFF image will only be generated is smoothing is enabled

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -716,6 +716,8 @@ def build_workflow(opts, retval):
             f"'--upper-bpf' ({opts.upper_bpf})."
         )
         retval["return_code"] = 1
+    elif not opts.bandpass_filter:
+        build_log.warning("Bandpass filtering is disabled. ALFF outputs will not be generated.")
 
     # Motion filtering parameters
     if opts.motion_filter_type == "notch":

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -262,7 +262,10 @@ def get_parser():
         "--disable_bandpass_filter",
         dest="bandpass_filter",
         action="store_false",
-        help="Disable bandpass filtering.",
+        help=(
+            "Disable bandpass filtering. "
+            "If bandpass filtering is disabled, then ALFF derivatives will not be calculated."
+        ),
     )
     bandpass_filter_params.add_argument(
         "--bandpass_filter",
@@ -271,6 +274,7 @@ def get_parser():
         type=bool,
         help=(
             "Whether to Butterworth bandpass filter the data or not. "
+            "If bandpass filtering is disabled, then ALFF derivatives will not be calculated. "
             "This parameter is deprecated and will be removed in version 0.3.0. "
             "Bandpass filtering is performed by default, and if you wish to disable it, "
             "please use `--disable-bandpass-filter``."

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -287,6 +287,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     write_derivative_wf = init_writederivatives_wf(
         smoothing=smoothing,
         bold_file=bold_file,
+        bandpass_filter=bandpass_filter,
         params=params,
         cifti=True,
         output_dir=output_dir,


### PR DESCRIPTION
Closes #615.

## Changes proposed in this pull request

- Only run ALFF workflow and save ALFF outputs if bandpass filter is enabled. This will allow users to use the `--disable-bandpass-filter` parameter without breaking xcpd.

## Documentation that should be reviewed

The output documentation.