### PR TITLE
Do not merge in concatenated files when re-running concatenation workflow

### DIFF
--- a/.circleci/CiftiWithFreeSurferTest.sh
+++ b/.circleci/CiftiWithFreeSurferTest.sh
@@ -30,18 +30,9 @@ XCPD_CMD=$(run_xcpd_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR} ${TEMPDIR})
 
 $XCPD_CMD \
     --despike --head_radius 40 \
-	--smoothing 6 -vvv \
+    --smoothing 6 -vvv \
     --motion-filter-type lp --band-stop-min 6 \
     --warp-surfaces-native2std \
     --cifti \
     --combineruns
 echo $XCPD_CMD
-
-# Run a second time
-$XCPD_CMD \
-    --despike --head_radius 40 \
-	--smoothing 6 -vvv \
-    --motion-filter-type lp --band-stop-min 6 \
-    --warp-surfaces-native2std \
-    --cifti \
-    --combineruns

--- a/.circleci/CiftiWithFreeSurferTest.sh
+++ b/.circleci/CiftiWithFreeSurferTest.sh
@@ -30,9 +30,18 @@ XCPD_CMD=$(run_xcpd_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR} ${TEMPDIR})
 
 $XCPD_CMD \
     --despike --head_radius 40 \
-	--smoothing 6 -v -v \
+	--smoothing 6 -vvv \
     --motion-filter-type lp --band-stop-min 6 \
     --warp-surfaces-native2std \
     --cifti \
     --combineruns
 echo $XCPD_CMD
