### PR TITLE
Cache the downloaded test data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,58 @@ jobs:
       - checkout
       - run: *runinstall
 
+  download_data_fmriprepwithfreesurfer:
+    <<: *dockersetup
+    working_directory: /src/xcp_d/.circleci/
+    steps:
+      - checkout
+      - restore_cache:
+          key: fmriprepwithfreesurfer-01
+      - run:
+          TESTDIR="/src/xcp_d/.circleci"
+          cd ${TESTDIR}
+          source get_data.sh
+          get_bids_data ${TESTDIR} fmriprep_colornest
+          get_bids_data ${TESTDIR} freesurfer_colornest
+      - save_cache:
+          key: fmriprepwithfreesurfer-01
+          paths:
+              - /src/xcp_d/.circleci/data/fmriprepwithfreesurfer
+
+  download_data_fmriprepwithoutfreesurfer:
+    <<: *dockersetup
+    working_directory: /src/xcp_d/.circleci/
+    steps:
+      - checkout
+      - restore_cache:
+          key: fmriprepwithoutfreesurfer-01
+      - run:
+          TESTDIR="/src/xcp_d/.circleci"
+          cd ${TESTDIR}
+          source get_data.sh
+          get_bids_data ${TESTDIR} sub01
+      - save_cache:
+          key: fmriprepwithoutfreesurfer-01
+          paths:
+              - /src/xcp_d/.circleci/data/fmriprepwithoutfreesurfer
+
+  download_data_nibabies:
+    <<: *dockersetup
+    working_directory: /src/xcp_d/.circleci/
+    steps:
+      - checkout
+      - restore_cache:
+          key: nibabies-01
+      - run:
+          TESTDIR="/src/xcp_d/.circleci"
+          cd ${TESTDIR}
+          source get_data.sh
+          get_bids_data ${TESTDIR} nibabies
+      - save_cache:
+          key: nibabies-01
+          paths:
+              - /src/xcp_d/.circleci/data/nibabies_test_data
+
   nifti_without_freesurfer:
     <<: *dockersetup
     steps:
@@ -45,6 +97,8 @@ jobs:
               echo "Skipping nifti_without_freesurfer build"
               circleci step halt
             fi
+      - restore_cache:
+          key: fmriprepwithoutfreesurfer-01
       - run: *runinstall
       - run:
           name: Run full xcp_d on nifti without freesurfer
@@ -75,6 +129,8 @@ jobs:
               echo "Skipping nifti_with_freesurfer build"
               circleci step halt
             fi
+      - restore_cache:
+          key: fmriprepwithfreesurfer-01
       - run: *runinstall
       - run:
           name: Run full xcp_d on nifti with freesurfer
@@ -93,7 +149,6 @@ jobs:
             diff <(sort /src/xcp_d/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nifti_with_freesurfer/test/outputs.out)
             exit $?
 
-
   nibabies:
     <<: *dockersetup
     steps:
@@ -106,6 +161,8 @@ jobs:
               echo "Skipping nibabies build"
               circleci step halt
             fi
+      - restore_cache:
+          key: nibabies-01
       - run: *runinstall
       - run:
           name: Run full xcp_d on nibabies
@@ -136,8 +193,9 @@ jobs:
               echo "Skipping cifti_with_freesurfer build"
               circleci step halt
             fi
+      - restore_cache:
+          key: fmriprepwithfreesurfer-01
       - run: *runinstall
-
       - run:
           name: Run full xcp_d on cifti with freesurfer
           no_output_timeout: 5h
@@ -167,8 +225,11 @@ jobs:
               echo "Skipping cifti_with_freesurfer build"
               circleci step halt
             fi
+      - restore_cache:
+          key: fmriprepwithfreesurfer-01
+      - restore_cache:
+          key: fmriprepwithoutfreesurfer-01
       - run: *runinstall
-
       - run:
           name: Run pytest on the tests directory
           no_output_timeout: 1h
@@ -241,9 +302,22 @@ workflows:
             tags:
               only: /.*/
 
+      - download_data_fmriprepwithfreesurfer:
+          requires:
+            - build
+
+      - download_data_fmriprepwithoutfreesurfer:
+          requires:
+            - build
+
+      - download_data_nibabies:
+          requires:
+            - build
+
       - cifti_with_freesurfer:
           requires:
             - build
+            - download_data_fmriprepwithfreesurfer
           filters:
             branches:
               ignore:
@@ -255,6 +329,7 @@ workflows:
       - nifti_with_freesurfer:
           requires:
             - build
+            - download_data_fmriprepwithfreesurfer
           filters:
             branches:
               ignore:
@@ -266,6 +341,7 @@ workflows:
       - nibabies:
           requires:
             - build
+            - download_data_nibabies
           filters:
             branches:
               ignore:
@@ -277,6 +353,7 @@ workflows:
       - nifti_without_freesurfer:
           requires:
             - build
+            - download_data_fmriprepwithoutfreesurfer
           filters:
             branches:
               ignore:
@@ -288,6 +365,8 @@ workflows:
       - pytests:
           requires:
             - build
+            - download_data_fmriprepwithfreesurfer
+            - download_data_fmriprepwithoutfreesurfer
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ version: 2.1
 .dockersetup: &dockersetup
   docker:
     - image: pennbbl/xcpd_build:0.0.6rc1
-  working_directory: /home/circleci
+  working_directory: /src/xcp_d
 
 .fastdockersetup: &fastdockersetup
   docker:
     - image: cimg/base:2022.11
-  working_directory: /home/circleci
+  working_directory: /src/xcp_d
 
 runinstall: &runinstall
   name: Install xcp_d
@@ -18,8 +18,8 @@ runinstall: &runinstall
       VERSION="$CIRCLE_TAG"
     fi
     git checkout $CIRCLE_BRANCH
-    echo "${VERSION}" > /home/circleci/xcp_d/VERSION
-    echo "include xcp_d/VERSION" >> /home/circleci/MANIFEST.in
+    echo "${VERSION}" > /src/xcp_d/xcp_d/VERSION
+    echo "include xcp_d/VERSION" >> /src/xcp_d/MANIFEST.in
     pip install .[tests] --progress-bar off
 
     # Write the config file
@@ -45,14 +45,14 @@ jobs:
       - run:
           name: Download fmriprepwithfreesurfer test data
           command: |
-            cd /home/circleci/.circleci
+            cd /src/xcp_d/.circleci
             source get_data.sh
             get_bids_data $PWD fmriprep_colornest
             get_bids_data $PWD freesurfer_colornest
       - save_cache:
           key: fmriprepwithfreesurfer-00
           paths:
-              - /home/circleci/.circleci/data/fmriprepwithfreesurfer
+              - /src/xcp_d/.circleci/data/fmriprepwithfreesurfer
 
   download_data_fmriprepwithoutfreesurfer:
     <<: *fastdockersetup
@@ -63,13 +63,13 @@ jobs:
       - run:
           name: Download fmriprepwithoutfreesurfer test data
           command: |
-            cd /home/circleci/.circleci
+            cd /src/xcp_d/.circleci
             source get_data.sh
             get_bids_data $PWD sub01
       - save_cache:
           key: fmriprepwithoutfreesurfer-01
           paths:
-              - /home/circleci/.circleci/data/fmriprepwithoutfreesurfer
+              - /src/xcp_d/.circleci/data/fmriprepwithoutfreesurfer
 
   download_data_nibabies:
     <<: *fastdockersetup
@@ -80,13 +80,13 @@ jobs:
       - run:
           name: Download nibabies test data
           command: |
-            cd /home/circleci/.circleci
+            cd /src/xcp_d/.circleci
             source get_data.sh
             get_bids_data $PWD nibabies
       - save_cache:
           key: nibabies-01
           paths:
-              - /home/circleci/.circleci/data/nibabies_test_data
+              - /src/xcp_d/.circleci/data/nibabies_test_data
 
   nifti_without_freesurfer:
     <<: *dockersetup
@@ -95,7 +95,7 @@ jobs:
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /home/circleci
+            cd /src/xcp_d
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?nifti_without_freesurfer\]' )" != "" ]]; then
               echo "Skipping nifti_without_freesurfer build"
               circleci step halt
@@ -107,17 +107,17 @@ jobs:
           name: Run full xcp_d on nifti without freesurfer
           no_output_timeout: 1h
           command: |
-            cd /home/circleci/.circleci
+            cd /src/xcp_d/.circleci
             bash NiftiWithoutFreeSurferTest.sh
       - store_artifacts:
-          path: /home/circleci/.circleci/nifti_without_freesurfer/derivatives/xcp_d/
+          path: /src/xcp_d/.circleci/nifti_without_freesurfer/derivatives/xcp_d/
       - run:
           name: Check outputs of xcp_d run
           command: |
             mkdir -p /tmp/nifti_without_freesurfer/test
             CHECK_OUTPUTS_FILE="nifti_without_freesurfer_outputs.txt"
-            find /home/circleci/.circleci/nifti_without_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/home/circleci/.circleci/nifti_without_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/nifti_without_freesurfer/test/outputs.out
-            diff <(sort /home/circleci/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nifti_without_freesurfer/test/outputs.out)
+            find /src/xcp_d/.circleci/nifti_without_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/src/xcp_d/.circleci/nifti_without_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/nifti_without_freesurfer/test/outputs.out
+            diff <(sort /src/xcp_d/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nifti_without_freesurfer/test/outputs.out)
             exit $?
 
   nifti_with_freesurfer:
@@ -127,7 +127,7 @@ jobs:
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /home/circleci
+            cd /src/xcp_d
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?nifti_with_freesurfer\]' )" != "" ]]; then
               echo "Skipping nifti_with_freesurfer build"
               circleci step halt
@@ -139,17 +139,17 @@ jobs:
           name: Run full xcp_d on nifti with freesurfer
           no_output_timeout: 1h
           command: |
-            cd /home/circleci/.circleci
+            cd /src/xcp_d/.circleci
             bash NiftiWithFreeSurferTest.sh
       - store_artifacts:
-          path: /home/circleci/.circleci/nifti_with_freesurfer/derivatives/xcp_d/
+          path: /src/xcp_d/.circleci/nifti_with_freesurfer/derivatives/xcp_d/
       - run:
           name: Check outputs of xcp_d run
           command: |
             mkdir -p /tmp/nifti_with_freesurfer/test
             CHECK_OUTPUTS_FILE="nifti_with_freesurfer_outputs.txt"
-            find /home/circleci/.circleci/nifti_with_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/home/circleci/.circleci/nifti_with_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/nifti_with_freesurfer/test/outputs.out
-            diff <(sort /home/circleci/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nifti_with_freesurfer/test/outputs.out)
+            find /src/xcp_d/.circleci/nifti_with_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/src/xcp_d/.circleci/nifti_with_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/nifti_with_freesurfer/test/outputs.out
+            diff <(sort /src/xcp_d/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nifti_with_freesurfer/test/outputs.out)
             exit $?
 
   nibabies:
@@ -159,7 +159,7 @@ jobs:
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /home/circleci
+            cd /src/xcp_d
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?nibabies\]' )" != "" ]]; then
               echo "Skipping nibabies build"
               circleci step halt
@@ -171,17 +171,17 @@ jobs:
           name: Run full xcp_d on nibabies
           no_output_timeout: 1h
           command: |
-            cd /home/circleci/.circleci
+            cd /src/xcp_d/.circleci
             bash Nibabies.sh
       - store_artifacts:
-          path: /home/circleci/.circleci/nibabies/derivatives/xcp_d/
+          path: /src/xcp_d/.circleci/nibabies/derivatives/xcp_d/
       - run:
           name: Check outputs of xcp_d run
           command: |
             mkdir -p /tmp/nibabies/test
             CHECK_OUTPUTS_FILE="nibabies_outputs.txt"
-            find /home/circleci/.circleci/nibabies/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/home/circleci/.circleci/nibabies/derivatives/++ | grep -v sourcedata | sort > /tmp/nibabies/test/outputs.out
-            diff <(sort /home/circleci/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nibabies/test/outputs.out)
+            find /src/xcp_d/.circleci/nibabies/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/src/xcp_d/.circleci/nibabies/derivatives/++ | grep -v sourcedata | sort > /tmp/nibabies/test/outputs.out
+            diff <(sort /src/xcp_d/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nibabies/test/outputs.out)
             exit $?
 
   cifti_with_freesurfer:
@@ -191,7 +191,7 @@ jobs:
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /home/circleci
+            cd /src/xcp_d
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?cifti_with_freesurfer\]' )" != "" ]]; then
               echo "Skipping cifti_with_freesurfer build"
               circleci step halt
@@ -203,17 +203,17 @@ jobs:
           name: Run full xcp_d on cifti with freesurfer
           no_output_timeout: 5h
           command: |
-            cd /home/circleci/.circleci
+            cd /src/xcp_d/.circleci
             bash CiftiWithFreeSurferTest.sh
       - store_artifacts:
-          path: /home/circleci/.circleci/cifti_with_freesurfer/derivatives/xcp_d/
+          path: /src/xcp_d/.circleci/cifti_with_freesurfer/derivatives/xcp_d/
       - run:
           name: Check outputs of xcp_d run
           command: |
             mkdir -p /tmp/cifti_with_freesurfer/test
             CHECK_OUTPUTS_FILE="cifti_with_freesurfer_outputs.txt"
-            find /home/circleci/.circleci/cifti_with_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/home/circleci/.circleci/cifti_with_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/cifti_with_freesurfer/test/outputs.out
-            diff <(sort /home/circleci/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/cifti_with_freesurfer/test/outputs.out)
+            find /src/xcp_d/.circleci/cifti_with_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/src/xcp_d/.circleci/cifti_with_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/cifti_with_freesurfer/test/outputs.out
+            diff <(sort /src/xcp_d/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/cifti_with_freesurfer/test/outputs.out)
             exit $?
 
   pytests:
@@ -223,7 +223,7 @@ jobs:
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /home/circleci
+            cd /src/xcp_d
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?cifti_with_freesurfer\]' )" != "" ]]; then
               echo "Skipping cifti_with_freesurfer build"
               circleci step halt
