### PR TITLE
Add `--dcan-qc` flag

### DIFF
--- a/.circleci/CiftiWithFreeSurferTest.sh
+++ b/.circleci/CiftiWithFreeSurferTest.sh
@@ -28,11 +28,13 @@ OUTPUT_DIR=${TESTDIR}/${TESTNAME}/derivatives
 BIDS_INPUT_DIR=${TESTDIR}/data/fmriprepwithfreesurfer/fmriprep
 XCPD_CMD=$(run_xcpd_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR} ${TEMPDIR})
 
+echo $XCPD_CMD
+
 $XCPD_CMD \
     --despike --head_radius 40 \
     --smoothing 6 -vvv \
     --motion-filter-type lp --band-stop-min 6 \
     --warp-surfaces-native2std \
     --cifti \
-    --combineruns
-echo $XCPD_CMD
+    --combineruns \
+    --dcan-qc

--- a/.circleci/Nibabies.sh
+++ b/.circleci/Nibabies.sh
@@ -28,8 +28,12 @@ BIDS_INPUT_DIR=${TESTDIR}/data/nibabies_test_data/derivatives/nibabies
 XCPD_CMD=$(run_xcpd_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR} ${TEMPDIR})
 
 $XCPD_CMD \
-    --despike  --head_radius 40 \
-    --smoothing 6  -f 100 -v -v \
-    --nuissance-regressors 27P --input-type nibabies
-    
+    --despike \
+    --head_radius 40 \
+    --smoothing 6 \
+    -f 100 \
+    -vv \
+    --nuissance-regressors 27P \
+    --input-type nibabies
+
 echo $XCPD_CMD

--- a/.circleci/NiftiWithoutFreeSurferTest.sh
+++ b/.circleci/NiftiWithoutFreeSurferTest.sh
@@ -27,9 +27,13 @@ BIDS_INPUT_DIR=${TESTDIR}/data/fmriprepwithoutfreesurfer/fmriprep
 XCPD_CMD=$(run_xcpd_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR} ${TEMPDIR})
 
 $XCPD_CMD \
-    --despike --head_radius 40 \
-    --smoothing 6 -f 100 -vv \
-    --nuissance-regressors 27P \
-    --disable-bandpass-filter
+    --despike \
+    --head_radius 40 \
+    --smoothing 6 \
+    -f 100 \
+    -vv \
+    --nuisance-regressors 27P \
+    --disable-bandpass-filter \
+    --dcan-qc
 
 echo $XCPD_CMD

--- a/.circleci/nibabies_outputs.txt
+++ b/.circleci/nibabies_outputs.txt
@@ -1,6 +1,5 @@
 xcp_d/
 xcp_d/dataset_description.json
-xcp_d/sub-01_ses-1mo_executive_summary.html
 xcp_d/sub-01.html
 xcp_d/logs
 xcp_d/logs/CITATION.bib

--- a/.circleci/nifti_with_freesurfer_outputs.txt
+++ b/.circleci/nifti_with_freesurfer_outputs.txt
@@ -104,4 +104,3 @@ xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_space-M
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_space-MNI152NLin2009cAsym_desc-denoised_bold.nii.gz
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_space-MNI152NLin2009cAsym_desc-denoisedSmoothed_bold.json
 xcp_d/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-2_space-MNI152NLin2009cAsym_desc-denoisedSmoothed_bold.nii.gz
-xcp_d/sub-colornest001_ses-1_executive_summary.html

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -959,6 +959,7 @@ Running xcp_d version {__version__}:
         dummytime=opts.dummytime,
         fd_thresh=opts.fd_thresh,
         process_surfaces=opts.process_surfaces,
