### PR TITLE
Remove dummy volumes from custom confounds files

### DIFF
--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -134,10 +134,8 @@ class RemoveTR(SimpleInterface):
 
         # Drop the first N rows from the custom confounds file, if provided:
         if self.inputs.custom_confounds:
-            custom_confounds_tsv_undropped = pd.read_table(self.inputs.custom_confounds)
-            custom_confounds_tsv_dropped = custom_confounds_tsv_undropped.loc[
-                np.arange(volumes_to_drop)
-            ]
+            custom_confounds_df = pd.read_table(self.inputs.custom_confounds)
+            custom_confounds_tsv_dropped = custom_confounds_df.drop[np.arange(volumes_to_drop)]
         else:
             LOGGER.warning("No custom confounds were found or had their volumes dropped.")
 


### PR DESCRIPTION
In RemoveTR, the step that removes dummy volumes from custom confounds files was actually only _retaining_ the dummy volumes, instead of dropping them.

## Changes proposed in this pull request
Drop dummy volumes, instead of keeping _only_ dummy volumes, in custom confounds file.
