### PR TITLE
Remove brainsprite and tempita from requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
 [options]
 python_requires = >=3.8
 install_requires =
-    brainsprite ~= 0.14.2  # for figures
     h5py  # for DCAN motion file
     indexed_gzip ~= 1.6.4  # for loading imgs in nibabel
     matplotlib ~= 3.3.4
@@ -37,7 +36,6 @@ install_requires =
     scipy >= 1.8.0  # nipype needs networkx, which needs scipy > 1.8.0
     seaborn  # for plots
     sentry-sdk ~= 1.4.3  # for usage reports
-    tempita  # for brainsprite
     templateflow ~= 0.8.1
 packages = find:
 


### PR DESCRIPTION
I must have made a mistake in handling merge conflicts between #606 and #607, because somehow brainsprite and tempita were added back as dependencies.