+        dcan_qc=opts.dcan_qc,
         input_type=opts.input_type,
         name="xcpd_wf",
     )

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -493,6 +493,13 @@ By default, this workflow is disabled.
         This file is only created if the input type is "fmriprep" or "nibabies".
 """
     )
+    g_experimental.add_argument(
+        "--dcan-qc",
+        action="store_true",
+        dest="dcan_qc",
+        default=False,
+        help="Run DCAN QC, including executive summary generation.",
+    )
 
     return parser
 
@@ -652,6 +659,7 @@ def main():
             output_dir=output_dir,
             run_uuid=run_uuid,
             combineruns=opts.combineruns,
+            dcan_qc=opts.dcan_qc,
             input_type=opts.input_type,
             cifti=opts.cifti,
             config=pkgrf("xcp_d", "data/reports.yml"),

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -495,6 +495,7 @@ By default, this workflow is disabled.
     )
     g_experimental.add_argument(
         "--dcan-qc",
+        "--dcan_qc",
         action="store_true",
         dest="dcan_qc",
         default=False,

--- a/xcp_d/data/reports.yml
+++ b/xcp_d/data/reports.yml
@@ -13,6 +13,14 @@ sections:
     title: White Matter and Pial Ribbons
     caption: This panel is an interactive figure rendering the white matter and pial surfaces on the T1w image.
     static: false
+  - bids:
+      datatype: figures
+      desc: brainplot
+      extension: [.svg]
+      suffix: T1w
+    title: White Matter and Pial Ribbons
+    caption: This panel shows the white matter and pial surfaces on the T1w image.
+    static: true
 - name: Processing Summary
   ordering: session,task,acquisition,ceagent,reconstruction,direction,run,echo
   reportlets:
@@ -43,9 +51,9 @@ sections:
       datatype: figures
       desc: alffVolumetricPlot
       suffix: bold
-    caption: ALFF, or amplitude of low frequency fluctuations. Overlaid on T1W image with same entities as the original image. 
+    caption: ALFF, or amplitude of low frequency fluctuations. Overlaid on T1W image with same entities as the original image.
     subtitle: ALFF
-  - bids: 
+  - bids:
       datatype: figures
       desc: rehoVolumetricPlot
       suffix: bold

--- a/xcp_d/interfaces/surfplotting.py
+++ b/xcp_d/interfaces/surfplotting.py
@@ -50,7 +50,7 @@ class _BrainPlotxInputSpec(BaseInterfaceInputSpec):
 
 
 class _BrainPlotxOutputSpec(TraitedSpec):
-    out_html = File(exists=True, mandatory=True, desc="zscore html")
+    plot_file = File(exists=True, mandatory=True, desc="zscore html")
 
 
 class BrainPlotx(SimpleInterface):
@@ -61,17 +61,17 @@ class BrainPlotx(SimpleInterface):
 
     def _run_interface(self, runtime):
 
-        self._results['out_html'] = fname_presuffix(
+        self._results['plot_file'] = fname_presuffix(
             'brainsprite_out_',
             suffix='file.html',
             newpath=runtime.cwd,
             use_ext=False,
         )
 
-        self._results['out_html'] = generate_brain_sprite(
+        self._results['plot_file'] = generate_brain_sprite(
             template_image=self.inputs.template,
             stat_map=self.inputs.in_file,
-            out_file=self._results['out_html'])
+            out_file=self._results['plot_file'])
 
         return runtime
 

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -330,11 +330,11 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
 
                         LOGGER.debug("Starting plot_svgx")
                         plot_svgx(
+                            preprocessed_file=concat_preproc_file,
+                            denoised_file=concat_bold_file,
+                            denoised_filtered_file=concat_bold_file,
                             dummyvols=initial_volumes_to_drop,
                             tmask=outfile,
-                            rawdata=concat_preproc_file,
-                            regressed_data=concat_bold_file,
-                            residual_data=concat_bold_file,
                             filtered_motion=concat_motion_file,
                             raw_dvars=raw_dvars,
                             regressed_dvars=regressed_dvars,

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -1205,7 +1205,9 @@ def plot_ribbon_svg(template, in_file):
     pial_img = math_img("img == 2", img=img)
     both_img = math_img("img == 3", img=img)
 
-    fig = plt.figure(figsize=(25, 10), )
+    fig = plt.figure(
+        figsize=(25, 10),
+    )
     display = plot_anat(
         template,
         draw_cross=False,
@@ -1216,25 +1218,25 @@ def plot_ribbon_svg(template, in_file):
         white_img,
         contours=1,
         antialiased=False,
-        linewidths=1.,
+        linewidths=1.0,
         levels=[0],
-        colors=['purple'],
+        colors=["purple"],
     )
     display.add_contours(
         pial_img,
         contours=1,
         antialiased=False,
-        linewidths=1.,
+        linewidths=1.0,
         levels=[0],
-        colors=['green'],
+        colors=["green"],
     )
     display.add_contours(
         both_img,
         contours=1,
         antialiased=False,
-        linewidths=1.,
+        linewidths=1.0,
         levels=[0],
-        colors=['red'],
+        colors=["red"],
     )
     # We generate a legend using the trick described on
     # http://matplotlib.sourceforge.net/users/legend_guide.httpml#using-proxy-artist

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -1168,6 +1168,7 @@ def plot_ribbon_svg(template, in_file):
 
     import matplotlib.pyplot as plt
     import nibabel as nib
+    import numpy as np
     from matplotlib.patches import Rectangle
     from nilearn.image import math_img
     from nilearn.plotting import plot_anat

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -1160,3 +1160,68 @@ def plot_alff_reho_surface(output_path, filename, bold_file):
     fig.tight_layout()
     fig.savefig(output_path)
     return output_path
+
+
+def plot_ribbon_svg(template, in_file):
+    """Plot the anatomical template and ribbon in a static SVG file."""
+    import os
+
+    import matplotlib.pyplot as plt
+    import nibabel as nib
+    from matplotlib.patches import Rectangle
+    from nilearn.image import math_img
+    from nilearn.plotting import plot_anat
+
+    plot_file = os.path.abspath("ribbon.svg")
+
+    # Set vmax to 95-th percentile of T1w image
+    t1w_img = nib.load(template)
+    vmax = np.percentile(t1w_img.get_fdata(), 95)
+
+    # Coerce to ints
+    img = math_img("img.astype(int)", img=in_file)
+    white_img = math_img("img == 1", img=img)
+    pial_img = math_img("img == 2", img=img)
+    both_img = math_img("img == 3", img=img)
+
+    fig = plt.figure(figsize=(25, 10), )
+    display = plot_anat(
+        template,
+        draw_cross=False,
+        vmax=vmax,
+        figure=fig,
+    )
+    display.add_contours(
+        white_img,
+        contours=1,
+        antialiased=False,
+        linewidths=1.,
+        levels=[0],
+        colors=['purple'],
+    )
+    display.add_contours(
+        pial_img,
+        contours=1,
+        antialiased=False,
+        linewidths=1.,
+        levels=[0],
+        colors=['green'],
+    )
+    display.add_contours(
+        both_img,
+        contours=1,
+        antialiased=False,
+        linewidths=1.,
+        levels=[0],
+        colors=['red'],
+    )
+    # We generate a legend using the trick described on
+    # http://matplotlib.sourceforge.net/users/legend_guide.httpml#using-proxy-artist
+    p1 = Rectangle((0, 0), 1, 1, fc="purple", label="White Matter")
+    p2 = Rectangle((0, 0), 1, 1, fc="green", label="Pial")
+    p3 = Rectangle((0, 0), 1, 1, fc="red", label="Both Somehow")
+    plt.legend([p1, p2, p3], ["White Matter", "Pial", "Both Somehow"], fontsize=18)
+
+    fig.savefig(plot_file, bbox_inches="tight", pad_inches=None)
+    # return fig
+    return plot_file

--- a/xcp_d/workflow/base.py
+++ b/xcp_d/workflow/base.py
@@ -424,6 +424,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
         fmri_dir=fmri_dir,
         subject_id=subject_id,
         output_dir=output_dir,
+        dcan_qc=dcan_qc,
         input_type=input_type,
         omp_nthreads=omp_nthreads,
         mem_gb=5,

--- a/xcp_d/workflow/base.py
+++ b/xcp_d/workflow/base.py
@@ -61,6 +61,7 @@ def init_xcpd_wf(
     dummytime,
     fd_thresh,
     process_surfaces=False,
+    dcan_qc=False,
     input_type='fmriprep',
     name='xcpd_wf',
 ):
@@ -100,6 +101,7 @@ def init_xcpd_wf(
                 dummytime=0,
                 fd_thresh=0.2,
                 process_surfaces=False,
+                dcan_qc=False,
                 input_type='fmriprep',
                 name='xcpd_wf',
             )
@@ -142,6 +144,8 @@ def init_xcpd_wf(
     dummytime: float
         the first vols in seconds to be removed before postprocessing
     %(process_surfaces)s
+    dcan_qc : bool
+        Whether to run DCAN QC or not.
     %(input_type)s
     %(name)s
 
@@ -180,6 +184,7 @@ def init_xcpd_wf(
             custom_confounds=custom_confounds,
             fd_thresh=fd_thresh,
             process_surfaces=process_surfaces,
+            dcan_qc=dcan_qc,
             input_type=input_type,
             name=f"single_subject_{subject_id}_wf",
         )
@@ -218,6 +223,7 @@ def init_subject_wf(
     smoothing,
     custom_confounds,
     process_surfaces,
+    dcan_qc,
     output_dir,
     input_type,
     name,
@@ -253,6 +259,7 @@ def init_subject_wf(
                 smoothing=6.,
                 custom_confounds=None,
                 process_surfaces=False,
+                dcan_qc=False,
                 output_dir=".",
                 input_type="fmriprep",
                 name="single_subject_sub-01_wf",
@@ -289,6 +296,8 @@ def init_subject_wf(
     dummytime: float
         the first vols in seconds to be removed before postprocessing
     %(process_surfaces)s
+    dcan_qc : bool
+        Whether to run DCAN QC or not.
     %(subject_id)s
     %(input_type)s
     %(name)s
@@ -468,6 +477,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
             despike=despike,
             dummytime=dummytime,
             fd_thresh=fd_thresh,
+            dcan_qc=dcan_qc,
             output_dir=output_dir,
             name=f"{'cifti' if cifti else 'nifti'}_postprocess_{i_run}_wf",
         )

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -709,16 +709,20 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
                                   ('outputnode.correlations', 'correlations'),
                                   ('outputnode.timeseries', 'timeseries')]),
     ])
+    # fmt:on
 
     if bandpass_filter:
+        # fmt:off
         workflow.connect([
             (alff_compute_wf, outputnode, [
                 ('outputnode.alff_out', 'alff_out'),
                 ('outputnode.smoothed_alff', 'smoothed_alff'),
             ]),
         ])
+        # fmt:on
 
     # write derivatives
+    # fmt:off
     workflow.connect([
         (consolidate_confounds_node, write_derivative_wf, [('out_file',
                                                             'inputnode.confounds_file')]),
@@ -735,15 +739,17 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
                                            ('outputnode.timeseries', 'inputnode.timeseries')]),
         (qcreport, write_derivative_wf, [('qc_file', 'inputnode.qc_file')]),
     ])
+    # fmt:on
 
     if bandpass_filter:
+        # fmt:off
         workflow.connect([
             (alff_compute_wf, write_derivative_wf, [
                 ('outputnode.alff_out', 'inputnode.alff_out'),
                 ('outputnode.smoothed_alff', 'inputnode.smoothed_alff'),
             ]),
         ])
-    # fmt:on
+        # fmt:on
 
     functional_qc = pe.Node(
         FunctionalSummary(bold_file=bold_file, TR=TR),
@@ -862,43 +868,27 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
             omp_nthreads=omp_nthreads,
         )
 
-        workflow.connect(
-            [
-                (
-                    inputnode,
-                    executivesummary_wf,
-                    [
-                        ("t1w", "inputnode.t1w"),
-                        ("t1seg", "inputnode.t1seg"),
-                        ("bold_file", "inputnode.bold_file"),
-                        ("bold_mask", "inputnode.mask"),
-                        ("mni_to_t1w", "inputnode.mni_to_t1w"),
-                    ],
-                ),
-                (
-                    regression_wf,
-                    executivesummary_wf,
-                    [
-                        ("res_file", "inputnode.regressed_data"),
-                    ],
-                ),
-                (
-                    filtering_wf,
-                    executivesummary_wf,
-                    [
-                        ("filtered_file", "inputnode.residual_data"),
-                    ],
-                ),
-                (
-                    censor_scrub,
-                    executivesummary_wf,
-                    [
-                        ("filtered_motion", "inputnode.filtered_motion"),
-                        ("tmask", "inputnode.tmask"),
-                    ],
-                ),
-            ]
-        )
+        # fmt:off
+        workflow.connect([
+            (inputnode, executivesummary_wf, [
+                ("t1w", "inputnode.t1w"),
+                ("t1seg", "inputnode.t1seg"),
+                ("bold_file", "inputnode.bold_file"),
+                ("bold_mask", "inputnode.mask"),
+                ("mni_to_t1w", "inputnode.mni_to_t1w"),
+            ]),
+            (regression_wf, executivesummary_wf, [
+                ("res_file", "inputnode.regressed_data"),
+            ]),
+            (filtering_wf, executivesummary_wf, [
+                ("filtered_file", "inputnode.residual_data"),
+            ]),
+            (censor_scrub, executivesummary_wf, [
+                ("filtered_motion", "inputnode.filtered_motion"),
+                ("tmask", "inputnode.tmask"),
+            ]),
+        ])
+        # fmt:on
 
     return workflow
 

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -50,6 +50,7 @@ def init_ciftipostprocess_wf(
     dummytime,
     fd_thresh,
     despike,
+    dcan_qc,
     n_runs,
     layout=None,
     name='cifti_process_wf',
@@ -81,6 +82,7 @@ def init_ciftipostprocess_wf(
                 dummytime=0,
                 fd_thresh=0.2,
                 despike=False,
+                dcan_qc=False,
                 n_runs=1,
                 layout=None,
                 name='cifti_postprocess_wf',
@@ -109,6 +111,8 @@ def init_ciftipostprocess_wf(
     %(fd_thresh)s
     despike: bool
         afni depsike
+    dcan_qc : bool
+        Whether to run DCAN QC or not.
     n_runs
     layout : BIDSLayout object
         BIDS dataset layout
@@ -385,16 +389,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         n_procs=omp_nthreads,
     )
 
-    executivesummary_wf = init_execsummary_wf(
-        TR=TR,
-        bold_file=bold_file,
-        layout=layout,
-        output_dir=output_dir,
-        omp_nthreads=omp_nthreads,
-        dummyvols=initial_volumes_to_drop,
-        mem_gb=mem_gbx['timeseries'],
-    )
-
     # Remove TR first:
     if dummytime > 0:
         rm_dummytime = pe.Node(
@@ -616,22 +610,37 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         workflow.connect([
             (alff_compute_wf, ds_report_alffplot, [('outputnode.alffplot', 'in_file')])
         ])
+
     # executive summary workflow
-    workflow.connect([
-        (inputnode, executivesummary_wf, [('t1w', 'inputnode.t1w'),
-                                          ('t1seg', 'inputnode.t1seg'),
-                                          ('bold_file', 'inputnode.bold_file'),
-                                          ('mni_to_t1w', 'inputnode.mni_to_t1w')]),
-        (regression_wf, executivesummary_wf, [('res_file', 'inputnode.regressed_data')
-                                              ]),
-        (filtering_wf, executivesummary_wf, [('filtered_file',
-                                              'inputnode.residual_data')]),
-        (censor_scrub, executivesummary_wf, [('filtered_motion',
-                                              'inputnode.filtered_motion'),
-                                             ('tmask',
-                                              'inputnode.tmask')
-                                             ]),
-    ])
+    if dcan_qc:
+        executivesummary_wf = init_execsummary_wf(
+            TR=TR,
+            bold_file=bold_file,
+            layout=layout,
+            output_dir=output_dir,
+            omp_nthreads=omp_nthreads,
+            dummyvols=initial_volumes_to_drop,
+            mem_gb=mem_gbx['timeseries'],
+        )
+
+        workflow.connect([
+            (inputnode, executivesummary_wf, [
+                ('t1w', 'inputnode.t1w'),
+                ('t1seg', 'inputnode.t1seg'),
+                ('bold_file', 'inputnode.bold_file'),
+                ('mni_to_t1w', 'inputnode.mni_to_t1w'),
+            ]),
+            (regression_wf, executivesummary_wf, [
+                ('res_file', 'inputnode.regressed_data'),
+            ]),
+            (filtering_wf, executivesummary_wf, [
+                ('filtered_file', 'inputnode.residual_data'),
+            ]),
+            (censor_scrub, executivesummary_wf, [
+                ('filtered_motion', 'inputnode.filtered_motion'),
+                ('tmask', 'inputnode.tmask'),
+            ]),
+        ])
 
     return workflow
 

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -21,6 +21,7 @@ from xcp_d.interfaces.surfplotting import (
     RibbontoStatmap,
 )
 from xcp_d.utils.doc import fill_doc
+from xcp_d.utils.plot import plot_ribbon_svg
 from xcp_d.utils.utils import get_std2bold_xforms
 
 LOGGER = logging.getLogger("nipype.workflow")
@@ -32,6 +33,7 @@ def init_brainsprite_wf(
     fmri_dir,
     subject_id,
     output_dir,
+    dcan_qc,
     input_type,
     mem_gb,
     omp_nthreads,
@@ -45,6 +47,8 @@ def init_brainsprite_wf(
     %(fmri_dir)s
     %(subject_id)s
     %(output_dir)s
+    dcan_qc : bool
+        Whether to run DCAN QC or not.
     %(input_type)s
     %(mem_gb)s
     %(omp_nthreads)s
@@ -68,12 +72,27 @@ def init_brainsprite_wf(
         mem_gb=mem_gb,
         n_procs=omp_nthreads,
     )
-    generate_brainsprite = pe.Node(
-        BrainPlotx(),
-        name="brainsprite",
-        mem_gb=mem_gb,
-        n_procs=omp_nthreads,
-    )
+    if dcan_qc:
+        # Create a brainsprite if dcan_qc is True
+        plot_ribbon = pe.Node(
+            BrainPlotx(),
+            name="brainsprite",
+            mem_gb=mem_gb,
+            n_procs=omp_nthreads,
+        )
+    else:
+        # Otherwise, make a static mosaic plot
+        plot_ribbon = pe.Node(
+            Function(
+                input_names=["template", "in_file"],
+                output_names=["plot_file"],
+                function=plot_ribbon_svg,
+            ),
+            name="ribbon_mosaic",
+            mem_gb=mem_gb,
+            n_procs=omp_nthreads,
+        )
+
     ds_brainspriteplot = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
@@ -136,9 +155,9 @@ def init_brainsprite_wf(
 
     workflow.connect(
         [
-            (inputnode, generate_brainsprite, [("t1w", "template")]),
-            (ribbon2statmap, generate_brainsprite, [("out_file", "in_file")]),
-            (generate_brainsprite, ds_brainspriteplot, [("out_html", "in_file")]),
+            (inputnode, plot_ribbon, [("t1w", "template")]),
+            (ribbon2statmap, plot_ribbon, [("out_file", "in_file")]),
+            (plot_ribbon, ds_brainspriteplot, [("plot_file", "in_file")]),
             (inputnode, ds_brainspriteplot, [("t1w", "source_file")]),
         ]
     )


### PR DESCRIPTION
Closes #565 and paves the way for #645.

**The breaking changes are: (1) the executive summary is no longer generated by default, (2) the DCAN HDF5 files are not generated by default when concatenation is performed, and (3) the segmentation plot is no longer a brainsprite by default.**

We still need to build in a way for the DCAN team to generate their own brainsprite, which uses a bash script.

## Changes proposed in this pull request

- Create a new `--dcan-qc` flag. If set, DCAN HDF5 files, the segmentation brainsprite, and the executive summary will be created.

## Documentation that should be reviewed

