### PR TITLE
Ensure `dummyscans` is an integer in PlotSVGData

### DIFF
--- a/.circleci/NiftiWithFreeSurferTest.sh
+++ b/.circleci/NiftiWithFreeSurferTest.sh
@@ -29,6 +29,7 @@ XCPD_CMD=$(run_xcpd_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR} ${TEMPDIR})
 
 $XCPD_CMD \
     --despike \
+    --dummytime 8 \
     --fd-thresh 0.04 \
     --head_radius 40 \
     --smoothing 6 \

--- a/xcp_d/interfaces/surfplotting.py
+++ b/xcp_d/interfaces/surfplotting.py
@@ -135,11 +135,11 @@ class PlotSVGData(SimpleInterface):
         )
 
         self._results['before_process'], self._results['after_process'] = plot_svgx(
+            preprocessed_file=self.inputs.rawdata,
+            denoised_file=self.inputs.regressed_data,
+            denoised_filtered_file=self.inputs.residual_data,
             tmask=self.inputs.tmask,
             dummyvols=self.inputs.dummyvols,
-            rawdata=self.inputs.rawdata,
-            regressed_data=self.inputs.regressed_data,
-            residual_data=self.inputs.residual_data,
             TR=self.inputs.TR,
             mask=self.inputs.mask,
             filtered_motion=self.inputs.filtered_motion,

--- a/xcp_d/interfaces/surfplotting.py
+++ b/xcp_d/interfaces/surfplotting.py
@@ -91,7 +91,10 @@ class _PlotSVGDataInputSpec(BaseInterfaceInputSpec):
     tmask = File(exists=True, mandatory=False, desc="Temporal mask")
     seg_data = File(exists=True, mandatory=False, desc="Segmentation file")
     TR = traits.Float(default_value=1, desc="Repetition time")
-    dummyvols = traits.Float(default_value=0, desc="Dummy volumes to drop")
+    dummyvols = traits.Int(
+        default_value=0,
+        desc="Number of dummy volumes to drop from the beginning of the run.",
+    )
 
 
 class _PlotSVGDataOutputSpec(TraitedSpec):
@@ -117,29 +120,33 @@ class PlotSVGData(SimpleInterface):
 
     def _run_interface(self, runtime):
 
-        self._results['before_process'] = fname_presuffix('carpetplot_before_',
-                                                          suffix='file.svg',
-                                                          newpath=runtime.cwd,
-                                                          use_ext=False)
+        before_process_fn = fname_presuffix(
+            'carpetplot_before_',
+            suffix='file.svg',
+            newpath=runtime.cwd,
+            use_ext=False,
+        )
 
-        self._results['after_process'] = fname_presuffix('carpetplot_after_',
-                                                         suffix='file.svg',
-                                                         newpath=runtime.cwd,
-                                                         use_ext=False)
+        after_process_fn = fname_presuffix(
+            'carpetplot_after_',
+            suffix='file.svg',
+            newpath=runtime.cwd,
+            use_ext=False,
+        )
 
-        self._results['before_process'], self._results[
-            'after_process'] = plot_svgx(
-                tmask=self.inputs.tmask,
-                dummyvols=self.inputs.dummyvols,
-                rawdata=self.inputs.rawdata,
-                regressed_data=self.inputs.regressed_data,
-                residual_data=self.inputs.residual_data,
-                TR=self.inputs.TR,
-                mask=self.inputs.mask,
-                filtered_motion=self.inputs.filtered_motion,
-                seg_data=self.inputs.seg_data,
-                processed_filename=self._results['after_process'],
-                unprocessed_filename=self._results['before_process'])
+        self._results['before_process'], self._results['after_process'] = plot_svgx(
+            tmask=self.inputs.tmask,
+            dummyvols=self.inputs.dummyvols,
+            rawdata=self.inputs.rawdata,
+            regressed_data=self.inputs.regressed_data,
+            residual_data=self.inputs.residual_data,
+            TR=self.inputs.TR,
+            mask=self.inputs.mask,
+            filtered_motion=self.inputs.filtered_motion,
+            seg_data=self.inputs.seg_data,
+            processed_filename=after_process_fn,
+            unprocessed_filename=before_process_fn,
+        )
 
         return runtime
 

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -323,11 +323,11 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
 
                     LOGGER.debug("Starting plot_svgx")
                     plot_svgx(
+                        preprocessed_file=concat_preproc_file,
+                        denoised_file=concat_bold_file,
+                        denoised_filtered_file=concat_bold_file,
                         dummyvols=initial_volumes_to_drop,
                         tmask=outfile,
-                        rawdata=concat_preproc_file,
-                        regressed_data=concat_bold_file,
-                        residual_data=concat_bold_file,
                         filtered_motion=concat_motion_file,
                         raw_dvars=raw_dvars,
                         regressed_dvars=regressed_dvars,

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -475,8 +475,8 @@ def plot_svgx(rawdata,
     tmask_bool = ~tmask_arr.astype(bool)
 
     # Let's remove dummy time from the raw_data if needed
-    if dummyvols > 1:
-        raw_data = raw_data[dummyvols:]
+    if dummyvols > 0:
+        raw_data_arr = raw_data_arr[:, dummyvols:]
 
     # Let's censor the interpolated data and raw_data:
     if sum(tmask_arr) > 0:

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -1,7 +1,7 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Plotting tools."""
-
+import os
 import tempfile
 
 import matplotlib.cm as cm
@@ -517,11 +517,13 @@ def plot_svgx(rawdata,
         'Mean': np.nanmean(raw_data_arr, axis=0),
         'Std': np.nanstd(raw_data_arr, axis=0)
     })
+
     # The mean and standard deviation of filtered data
     processed_data_timeseries = pd.DataFrame({
-        'Mean': np.nanmean(residual_data, axis=0),
-        'Std': np.nanstd(residual_data, axis=0)
+        'Mean': np.nanmean(filtered_data_arr, axis=0),
+        'Std': np.nanstd(filtered_data_arr, axis=0)
     })
+
     if seg_data is not None:
         atlaslabels = nb.load(seg_data).get_fdata()
     else:
@@ -533,11 +535,11 @@ def plot_svgx(rawdata,
 
     # Make a temporary file for niftis and ciftis
     if rawdata.endswith('.nii.gz'):
-        scaledrawdata = tempfile.mkdtemp() + '/filex_raw.nii.gz'
-        scaledresdata = tempfile.mkdtemp() + '/filex_red.nii.gz'
+        scaledrawdata = os.path.join(tempfile.mkdtemp(), 'filex_raw.nii.gz')
+        scaledresdata = os.path.join(tempfile.mkdtemp(), 'filex_red.nii.gz')
     else:
-        scaledrawdata = tempfile.mkdtemp() + '/filex_raw.dtseries.nii'
-        scaledresdata = tempfile.mkdtemp() + '/filex_red.dtseries.nii'
+        scaledrawdata = os.path.join(tempfile.mkdtemp(), 'filex_raw.dtseries.nii')
+        scaledresdata = os.path.join(tempfile.mkdtemp(), 'filex_red.dtseries.nii')
 
     # Write out the scaled data
     scaledrawdata = write_ndata(data_matrix=scaled_raw_data,

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -253,10 +253,12 @@ def init_execsummary_wf(omp_nthreads,
         mem_gb=mem_gb * 3 * omp_nthreads)
 
     # Plot the SVG files
-    plot_svgx_wf = pe.Node(PlotSVGData(TR=TR, rawdata=bold_file, dummyvols=dummyvols),
-                           name='plot_svgx_wf',
-                           mem_gb=mem_gb,
-                           n_procs=omp_nthreads)
+    plot_svgx_wf = pe.Node(
+        PlotSVGData(TR=TR, rawdata=bold_file, dummyvols=dummyvols),
+        name='plot_svgx_wf',
+        mem_gb=mem_gb,
+        n_procs=omp_nthreads,
+    )
 
     # Write out the necessary files:
     # Reference file


### PR DESCRIPTION
This stems from https://neurostars.org/t/question-about-xcp-d/23945/8. It looks like dummyscans (dummytime / TR) is treated as a float in PlotSVGData, which (I think) breaks indexing.

## Changes proposed in this pull request

- Make `dummyscans` input to `PlotSVGData` an integer, instead of a float.
- Drop `dummyscans` along time axis, rather than space axis, in raw data within `PlotSVGData`.
- Drop `dummyscans` if > 0, not > 1, in `PlotSVGData`.

## Documentation that should be reviewed

None