+
+# Run a second time
+$XCPD_CMD \
+    --despike --head_radius 40 \
+	--smoothing 6 -vvv \
+    --motion-filter-type lp --band-stop-min 6 \
+    --warp-surfaces-native2std \
+    --cifti \
+    --combineruns

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -2,7 +2,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Functions for concatenating scans across runs."""
 import os
-import shutil
 import tempfile
 from json import loads
 from pathlib import Path
@@ -341,35 +340,6 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                     )
                     LOGGER.debug("plot_svgx done")
 
-                    # link or copy bb svgs
-                    # NOTE: This seems to fail, but execsummary workflow handles these figures.
-                    in_fig_entities = preproc_files[0].get_entities()
-                    in_fig_entities = _sanitize_entities(in_fig_entities)
-                    in_fig_entities["res"] = None
-                    in_fig_entities["den"] = None
-                    in_fig_entities["run"] = [None, 1]  # grab first run
-                    in_fig_entities["datatype"] = "figures"
-                    in_fig_entities["extension"] = ".svg"
-
-                    for desc in ["bbregister", "boldref"]:
-                        in_fig_entities["desc"] = desc
-                        fig_in = layout_fmriprep.get(**in_fig_entities)
-                        if len(fig_in) == 0:
-                            LOGGER.warning(f"No files found for {in_fig_entities}")
-                        else:
-                            fig_in = fig_in[0].path
-
-                            out_fig_entities = in_fig_entities.copy()
-                            out_fig_entities["run"] = None
-                            out_fig_entities["desc"] = desc
-                            fig_out = layout_xcpd.build_path(
-                                out_fig_entities,
-                                path_patterns=path_patterns,
-                                strict=False,
-                                validate=False,
-                            )
-                            shutil.copy(fig_in, fig_out)
-
                     # Now timeseries files
                     atlases = layout_xcpd.get_atlases(
                         suffix="timeseries",
@@ -385,9 +355,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                             extension=tsv_extensions,
                             **space_entities,
                         )
-                        concat_file = _get_concat_name(
-                            layout_xcpd, atlas_timeseries_files[0]
-                        )
+                        concat_file = _get_concat_name(layout_xcpd, atlas_timeseries_files[0])
                         if atlas_timeseries_files[0].extension == ".tsv":
                             concatenate_tsv_files(atlas_timeseries_files, concat_file)
                         elif atlas_timeseries_files[0].extension == ".ptseries.nii":

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -147,7 +147,8 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                     make_dcan_df([motion_file.path], dcan_df_file, TR)
 
                 # Concatenate motion files
-                LOGGER.debug(f"Concatenating motion files: {', '.join(motion_files)}")
+                motion_file_names = ', '.join([motion_file.path for motion_file in motion_files])
+                LOGGER.debug(f"Concatenating motion files: {motion_file_names}")
                 concat_motion_file = _get_concat_name(layout_xcpd, motion_files[0])
                 concatenate_tsv_files(motion_files, concat_motion_file)
 
@@ -162,7 +163,10 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                     extension=".tsv",
                     **task_entities,
                 )
-                LOGGER.debug(f"Concatenating outlier files: {', '.join(outlier_files)}")
+                outlier_file_names = ', '.join(
+                    [outlier_file.path for outlier_file in outlier_files]
+                )
+                LOGGER.debug(f"Concatenating outlier files: {outlier_file_names}")
                 concat_outlier_file = _get_concat_name(layout_xcpd, outlier_files[0])
                 outfile = concatenate_tsv_files(outlier_files, concat_outlier_file)
 

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -129,7 +129,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                     TR = _get_tr(preproc_files[0].path)
 
                     make_dcan_df([motion_files[0].path], dcan_df_file, TR)
-                    LOGGER.debug(f"Only one run found for {preproc_files[0].path}")
+                    LOGGER.debug(f"Only one run found for task {task}")
                     continue
 
                 # Get TR from one of the preproc files
@@ -311,9 +311,9 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                     LOGGER.debug("plot_svgx done")
 
                     # link or copy bb svgs
+                    # NOTE: This seems to fail, but execsummary workflow handles these figures.
                     in_fig_entities = preproc_files[0].get_entities()
                     in_fig_entities = _sanitize_entities(in_fig_entities)
-                    in_fig_entities["space"] = None
                     in_fig_entities["res"] = None
                     in_fig_entities["den"] = None
                     in_fig_entities["run"] = [None, 1]  # grab first run
@@ -321,7 +321,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                     in_fig_entities["extension"] = ".svg"
 
                     for desc in ["bbregister", "boldref"]:
-                        in_fig_entities["desc"] = "bbregister"
+                        in_fig_entities["desc"] = desc
                         fig_in = layout_fmriprep.get(**in_fig_entities)
                         if len(fig_in) == 0:
                             LOGGER.warning(f"No files found for {in_fig_entities}")
@@ -330,7 +330,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
 
                             out_fig_entities = in_fig_entities.copy()
                             out_fig_entities["run"] = None
-                            out_fig_entities["desc"] = "bbregister"
+                            out_fig_entities["desc"] = desc
                             fig_out = layout_xcpd.build_path(
                                 out_fig_entities,
                                 path_patterns=path_patterns,

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -129,6 +129,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                     TR = _get_tr(preproc_files[0].path)
 
                     make_dcan_df([motion_files[0].path], dcan_df_file, TR)
+                    LOGGER.debug(f"Only one run found for {preproc_files[0].path}")
                     continue
 
                 # Get TR from one of the preproc files
@@ -146,7 +147,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                     make_dcan_df([motion_file.path], dcan_df_file, TR)
 
                 # Concatenate motion files
-                LOGGER.debug("Concatenating motion files")
+                LOGGER.debug(f"Concatenating motion files: {', '.join(motion_files)}")
                 concat_motion_file = _get_concat_name(layout_xcpd, motion_files[0])
                 concatenate_tsv_files(motion_files, concat_motion_file)
 
@@ -155,14 +156,13 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                 make_dcan_df([concat_motion_file], concat_dcan_df_file, TR)
 
                 # Concatenate outlier files
-                LOGGER.debug("Concatenating outlier files")
                 outlier_files = layout_xcpd.get(
                     desc=None,
                     suffix="outliers",
                     extension=".tsv",
                     **task_entities,
                 )
-
+                LOGGER.debug(f"Concatenating outlier files: {', '.join(outlier_files)}")
                 concat_outlier_file = _get_concat_name(layout_xcpd, outlier_files[0])
                 outfile = concatenate_tsv_files(outlier_files, concat_outlier_file)
 


### PR DESCRIPTION
Solves part of #631.

@smeisler reported two bugs in #631:

1. On a first run, concatenated outlier files were longer than the concatenated data. For two runs of 420 volumes, the concatenated BOLD data had 840 volumes, as expected, while the concatenated outliers had 2520 (3x the expected amount).
    - I haven't been able to reproduce this problem so far.
2. On a second run, the concatenated files were collected along with the run-wise files, and were then added into the new concatenated files, resulting in files that are 2x longer than they should be.
    - This should be solvable by requiring a run entity in the files being grabbed for concatenation. I've added this in 45bcf5ef91f5d5e10262d11908368a40789249f4. Okay, it was a bit harder to resolve than I thought, but it seems okay as of f981259822556566c2bebdd1f5528624a2134664.

## Changes proposed in this pull request

- Require a run entity in filenames when concatenating those files. This will exclude any concatenated files from previous runs.
- Expand logging in concatenation workflow.
- Remove code to copy figures from preprocessed derivatives to xcpd derivatives. These figures are handled by the executive summary workflow.

## Documentation that should be reviewed
None