### PR TITLE
Remove dummy volumes from beginning of each run in concatenation workflow

### DIFF
--- a/.circleci/CiftiWithFreeSurferTest.sh
+++ b/.circleci/CiftiWithFreeSurferTest.sh
@@ -40,4 +40,5 @@ $XCPD_CMD \
     --cifti \
     --combineruns \
     --dcan-qc \
-    --dummytime 8
+    --dummytime 8 \
+    --fd-thresh 0.04

--- a/.circleci/CiftiWithFreeSurferTest.sh
+++ b/.circleci/CiftiWithFreeSurferTest.sh
@@ -31,10 +31,13 @@ XCPD_CMD=$(run_xcpd_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR} ${TEMPDIR})
 echo $XCPD_CMD
 
 $XCPD_CMD \
-    --despike --head_radius 40 \
-    --smoothing 6 -vvv \
+    --despike \
+    --head_radius 40 \
+    --smoothing 6 \
+    -vvv \
     --motion-filter-type lp --band-stop-min 6 \
     --warp-surfaces-native2std \
     --cifti \
     --combineruns \
-    --dcan-qc
+    --dcan-qc \
+    --dummytime 8

--- a/xcp_d/interfaces/surfplotting.py
+++ b/xcp_d/interfaces/surfplotting.py
@@ -129,8 +129,8 @@ class PlotSVGData(SimpleInterface):
 
         self._results["before_process"], self._results["after_process"] = plot_svgx(
             preprocessed_file=self.inputs.rawdata,
-            denoised_file=self.inputs.regressed_data,
-            denoised_filtered_file=self.inputs.residual_data,
+            residuals_file=self.inputs.regressed_data,
+            denoised_file=self.inputs.residual_data,
             tmask=self.inputs.tmask,
             dummyvols=self.inputs.dummyvols,
             TR=self.inputs.TR,

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -15,6 +15,7 @@ from nipype import logging
 from pkg_resources import resource_filename as _pkgres
 
 from xcp_d.utils.bids import _get_tr
+from xcp_d.utils.modified_data import _drop_dummy_scans
 from xcp_d.utils.plot import plot_svgx
 from xcp_d.utils.qcmetrics import compute_dvars
 from xcp_d.utils.utils import get_segfile

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -331,7 +331,6 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                         for bold_file in bold_files:
                             dvar = compute_dvars(read_ndata(bold_file.path, mask))
                             dvar[0] = np.mean(dvar)
-                            dvar = dvar[dummy_scans:]
                             denoised_dvars.append(dvar)
                         denoised_dvars = np.concatenate(denoised_dvars)
                         # Censor DVARS

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -320,6 +320,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                         for preproc_file in preproc_files:
                             dvar = compute_dvars(read_ndata(preproc_file.path, mask))
                             dvar[0] = np.mean(dvar)
+                            dvar = dvar[dummy_scans:]
                             raw_dvars.append(dvar)
                         raw_dvars = np.concatenate(raw_dvars)
                         # Censor DVARS
@@ -330,6 +331,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                         for bold_file in bold_files:
                             dvar = compute_dvars(read_ndata(bold_file.path, mask))
                             dvar[0] = np.mean(dvar)
+                            dvar = dvar[dummy_scans:]
                             denoised_dvars.append(dvar)
                         denoised_dvars = np.concatenate(denoised_dvars)
                         # Censor DVARS
@@ -359,7 +361,6 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                             validate=False,
                         )
 
-                        # Build figures
                         LOGGER.debug("Starting plot_svgx")
                         plot_svgx(
                             preprocessed_file=concat_preproc_file,

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -249,6 +249,7 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                             **space_entities,
                         )
                         TR = _get_tr(preproc_files[0].path)
+                        dummy_scans = int(np.ceil(dummytime / TR))
 
                         concat_preproc_file = os.path.join(
                             tmpdir,
@@ -261,7 +262,11 @@ def concatenate_derivatives(dummytime, fmridir, outputdir, work_dir, subjects, c
                             f"Concatenating preprocessed file ({concat_preproc_file}) from\n"
                             f"{preproc_files_str}"
                         )
-                        _concatenate_niimgs(preproc_files, concat_preproc_file)
+                        _concatenate_niimgs(
+                            preproc_files,
+                            concat_preproc_file,
+                            dummy_scans=dummy_scans,
+                        )
 
                         # Extract mask and segmentation files, if necessary
                         if not cifti:

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -141,9 +141,7 @@ def _drop_dummy_scans(bold_file, dummy_scans):
         ]
         new_total_volumes = dropped_data.shape[0]
         dropped_time_axis = time_axis[:new_total_volumes]