@@ -237,7 +237,7 @@ jobs:
           name: Run pytest on the tests directory
           no_output_timeout: 1h
           command: |
-            cd /home/circleci/.circleci
+            cd /src/xcp_d/.circleci
             bash RunPyTests.sh
 
   deployable:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 
 .fastdockersetup: &fastdockersetup
   docker:
-    - image: cimg/base:2022.04
+    - image: cimg/base:2022.11
   working_directory: /src/xcp_d
 
 runinstall: &runinstall

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,6 @@ workflows:
 
       - cifti_with_freesurfer:
           requires:
-            - build
             - download_data_fmriprepwithfreesurfer
           filters:
             branches:
@@ -326,7 +325,6 @@ workflows:
 
       - nifti_with_freesurfer:
           requires:
-            - build
             - download_data_fmriprepwithfreesurfer
           filters:
             branches:
@@ -338,7 +336,6 @@ workflows:
 
       - nibabies:
           requires:
-            - build
             - download_data_nibabies
           filters:
             branches:
@@ -350,7 +347,6 @@ workflows:
 
       - nifti_without_freesurfer:
           requires:
-            - build
             - download_data_fmriprepwithoutfreesurfer
           filters:
             branches:
@@ -362,7 +358,6 @@ workflows:
 
       - pytests:
           requires:
-            - build
             - download_data_fmriprepwithfreesurfer
             - download_data_fmriprepwithoutfreesurfer
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,8 @@ jobs:
       - run:
           name: Download fmriprepwithfreesurfer test data
           command: |
+            echo $PWD
+            echo `ls .`
             source get_data.sh
             get_bids_data $PWD fmriprep_colornest
             get_bids_data $PWD freesurfer_colornest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,23 +6,23 @@ version: 2.1
   working_directory: /src/xcp_d
 
 runinstall: &runinstall
-    name: Install xcp_d
-    command: |
-      VERSION=0+build
-      if [[ -n "$CIRCLE_TAG" ]]; then
-        VERSION="$CIRCLE_TAG"
-      fi
-      git checkout $CIRCLE_BRANCH
-      echo "${VERSION}" > /src/xcp_d/xcp_d/VERSION
-      echo "include xcp_d/VERSION" >> /src/xcp_d/MANIFEST.in
-      pip install .[tests] --progress-bar off
+  name: Install xcp_d
+  command: |
+    VERSION=0+build
+    if [[ -n "$CIRCLE_TAG" ]]; then
+      VERSION="$CIRCLE_TAG"
+    fi
+    git checkout $CIRCLE_BRANCH
+    echo "${VERSION}" > /src/xcp_d/xcp_d/VERSION
+    echo "include xcp_d/VERSION" >> /src/xcp_d/MANIFEST.in
+    pip install .[tests] --progress-bar off
 
-      # Write the config file
-      mkdir ~/.nipype
-      CFG=~/.nipype/nipype.cfg
-      printf "[execution]\nstop_on_first_crash = true\n" > ${CFG}
-      echo "poll_sleep_duration = 0.01" >> ${CFG}
-      echo "hash_method = content" >> ${CFG}
+    # Write the config file
+    mkdir ~/.nipype
+    CFG=~/.nipype/nipype.cfg
+    printf "[execution]\nstop_on_first_crash = true\n" > ${CFG}
+    echo "poll_sleep_duration = 0.01" >> ${CFG}
+    echo "hash_method = content" >> ${CFG}
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: fmriprepwithfreesurfer-01
+          key: fmriprepwithfreesurfer-00
       - run:
           name: Download fmriprepwithfreesurfer test data
           command: |
@@ -45,7 +45,7 @@ jobs:
             get_bids_data $PWD fmriprep_colornest
             get_bids_data $PWD freesurfer_colornest
       - save_cache:
-          key: fmriprepwithfreesurfer-01
+          key: fmriprepwithfreesurfer-00
           paths:
               - /src/xcp_d/.circleci/data/fmriprepwithfreesurfer
 
@@ -128,7 +128,7 @@ jobs:
               circleci step halt
             fi
       - restore_cache:
-          key: fmriprepwithfreesurfer-01
+          key: fmriprepwithfreesurfer-00
       - run: *runinstall
       - run:
           name: Run full xcp_d on nifti with freesurfer
@@ -192,7 +192,7 @@ jobs:
               circleci step halt
             fi
       - restore_cache:
-          key: fmriprepwithfreesurfer-01
+          key: fmriprepwithfreesurfer-00
       - run: *runinstall
       - run:
           name: Run full xcp_d on cifti with freesurfer
@@ -224,7 +224,7 @@ jobs:
               circleci step halt
             fi
       - restore_cache:
-          key: fmriprepwithfreesurfer-01
+          key: fmriprepwithfreesurfer-00
       - restore_cache:
           key: fmriprepwithoutfreesurfer-01
       - run: *runinstall

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 
 .fastdockersetup: &fastdockersetup
   docker:
-    - image: cimg/base:2022.11
+    - image: cimg/base:2022.04
   working_directory: /src/xcp_d
 
 runinstall: &runinstall

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,11 @@ version: 2.1
     - image: pennbbl/xcpd_build:0.0.6rc1
   working_directory: /src/xcp_d
 
+.fastdockersetup: &fastdockersetup
+  docker:
+    - image: cimg/base:2022.04
+  working_directory: /src/xcp_d
+
 runinstall: &runinstall
   name: Install xcp_d
   command: |
@@ -32,7 +37,7 @@ jobs:
       - run: *runinstall
 
   download_data_fmriprepwithfreesurfer:
-    <<: *dockersetup
+    <<: *fastdockersetup
     steps:
       - checkout
       - restore_cache:
@@ -50,7 +55,7 @@ jobs:
               - /src/xcp_d/.circleci/data/fmriprepwithfreesurfer
 
   download_data_fmriprepwithoutfreesurfer:
-    <<: *dockersetup
+    <<: *fastdockersetup
     steps:
       - checkout
       - restore_cache:
@@ -67,7 +72,7 @@ jobs:
               - /src/xcp_d/.circleci/data/fmriprepwithoutfreesurfer
 
   download_data_nibabies:
-    <<: *dockersetup
+    <<: *fastdockersetup
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ version: 2.1
 .dockersetup: &dockersetup
   docker:
     - image: pennbbl/xcpd_build:0.0.6rc1
-  working_directory: /src/xcp_d
+  working_directory: /home/circleci
 
 .fastdockersetup: &fastdockersetup
   docker:
     - image: cimg/base:2022.11
-  working_directory: /src/xcp_d
+  working_directory: /home/circleci
 
 runinstall: &runinstall
   name: Install xcp_d
@@ -18,8 +18,8 @@ runinstall: &runinstall
       VERSION="$CIRCLE_TAG"
     fi
     git checkout $CIRCLE_BRANCH
-    echo "${VERSION}" > /src/xcp_d/xcp_d/VERSION
-    echo "include xcp_d/VERSION" >> /src/xcp_d/MANIFEST.in
+    echo "${VERSION}" > /home/circleci/xcp_d/VERSION
+    echo "include xcp_d/VERSION" >> /home/circleci/MANIFEST.in
     pip install .[tests] --progress-bar off
 
     # Write the config file
@@ -45,14 +45,14 @@ jobs:
       - run:
           name: Download fmriprepwithfreesurfer test data
           command: |
-            cd /src/xcp_d/.circleci
+            cd /home/circleci/.circleci
             source get_data.sh
             get_bids_data $PWD fmriprep_colornest
             get_bids_data $PWD freesurfer_colornest
       - save_cache:
           key: fmriprepwithfreesurfer-00
           paths:
-              - /src/xcp_d/.circleci/data/fmriprepwithfreesurfer
+              - /home/circleci/.circleci/data/fmriprepwithfreesurfer
 
   download_data_fmriprepwithoutfreesurfer:
     <<: *fastdockersetup
@@ -63,13 +63,13 @@ jobs:
       - run:
           name: Download fmriprepwithoutfreesurfer test data
           command: |
-            cd /src/xcp_d/.circleci
+            cd /home/circleci/.circleci
             source get_data.sh
             get_bids_data $PWD sub01
       - save_cache:
           key: fmriprepwithoutfreesurfer-01
           paths:
-              - /src/xcp_d/.circleci/data/fmriprepwithoutfreesurfer
+              - /home/circleci/.circleci/data/fmriprepwithoutfreesurfer
 
   download_data_nibabies:
     <<: *fastdockersetup
@@ -80,13 +80,13 @@ jobs:
       - run:
           name: Download nibabies test data
           command: |
-            cd /src/xcp_d/.circleci
+            cd /home/circleci/.circleci
             source get_data.sh
             get_bids_data $PWD nibabies
       - save_cache:
           key: nibabies-01
           paths:
-              - /src/xcp_d/.circleci/data/nibabies_test_data
+              - /home/circleci/.circleci/data/nibabies_test_data
 
   nifti_without_freesurfer:
     <<: *dockersetup
@@ -95,7 +95,7 @@ jobs:
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /src/xcp_d
+            cd /home/circleci
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?nifti_without_freesurfer\]' )" != "" ]]; then
               echo "Skipping nifti_without_freesurfer build"
               circleci step halt
@@ -107,17 +107,17 @@ jobs:
           name: Run full xcp_d on nifti without freesurfer
           no_output_timeout: 1h
           command: |
