### PR TITLE
Start to standardize interface parameter calls

### DIFF
--- a/xcp_d/interfaces/ants.py
+++ b/xcp_d/interfaces/ants.py
@@ -25,6 +25,7 @@ class _ConvertTransformFileInputSpec(CommandLineInputSpec):
         name_template="%s.txt",
         keep_extension=False,
         position=2,
+        exists=False,
     )
 
 

--- a/xcp_d/interfaces/c3.py
+++ b/xcp_d/interfaces/c3.py
@@ -24,7 +24,7 @@ class _C3dInputSpec(CommandLineInputSpec):
     """Input specification for C3d."""
 
     in_file = InputMultiPath(
-        File(),
+        File(exists=True),
         position=1,
         argstr="%s",
         mandatory=True,
@@ -38,7 +38,7 @@ class _C3dInputSpec(CommandLineInputSpec):
         desc="Output file of last image on the stack.",
     )
     out_files = InputMultiPath(
-        File(),
+        File(exists=False),
         argstr="-oo %s",
         xor=["out_file"],
         position=-1,
@@ -124,7 +124,7 @@ class _C3dInputSpec(CommandLineInputSpec):
 class _C3dOutputSpec(TraitedSpec):
     """Output specification for C3d."""
 
-    out_files = OutputMultiPath(File(exists=False))
+    out_files = OutputMultiPath(File(exists=True))
 
 
 class C3d(CommandLine):

--- a/xcp_d/interfaces/filtering.py
+++ b/xcp_d/interfaces/filtering.py
@@ -35,7 +35,7 @@ class _FilteringDataInputSpec(BaseInterfaceInputSpec):
     highpass = traits.Float(mandatory=True,
                             default_value=0.01,
                             desc="Highpass filter in Hz")
-    mask = File(exists=False,
+    mask = File(exists=True,
                 mandatory=False,
                 desc="Bain mask for nifti file")
     bandpass_filter = traits.Bool(mandatory=True,

--- a/xcp_d/interfaces/filtering.py
+++ b/xcp_d/interfaces/filtering.py
@@ -37,7 +37,7 @@ class _FilteringDataInputSpec(BaseInterfaceInputSpec):
                             desc="Highpass filter in Hz")
     mask = File(exists=True,
                 mandatory=False,
-                desc="Bain mask for nifti file")
+                desc="Brain mask for nifti file")
     bandpass_filter = traits.Bool(mandatory=True,
                                   desc="To apply bandpass or not")
 

--- a/xcp_d/interfaces/filtering.py
+++ b/xcp_d/interfaces/filtering.py
@@ -25,24 +25,20 @@ class _FilteringDataInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True,
                    mandatory=True,
                    desc="Bold file")