-        dropped_header = nb.cifti2.Cifti2Header.from_axes(
-            (dropped_time_axis, brain_model_axis)
-        )
+        dropped_header = nb.cifti2.Cifti2Header.from_axes((dropped_time_axis, brain_model_axis))
         dropped_image = nb.Cifti2Image(
             dropped_data, header=dropped_header, nifti_header=bold_image.nifti_header
         )

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -51,8 +51,8 @@ def generate_mask(fd_res, fd_thresh):
     tmask : numpy.ndarray of shape (T)
         The temporal mask. Zeros are low-motion volumes. Ones are high-motion volumes.
     """
-    tmask = np.zeros(len(fd_res), dtype=bool)
-    tmask[fd_res > fd_thresh] = True
+    tmask = np.zeros(len(fd_res), dtype=int)
+    tmask[fd_res > fd_thresh] = 1
 
     return tmask
 

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -114,15 +114,14 @@ def interpolate_masked_data(bold_data, tmask, TR=1):
     return bold_data_interpolated
 
 
-def _drop_dummy_scans(bold_file, dummy_scans=None):
+def _drop_dummy_scans(bold_file, dummy_scans):
     """Remove the first X volumes from a BOLD file.
 
     Parameters
     ----------
     bold_file : str
         Path to a nifti or cifti file.
-    dummy_scans : None or int, optional
-        If None (default), no volumes will be removed.
+    dummy_scans : int
         If an integer, the first ``dummy_scans`` volumes will be removed.
 
     Returns
@@ -132,8 +131,6 @@ def _drop_dummy_scans(bold_file, dummy_scans=None):
     """
     # read the bold file
     bold_image = nb.load(bold_file)
-    if dummy_scans is None:
-        return bold_image
 
     data = bold_image.get_fdata()
 

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -1,6 +1,7 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Functions for interpolating over high-motion volumes."""
+import nibabel as nb
 import numpy as np
 
 from xcp_d.utils.doc import fill_doc
@@ -111,3 +112,49 @@ def interpolate_masked_data(bold_data, tmask, TR=1):
             bold_data_interpolated[voxel, (tmask == 1)] = interpolated_data[tmask == 1]
 
     return bold_data_interpolated
+
+
+def _drop_dummy_scans(bold_file, dummy_scans=None):
+    """Remove the first X volumes from a BOLD file.
+
+    Parameters
+    ----------
+    bold_file : str
+        Path to a nifti or cifti file.
+    dummy_scans : None or int, optional
+        If None (default), no volumes will be removed.
+        If an integer, the first ``dummy_scans`` volumes will be removed.
+
+    Returns
+    -------
+    dropped_image : img_like
+        The BOLD image, with the first X volumes removed.
+    """
+    # read the bold file
+    bold_image = nb.load(bold_file)
+    if dummy_scans is None:
+        return bold_image
+
+    data = bold_image.get_fdata()
+
+    if bold_image.ndim == 2:  # cifti
+        dropped_data = data[dummy_scans:, ...]  # time series is the first element
+        time_axis, brain_model_axis = [
+            bold_image.header.get_axis(i) for i in range(bold_image.ndim)
+        ]
+        new_total_volumes = dropped_data.shape[0]
+        dropped_time_axis = time_axis[:new_total_volumes]
+        dropped_header = nb.cifti2.Cifti2Header.from_axes(
+            (dropped_time_axis, brain_model_axis)
+        )
+        dropped_image = nb.Cifti2Image(
+            dropped_data, header=dropped_header, nifti_header=bold_image.nifti_header
+        )
+
+    else:  # nifti
+        dropped_data = data[..., dummy_scans:]
+        dropped_image = nb.Nifti1Image(
+            dropped_data, affine=bold_image.affine, header=bold_image.header
+        )
+
+    return dropped_image


### PR DESCRIPTION
Currently, the concatenation workflow removes dummy volumes from the beginning of the concatenated preprocessed BOLD data within `plot_svgx`. This misses the dummy volumes at the beginning of each run after the first, as they are buried in the middle of the concatenated time series.

## Changes proposed in this pull request
- Add a `dummy_scans` parameter to `_concatenate_niimgs`.
- Create a new function, `_drop_dummy_scans`, to remove dummy volumes from BOLD files. This will be used by both `RemoveTR` (in the main workflow) and `_concatenate_niimgs` (in the concatenation workflow, with `--dcan-qc` enabled).
- Only concatenate preprocessed files, calculate preprocessed and post-processed data DVARS, and flag segmentation and mask files, if `dcan_qc` is enabled.
- Remove dummy volumes from preprocessed DVARS.
- Mask the pre- and post-processed DVARS with the outlier mask.