-            cd /src/xcp_d/.circleci
+            cd /home/circleci/.circleci
             bash NiftiWithoutFreeSurferTest.sh
       - store_artifacts:
-          path: /src/xcp_d/.circleci/nifti_without_freesurfer/derivatives/xcp_d/
+          path: /home/circleci/.circleci/nifti_without_freesurfer/derivatives/xcp_d/
       - run:
           name: Check outputs of xcp_d run
           command: |
             mkdir -p /tmp/nifti_without_freesurfer/test
             CHECK_OUTPUTS_FILE="nifti_without_freesurfer_outputs.txt"
-            find /src/xcp_d/.circleci/nifti_without_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/src/xcp_d/.circleci/nifti_without_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/nifti_without_freesurfer/test/outputs.out
-            diff <(sort /src/xcp_d/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nifti_without_freesurfer/test/outputs.out)
+            find /home/circleci/.circleci/nifti_without_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/home/circleci/.circleci/nifti_without_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/nifti_without_freesurfer/test/outputs.out
+            diff <(sort /home/circleci/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nifti_without_freesurfer/test/outputs.out)
             exit $?
 
   nifti_with_freesurfer:
@@ -127,7 +127,7 @@ jobs:
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /src/xcp_d
+            cd /home/circleci
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?nifti_with_freesurfer\]' )" != "" ]]; then
               echo "Skipping nifti_with_freesurfer build"
               circleci step halt
@@ -139,17 +139,17 @@ jobs:
           name: Run full xcp_d on nifti with freesurfer
           no_output_timeout: 1h
           command: |
-            cd /src/xcp_d/.circleci
+            cd /home/circleci/.circleci
             bash NiftiWithFreeSurferTest.sh
       - store_artifacts:
-          path: /src/xcp_d/.circleci/nifti_with_freesurfer/derivatives/xcp_d/
+          path: /home/circleci/.circleci/nifti_with_freesurfer/derivatives/xcp_d/
       - run:
           name: Check outputs of xcp_d run
           command: |
             mkdir -p /tmp/nifti_with_freesurfer/test
             CHECK_OUTPUTS_FILE="nifti_with_freesurfer_outputs.txt"
-            find /src/xcp_d/.circleci/nifti_with_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/src/xcp_d/.circleci/nifti_with_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/nifti_with_freesurfer/test/outputs.out
-            diff <(sort /src/xcp_d/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nifti_with_freesurfer/test/outputs.out)
+            find /home/circleci/.circleci/nifti_with_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/home/circleci/.circleci/nifti_with_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/nifti_with_freesurfer/test/outputs.out
+            diff <(sort /home/circleci/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nifti_with_freesurfer/test/outputs.out)
             exit $?
 
   nibabies:
@@ -159,7 +159,7 @@ jobs:
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /src/xcp_d
+            cd /home/circleci
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?nibabies\]' )" != "" ]]; then
               echo "Skipping nibabies build"
               circleci step halt
@@ -171,17 +171,17 @@ jobs:
           name: Run full xcp_d on nibabies
           no_output_timeout: 1h
           command: |
-            cd /src/xcp_d/.circleci
+            cd /home/circleci/.circleci
             bash Nibabies.sh
       - store_artifacts:
-          path: /src/xcp_d/.circleci/nibabies/derivatives/xcp_d/
+          path: /home/circleci/.circleci/nibabies/derivatives/xcp_d/
       - run:
           name: Check outputs of xcp_d run
           command: |
             mkdir -p /tmp/nibabies/test
             CHECK_OUTPUTS_FILE="nibabies_outputs.txt"
-            find /src/xcp_d/.circleci/nibabies/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/src/xcp_d/.circleci/nibabies/derivatives/++ | grep -v sourcedata | sort > /tmp/nibabies/test/outputs.out
-            diff <(sort /src/xcp_d/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nibabies/test/outputs.out)
+            find /home/circleci/.circleci/nibabies/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/home/circleci/.circleci/nibabies/derivatives/++ | grep -v sourcedata | sort > /tmp/nibabies/test/outputs.out
+            diff <(sort /home/circleci/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/nibabies/test/outputs.out)
             exit $?
 
   cifti_with_freesurfer:
@@ -191,7 +191,7 @@ jobs:
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /src/xcp_d
+            cd /home/circleci
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?cifti_with_freesurfer\]' )" != "" ]]; then
               echo "Skipping cifti_with_freesurfer build"
               circleci step halt
@@ -203,17 +203,17 @@ jobs:
           name: Run full xcp_d on cifti with freesurfer
           no_output_timeout: 5h
           command: |
-            cd /src/xcp_d/.circleci
+            cd /home/circleci/.circleci
             bash CiftiWithFreeSurferTest.sh
       - store_artifacts:
-          path: /src/xcp_d/.circleci/cifti_with_freesurfer/derivatives/xcp_d/
+          path: /home/circleci/.circleci/cifti_with_freesurfer/derivatives/xcp_d/
       - run:
           name: Check outputs of xcp_d run
           command: |
             mkdir -p /tmp/cifti_with_freesurfer/test
             CHECK_OUTPUTS_FILE="cifti_with_freesurfer_outputs.txt"
-            find /src/xcp_d/.circleci/cifti_with_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/src/xcp_d/.circleci/cifti_with_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/cifti_with_freesurfer/test/outputs.out
-            diff <(sort /src/xcp_d/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/cifti_with_freesurfer/test/outputs.out)
+            find /home/circleci/.circleci/cifti_with_freesurfer/derivatives/xcp_d/ \( -path */figures -o -path */log \) -prune -o -name "*" -print | sed s+/home/circleci/.circleci/cifti_with_freesurfer/derivatives/++ | grep -v sourcedata | sort > /tmp/cifti_with_freesurfer/test/outputs.out
+            diff <(sort /home/circleci/.circleci/${CHECK_OUTPUTS_FILE}) <(sort /tmp/cifti_with_freesurfer/test/outputs.out)
             exit $?
 
   pytests:
@@ -223,7 +223,7 @@ jobs:
       - run:
           name: Check whether build should be skipped
           command: |
-            cd /src/xcp_d
+            cd /home/circleci
             if [[ "$( git log --format=oneline -n 1 $CIRCLE_SHA1 | grep -i -E '\[skip[ _]?cifti_with_freesurfer\]' )" != "" ]]; then
               echo "Skipping cifti_with_freesurfer build"
               circleci step halt
@@ -237,7 +237,7 @@ jobs:
           name: Run pytest on the tests directory
           no_output_timeout: 1h
           command: |
-            cd /src/xcp_d/.circleci
+            cd /home/circleci/.circleci
             bash RunPyTests.sh
 
   deployable:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,6 @@ version: 2.1
     - image: pennbbl/xcpd_build:0.0.6rc1
   working_directory: /src/xcp_d
 
-.fastdockersetup: &fastdockersetup
-  docker:
-    - image: cimg/base:2022.04
-  working_directory: /src/xcp_d
-
 runinstall: &runinstall
   name: Install xcp_d
   command: |
@@ -37,7 +32,7 @@ jobs:
       - run: *runinstall
 
   download_data_fmriprepwithfreesurfer:
-    <<: *fastdockersetup
+    <<: *dockersetup
     steps:
       - checkout
       - restore_cache:
@@ -55,7 +50,7 @@ jobs:
               - /src/xcp_d/.circleci/data/fmriprepwithfreesurfer
 
   download_data_fmriprepwithoutfreesurfer:
-    <<: *fastdockersetup
+    <<: *dockersetup
     steps:
       - checkout
       - restore_cache:
@@ -72,7 +67,7 @@ jobs:
               - /src/xcp_d/.circleci/data/fmriprepwithoutfreesurfer
 
   download_data_nibabies:
-    <<: *fastdockersetup
+    <<: *dockersetup
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,7 @@ runinstall: &runinstall
       echo "poll_sleep_duration = 0.01" >> ${CFG}
       echo "hash_method = content" >> ${CFG}
 
-
 jobs:
-
   build:
     <<: *dockersetup
     steps:
@@ -41,11 +39,13 @@ jobs:
       - restore_cache:
           key: fmriprepwithfreesurfer-01
       - run:
-          TESTDIR="/src/xcp_d/.circleci"
-          cd ${TESTDIR}
-          source get_data.sh
-          get_bids_data ${TESTDIR} fmriprep_colornest
-          get_bids_data ${TESTDIR} freesurfer_colornest
+          name: Download fmriprepwithfreesurfer test data
+          command: |
+            TESTDIR="/src/xcp_d/.circleci"
+            cd ${TESTDIR}
+            source get_data.sh
+            get_bids_data ${TESTDIR} fmriprep_colornest
+            get_bids_data ${TESTDIR} freesurfer_colornest
       - save_cache:
           key: fmriprepwithfreesurfer-01
           paths:
@@ -59,10 +59,12 @@ jobs:
       - restore_cache:
           key: fmriprepwithoutfreesurfer-01
       - run:
-          TESTDIR="/src/xcp_d/.circleci"
-          cd ${TESTDIR}
-          source get_data.sh
-          get_bids_data ${TESTDIR} sub01
+          name: Download fmriprepwithoutfreesurfer test data
+          command: |
+            TESTDIR="/src/xcp_d/.circleci"
+            cd ${TESTDIR}
+            source get_data.sh
+            get_bids_data ${TESTDIR} sub01
       - save_cache:
           key: fmriprepwithoutfreesurfer-01
           paths:
