### PR TITLE
Fix MNI152NLin6Sym import in utils.py

### DIFF
--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -148,8 +148,8 @@ def get_transformfilex(bold_file, mni_to_t1w, t1w_to_native):
     elif 'MNI152NLin6Asym' in os.path.basename(mni_to_t1w):
         template = 'MNI152NLin6Asym'
 
-    elif 'MNI152NLin6Asym' in os.path.basename(mni_to_t1w):
-        template = 'MNI152NLin6Asym'
+    elif 'MNI152NLin6Sym' in os.path.basename(mni_to_t1w):
+        template = 'MNI152NLin6Sym'
 
     # Pull out the correct transforms based on bold_file name
     # and string them together.


### PR DESCRIPTION
I presumed the original duplicate MNI152NLin6Asym template finding was a typo.

## Changes proposed in this pull request
Fix utils.py to accept MNI152NLin6Sym

## Documentation that should be reviewed
N/A