-    TR = traits.Float(exists=True, mandatory=True, desc="Repetition time")
-    filter_order = traits.Int(exists=True,
-                              mandatory=True,
+    TR = traits.Float(mandatory=True, desc="Repetition time")
+    filter_order = traits.Int(mandatory=True,
                               default_value=2,
                               desc="Filter order")
-    lowpass = traits.Float(exists=True,
-                           mandatory=True,
+    lowpass = traits.Float(mandatory=True,
                            default_value=0.10,
                            desc="Lowpass filter in Hz")
-    highpass = traits.Float(exists=True,
-                            mandatory=True,
+    highpass = traits.Float(mandatory=True,
                             default_value=0.01,
                             desc="Highpass filter in Hz")
     mask = File(exists=False,
                 mandatory=False,
                 desc="Bain mask for nifti file")
-    bandpass_filter = traits.Bool(exists=False,
-                                  mandatory=True,
+    bandpass_filter = traits.Bool(mandatory=True,
                                   desc="To apply bandpass or not")
 
 

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -172,9 +172,8 @@ class _CensorScrubInputSpec(BaseInterfaceInputSpec):
     )
     custom_confounds = traits.Either(
         traits.Undefined,
-        File,
-        desc="Name of custom confounds file, or True",
-        exists=False,
+        File(exists=True),
+        desc="Name of custom confounds file.",
         mandatory=False,
     )
     fmriprep_confounds_file = File(
@@ -212,8 +211,10 @@ class _CensorScrubOutputSpec(TraitedSpec):
     fmriprep_confounds_censored = File(
         exists=True, mandatory=True, desc="fmriprep_confounds_tsv censored"
     )
-    custom_confounds_censored = File(
-        exists=False, mandatory=False, desc="custom_confounds_tsv censored"
+    custom_confounds_censored = traits.Either(
+        traits.Undefined,
+        File(exists=True),
+        desc="Name of censored custom confounds file.",
     )
     tmask = File(
         exists=True,
@@ -401,11 +402,9 @@ class CensorScrub(SimpleInterface):
 
 class _InterpolateInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc=" censored or clean bold")
-    bold_file = File(exists=True,
-                     mandatory=True,
-                     desc=" censored or clean bold")
+    bold_file = File(exists=True, mandatory=True, desc=" censored or clean bold")
     tmask = File(exists=True, mandatory=True, desc="temporal mask")
-    mask_file = File(exists=False, mandatory=False, desc="required for nifti")
+    mask_file = File(exists=True, mandatory=False, desc="required for nifti")
     TR = traits.Float(mandatory=True, desc="repetition time in TR")
 
 

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -165,7 +165,6 @@ class _CensorScrubInputSpec(BaseInterfaceInputSpec):
         exists=True, mandatory=True, desc=" Partially processed bold or nifti"
     )
     fd_thresh = traits.Float(
-        exists=True,
         mandatory=False,
         default_value=0.2,
         desc="Framewise displacement"
@@ -184,27 +183,24 @@ class _CensorScrubInputSpec(BaseInterfaceInputSpec):
         desc="fMRIPrep confounds tsv after removing dummy time, if any",
     )
     head_radius = traits.Float(
-        exists=True, mandatory=False, default_value=50, desc="Head radius in mm "
+        mandatory=False, default_value=50, desc="Head radius in mm "
     )
     motion_filter_type = traits.Either(
         None,
         traits.Str,
-        exists=False,
         mandatory=True,
     )
-    motion_filter_order = traits.Int(exists=False, mandatory=True)
+    motion_filter_order = traits.Int(mandatory=True)
     TR = traits.Float(mandatory=True, desc="Repetition time in seconds")
     band_stop_min = traits.Either(
         None,
         traits.Float,
-        exists=True,
         mandatory=True,
         desc="Lower frequency for the band-stop motion filter, in breaths-per-minute (bpm).",
     )
     band_stop_max = traits.Either(
         None,
         traits.Float,
-        exists=True,
         mandatory=True,
         desc="Upper frequency for the band-stop motion filter, in breaths-per-minute (bpm).",
     )
@@ -410,9 +406,7 @@ class _InterpolateInputSpec(BaseInterfaceInputSpec):
                      desc=" censored or clean bold")
     tmask = File(exists=True, mandatory=True, desc="temporal mask")
     mask_file = File(exists=False, mandatory=False, desc="required for nifti")
-    TR = traits.Float(exists=True,
-                      mandatory=True,
-                      desc="repetition time in TR")
+    TR = traits.Float(mandatory=True, desc="repetition time in TR")
 
 
 class _InterpolateOutputSpec(TraitedSpec):

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -34,14 +34,12 @@ class _CensoringPlotInputSpec(BaseInterfaceInputSpec):
     )
     tmask = File(exists=False, mandatory=False, desc="Temporal mask. Current unused.")
     dummytime = traits.Float(
-        exists=False,
         mandatory=False,
         default_value=0,
         desc="Dummy time to drop",
     )
-    TR = traits.Float(exists=True, mandatory=True, desc="Repetition Time")
+    TR = traits.Float(mandatory=True, desc="Repetition Time")
     head_radius = traits.Float(
-        exists=True,
         mandatory=False,
         default_value=50,
         desc="Head radius; recommended value is 40 for babies",
@@ -49,29 +47,22 @@ class _CensoringPlotInputSpec(BaseInterfaceInputSpec):
     motion_filter_type = traits.Either(
         None,
         traits.Str,
-        exists=False,
         mandatory=True,
     )
-    motion_filter_order = traits.Int(exists=False, mandatory=True)
+    motion_filter_order = traits.Int(mandatory=True)
     band_stop_min = traits.Either(
         None,
         traits.Float,
-        exists=False,
         mandatory=True,
         desc="Lower frequency for the band-stop motion filter, in breaths-per-minute (bpm).",
     )
     band_stop_max = traits.Either(
         None,
         traits.Float,
-        exists=False,
         mandatory=True,
         desc="Upper frequency for the band-stop motion filter, in breaths-per-minute (bpm).",
     )
-    fd_thresh = traits.Float(
-        exists=False,
-        mandatory=True,
-        desc="Framewise displacement threshold."
-    )
+    fd_thresh = traits.Float(mandatory=True, desc="Framewise displacement threshold.")
 
 
 class _CensoringPlotOutputSpec(TraitedSpec):
@@ -203,14 +194,12 @@ class _QCPlotInputSpec(BaseInterfaceInputSpec):
     cleaned_file = File(exists=True, mandatory=True, desc="Processed file")
     tmask = File(exists=False, mandatory=False, desc="Temporal mask")
     dummytime = traits.Float(
-        exists=False,
         mandatory=False,
         default_value=0,
         desc="Dummy time to drop",
     )
-    TR = traits.Float(exists=True, mandatory=True, desc="Repetition Time")
+    TR = traits.Float(mandatory=True, desc="Repetition Time")
     head_radius = traits.Float(
-        exists=True,
         mandatory=False,
         default_value=50,
         desc="Head radius; recommended value is 40 for babies",

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -32,7 +32,7 @@ class _CensoringPlotInputSpec(BaseInterfaceInputSpec):
         mandatory=True,
         desc="Raw bold file from fMRIPrep. Used only to identify the right confounds file.",
     )
-    tmask = File(exists=False, mandatory=False, desc="Temporal mask. Current unused.")
+    tmask = File(exists=True, mandatory=False, desc="Temporal mask. Current unused.")
     dummytime = traits.Float(
         mandatory=False,
         default_value=0,
@@ -189,10 +189,10 @@ class CensoringPlot(SimpleInterface):
 
 class _QCPlotInputSpec(BaseInterfaceInputSpec):
     bold_file = File(exists=True, mandatory=True, desc="Raw bold file from fMRIPrep")
-    mask_file = File(exists=False, mandatory=False, desc="Mask file from nifti")
-    seg_file = File(exists=False, mandatory=False, desc="Seg file for nifti")
+    mask_file = File(exists=True, mandatory=False, desc="Mask file from nifti")
+    seg_file = File(exists=True, mandatory=False, desc="Seg file for nifti")
     cleaned_file = File(exists=True, mandatory=True, desc="Processed file")
-    tmask = File(exists=False, mandatory=False, desc="Temporal mask")
+    tmask = File(exists=True, mandatory=False, desc="Temporal mask")
     dummytime = traits.Float(
         mandatory=False,
         default_value=0,
@@ -204,10 +204,10 @@ class _QCPlotInputSpec(BaseInterfaceInputSpec):
         default_value=50,
         desc="Head radius; recommended value is 40 for babies",
     )
-    bold2T1w_mask = File(exists=False, mandatory=False, desc="Bold mask in MNI")
-    bold2temp_mask = File(exists=False, mandatory=False, desc="Bold mask in T1W")
-    template_mask = File(exists=False, mandatory=False, desc="Template mask")
-    t1w_mask = File(exists=False, mandatory=False, desc="Mask in T1W")
+    bold2T1w_mask = File(exists=True, mandatory=False, desc="Bold mask in MNI")
+    bold2temp_mask = File(exists=True, mandatory=False, desc="Bold mask in T1W")
+    template_mask = File(exists=True, mandatory=False, desc="Template mask")
+    t1w_mask = File(exists=True, mandatory=False, desc="Mask in T1W")
 
 
 class _QCPlotOutputSpec(TraitedSpec):

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -42,10 +42,11 @@ class _RegressInputSpec(BaseInterfaceInputSpec):
         ),
     )
     custom_confounds = traits.Either(
-        traits.Undefined,
+        None,
         File(exists=True),
-        desc="Name of custom confounds file, or True",
+        desc="Name of custom confounds file",
         mandatory=False,
+        usedefault=True,
     )
 
 
@@ -76,7 +77,7 @@ class Regress(SimpleInterface):
 
         # Get the confound matrix
         # Do we have custom confounds?
-        if self.inputs.custom_confounds and exists(self.inputs.custom_confounds):
+        if self.inputs.custom_confounds:
             confound = load_confound_matrix(
                 original_file=self.inputs.original_file,
                 custom_confounds=self.inputs.custom_confounds,

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -30,17 +30,23 @@ class _RegressInputSpec(BaseInterfaceInputSpec):
         mandatory=True,
         desc="The fMRIPrep confounds tsv after censoring")
     # TODO: Use Enum maybe?
-    original_file = traits.Str(exists=True, mandatory=False,
-                               desc="Name of original bold file- helps load in the confounds"
-                               "file down the line using the original path name")
-    custom_confounds = traits.Either(traits.Undefined,
-                                     File,
-                                     desc="Name of custom confounds file, or True",
-                                     exists=False,
-                                     mandatory=False)
     params = traits.Str(mandatory=True, desc="Parameter set to use.")
     TR = traits.Float(mandatory=True, desc="Repetition time")
     mask = File(exists=True, mandatory=False, desc="Brain mask for nifti files")
+    original_file = traits.File(
+        exists=True,
+        mandatory=False,
+        desc=(
+            "Name of original bold file- helps load in the confounds "
+            "file down the line using the original path name"
+        ),
+    )
+    custom_confounds = traits.Either(
+        traits.Undefined,
+        File(exists=True),
+        desc="Name of custom confounds file, or True",
+        mandatory=False,
+    )
 
 
 class _RegressOutputSpec(TraitedSpec):

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -1,8 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Regression interfaces."""
-from os.path import exists
-
 import pandas as pd
 from nipype import logging
 from nipype.interfaces.base import (

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -30,9 +30,6 @@ class _RegressInputSpec(BaseInterfaceInputSpec):
         mandatory=True,
         desc="The fMRIPrep confounds tsv after censoring")
     # TODO: Use Enum maybe?
-    params = traits.Str(exists=True, mandatory=True, desc="Parameter set to use.")
-    TR = traits.Float(exists=True, mandatory=True, desc="Repetition time")
-    mask = File(exists=False, mandatory=False, desc="Brain mask for nifti files")
     original_file = traits.Str(exists=True, mandatory=False,
                                desc="Name of original bold file- helps load in the confounds"
                                "file down the line using the original path name")
@@ -41,6 +38,9 @@ class _RegressInputSpec(BaseInterfaceInputSpec):
                                      desc="Name of custom confounds file, or True",
                                      exists=False,
                                      mandatory=False)
+    params = traits.Str(mandatory=True, desc="Parameter set to use.")
+    TR = traits.Float(mandatory=True, desc="Repetition time")
+    mask = File(exists=True, mandatory=False, desc="Brain mask for nifti files")
 
 
 class _RegressOutputSpec(TraitedSpec):
@@ -134,7 +134,7 @@ class Regress(SimpleInterface):
 
 class _CiftiDespikeInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc=" cifti  file ")
-    TR = traits.Float(exists=True, mandatory=True, desc="repetition time")
+    TR = traits.Float(mandatory=True, desc="repetition time")
 
 
 class _CiftiDespikeOutputSpec(TraitedSpec):

--- a/xcp_d/interfaces/report.py
+++ b/xcp_d/interfaces/report.py
@@ -77,9 +77,14 @@ class _SubjectSummaryInputSpec(BaseInterfaceInputSpec):
     """Input specification for SubjectSummaryInterface."""
 
     subject_id = Str(desc='Subject ID')
-    bold = InputMultiObject(traits.Either(File(exists=True),
-                                          traits.List(File(exists=True))),
-                            desc='BOLD or CIFTI functional series')
+    # A list of files or a list of lists of files?
+    bold = InputMultiObject(
+        traits.Either(
+            File(exists=True),
+            traits.List(File(exists=True)),
+        ),
+        desc='BOLD or CIFTI functional series',
+    )
 
 
 class _SubjectSummaryOutputSpec(_SummaryInterfaceOutputSpec):
@@ -112,7 +117,7 @@ class SubjectSummary(SummaryInterface):
 class _FunctionalSummaryInputSpec(BaseInterfaceInputSpec):
     """Input specification for FunctionalSummary."""
 
-    bold_file = traits.File(True, True, desc='cifti or bold File')
+    bold_file = traits.File(exists=True, mandatory=True, desc='cifti or bold File')
     qc_file = traits.File(exists=True, desc='qc file')
     TR = traits.Float(
         mandatory=True,

--- a/xcp_d/interfaces/resting_state.py
+++ b/xcp_d/interfaces/resting_state.py
@@ -34,7 +34,8 @@ class _SurfaceReHoInputSpec(BaseInterfaceInputSpec):
     surf_bold = File(exists=True,
                      mandatory=True,
                      desc="left or right hemisphere gii ")
-    surf_hemi = traits.Str(exists=True, mandatory=True, desc="L or R ")
+    # TODO: Change to Enum
+    surf_hemi = traits.Str(mandatory=True, desc="L or R ")
 
 
 class _SurfaceReHoOutputSpec(TraitedSpec):
@@ -89,18 +90,20 @@ class SurfaceReHo(SimpleInterface):
 
 class _ComputeALFFInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc="nifti, cifti or gifti")
-    TR = traits.Float(exists=True, mandatory=True, desc="repetition time")
-    lowpass = traits.Float(exists=True,
-                           mandatory=True,
-                           default_value=0.10,
-                           desc="lowpass filter in Hz")
-    highpass = traits.Float(exists=True,
-                            mandatory=True,
-                            default_value=0.01,
-                            desc="highpass filter in Hz")
     mask = File(exists=False,
                 mandatory=False,
                 desc=" brain mask for nifti file")
+    TR = traits.Float(mandatory=True, desc="repetition time")
+    lowpass = traits.Float(
+        mandatory=True,
+        default_value=0.10,
+        desc="lowpass filter in Hz",
+    )
+    highpass = traits.Float(
+        mandatory=True,
+        default_value=0.01,
+        desc="highpass filter in Hz",
+    )
 
 
 class _ComputeALFFOutputSpec(TraitedSpec):

--- a/xcp_d/interfaces/resting_state.py
+++ b/xcp_d/interfaces/resting_state.py
@@ -90,9 +90,6 @@ class SurfaceReHo(SimpleInterface):
 
 class _ComputeALFFInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc="nifti, cifti or gifti")
-    mask = File(exists=False,
-                mandatory=False,
-                desc=" brain mask for nifti file")
     TR = traits.Float(mandatory=True, desc="repetition time")
     lowpass = traits.Float(
         mandatory=True,
@@ -103,6 +100,11 @@ class _ComputeALFFInputSpec(BaseInterfaceInputSpec):
         mandatory=True,
         default_value=0.01,
         desc="highpass filter in Hz",
+    )
+    mask = File(
+        exists=True,
+        mandatory=False,
+        desc=" brain mask for nifti file",
     )
 
 

--- a/xcp_d/interfaces/surfplotting.py
+++ b/xcp_d/interfaces/surfplotting.py
@@ -87,9 +87,9 @@ class _PlotSVGDataInputSpec(BaseInterfaceInputSpec):
         mandatory=True,
         desc="TSV file with filtered motion parameters.",
     )
-    mask = File(exists=False, mandatory=False, desc="Bold mask")
+    mask = File(exists=True, mandatory=False, desc="Bold mask")
     tmask = File(exists=True, mandatory=False, desc="Temporal mask")
-    seg_data = File(exists=False, mandatory=False, desc="Segmentation file")
+    seg_data = File(exists=True, mandatory=False, desc="Segmentation file")
     TR = traits.Float(default_value=1, desc="Repetition time")
     dummyvols = traits.Float(default_value=0, desc="Dummy volumes to drop")
 

--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -427,7 +427,6 @@ class _CiftiCorrelationInputSpec(CommandLineInputSpec):
     )
 
     roi_override = traits.Bool(
-        exists=True,
         argstr="-roi-override %s ",
         position=2,
         desc=" perform correlation from a subset of rows to all rows",

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -264,7 +264,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     inputnode.inputs.bold_file = bold_file
     inputnode.inputs.ref_file = run_data["boldref"]
     inputnode.inputs.bold_mask = mask_file
-    inputnode.inputs.custom_confounds = str(custom_confounds)
+    inputnode.inputs.custom_confounds = custom_confounds
     inputnode.inputs.fmriprep_confounds_tsv = run_data["confounds"]
     inputnode.inputs.t1w_to_native = run_data["t1w_to_native_xform"]
 

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -231,7 +231,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     )
 
     inputnode.inputs.bold_file = bold_file
-    inputnode.inputs.custom_confounds = str(custom_confounds)
+    inputnode.inputs.custom_confounds = custom_confounds
     inputnode.inputs.fmriprep_confounds_tsv = run_data["confounds"]
 
     outputnode = pe.Node(


### PR DESCRIPTION
Closes None.

## Changes proposed in this pull request

- For non-File, non-Directory traits, remove the `exists` parameter. This shouldn't be used.
- Try to ensure that any Files that must exist have `exists=True`.
- Allow custom confounds to be None, and do not coerce it to a string.

## Documentation that should be reviewed

None