@@ -76,10 +78,12 @@ jobs:
       - restore_cache:
           key: nibabies-01
       - run:
-          TESTDIR="/src/xcp_d/.circleci"
-          cd ${TESTDIR}
-          source get_data.sh
-          get_bids_data ${TESTDIR} nibabies
+          name: Download nibabies test data
+          command: |
+            TESTDIR="/src/xcp_d/.circleci"
+            cd ${TESTDIR}
+            source get_data.sh
+            get_bids_data ${TESTDIR} nibabies
       - save_cache:
           key: nibabies-01
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,9 @@ jobs:
       - run:
           name: Download fmriprepwithfreesurfer test data
           command: |
-            TESTDIR="/src/xcp_d/.circleci"
-            cd ${TESTDIR}
             source get_data.sh
-            get_bids_data ${TESTDIR} fmriprep_colornest
-            get_bids_data ${TESTDIR} freesurfer_colornest
+            get_bids_data $PWD fmriprep_colornest
+            get_bids_data $PWD freesurfer_colornest
       - save_cache:
           key: fmriprepwithfreesurfer-01
           paths:
@@ -61,10 +59,8 @@ jobs:
       - run:
           name: Download fmriprepwithoutfreesurfer test data
           command: |
-            TESTDIR="/src/xcp_d/.circleci"
-            cd ${TESTDIR}
             source get_data.sh
-            get_bids_data ${TESTDIR} sub01
+            get_bids_data $PWD sub01
       - save_cache:
           key: fmriprepwithoutfreesurfer-01
           paths:
@@ -80,10 +76,8 @@ jobs:
       - run:
           name: Download nibabies test data
           command: |
-            TESTDIR="/src/xcp_d/.circleci"
-            cd ${TESTDIR}
             source get_data.sh
-            get_bids_data ${TESTDIR} nibabies
+            get_bids_data $PWD nibabies
       - save_cache:
           key: nibabies-01
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
 
   download_data_fmriprepwithfreesurfer:
     <<: *dockersetup
-    working_directory: /src/xcp_d/.circleci/
     steps:
       - checkout
       - restore_cache:
@@ -41,8 +40,7 @@ jobs:
       - run:
           name: Download fmriprepwithfreesurfer test data
           command: |
-            echo $PWD
-            echo `ls .`
+            cd /src/xcp_d/.circleci
             source get_data.sh
             get_bids_data $PWD fmriprep_colornest
             get_bids_data $PWD freesurfer_colornest
@@ -53,7 +51,6 @@ jobs:
 
   download_data_fmriprepwithoutfreesurfer:
     <<: *dockersetup
-    working_directory: /src/xcp_d/.circleci/
     steps:
       - checkout
       - restore_cache:
@@ -61,6 +58,7 @@ jobs:
       - run:
           name: Download fmriprepwithoutfreesurfer test data
           command: |
+            cd /src/xcp_d/.circleci
             source get_data.sh
             get_bids_data $PWD sub01
       - save_cache:
@@ -70,7 +68,6 @@ jobs:
 
   download_data_nibabies:
     <<: *dockersetup
-    working_directory: /src/xcp_d/.circleci/
     steps:
       - checkout
       - restore_cache:
@@ -78,6 +75,7 @@ jobs:
       - run:
           name: Download nibabies test data
           command: |
+            cd /src/xcp_d/.circleci
             source get_data.sh
             get_bids_data $PWD nibabies
       - save_cache:

--- a/.circleci/get_data.sh
+++ b/.circleci/get_data.sh
@@ -73,7 +73,7 @@ run_xcpd_cmd () {
     output_mount="-v ${output_dir}:/out:rw"
     workdir_mount="-v ${workdir}:/work:rw"
 
-    
+
     XCPD_RUN="docker run --rm -u $(id -u) ${workdir_mount} ${patch_mount} ${cfg_arg} ${bids_mount} ${output_mount} ${IMAGE} /bids-input/${bids_folder_name} /out participant -w /work"
 
   fi
@@ -215,7 +215,7 @@ get_bids_data() {
 
     elif [[ ${DS} = freesurfer_colornest ]]
     then
-      dataset_dir="$TEST_DATA_DIR/fmriprepwithfreesurfer/freesurfer/freesurfer"
+      dataset_dir="$TEST_DATA_DIR/fmriprepwithfreesurfer/freesurfer"
       # Do not re-download if the folder exists
       if [ ! -d $dataset_dir ]
       then


### PR DESCRIPTION
Closes #337.

## Changes proposed in this pull request

- Eliminate duplicated test data by downloading the data in a step _before_ the actual tests.
- Keep data saved in a long-term cache.

## Documentation that should be reviewed

None