### PR TITLE
Consolidate confounds at beginning of denoising workflows

### DIFF
--- a/.circleci/tests/test_FD.py
+++ b/.circleci/tests/test_FD.py
@@ -43,6 +43,7 @@ def test_fd_interface_cifti(data_dir, tmp_path_factory):
     cscrub.inputs.band_stop_min = 0
     cscrub.inputs.band_stop_max = 0
     cscrub.inputs.fmriprep_confounds_file = confounds_tsv
+    cscrub.inputs.confounds_file = confounds_tsv
     cscrub.inputs.head_radius = 50
     results = cscrub.run(cwd=tmpdir)
 
@@ -54,9 +55,7 @@ def test_fd_interface_cifti(data_dir, tmp_path_factory):
 
     # Load in censored image and confounds tsv
     censored_image = nb.load(results.outputs.bold_censored)
-    censored_confounds_timeseries = pd.read_table(
-        results.outputs.fmriprep_confounds_censored
-    )
+    censored_confounds_timeseries = pd.read_table(results.outputs.fmriprep_confounds_censored)
     # Assert the length of the confounds is the same as the nvol of the image
     if censored_confounds_timeseries.shape[0] != censored_image.get_fdata().shape[0]:
         raise Exception(
@@ -101,6 +100,7 @@ def test_fd_interface_nifti(data_dir, tmp_path_factory):
     cscrub.inputs.band_stop_min = 0
     cscrub.inputs.band_stop_max = 0
     cscrub.inputs.fmriprep_confounds_file = confounds_tsv
+    cscrub.inputs.confounds_file = confounds_tsv
     cscrub.inputs.head_radius = 50
     results = cscrub.run(cwd=tmpdir)
 
@@ -112,9 +112,7 @@ def test_fd_interface_nifti(data_dir, tmp_path_factory):
 
     # Load in censored image and confounds tsv
     censored_image = nb.load(results.outputs.bold_censored)
-    censored_confounds_timeseries = pd.read_table(
-        results.outputs.fmriprep_confounds_censored
-    )
+    censored_confounds_timeseries = pd.read_table(results.outputs.fmriprep_confounds_censored)
 
     # Assert the length of the confounds is the same as the nvol of the image
     if censored_confounds_timeseries.shape[0] != censored_image.get_fdata().shape[3]:
@@ -155,7 +153,7 @@ def test_fd_interface_nifti(data_dir, tmp_path_factory):
 #     cscrub.inputs.band_stop_min = 0
 #     cscrub.inputs.band_stop_max = 0
 #     cscrub.inputs.fmriprep_confounds_file = confounds_tsv
-#     cscrub.inputs.custom_confounds = custom_confounds_tsv
+#     cscrub.inputs.confounds_file = custom_confounds_tsv
 #     cscrub.inputs.head_radius = 50
 #     results = cscrub.run()
 #     # Load in censored image and confounds tsv
@@ -196,7 +194,7 @@ def test_fd_interface_nifti(data_dir, tmp_path_factory):
 #     cscrub.inputs.band_stop_min = 0
 #     cscrub.inputs.band_stop_max = 0
 #     cscrub.inputs.fmriprep_confounds_file = confounds_tsv
-#     cscrub.inputs.custom_confounds = custom_confounds_tsv
+#     cscrub.inputs.confounds_file = custom_confounds_tsv
 #     cscrub.inputs.head_radius = 50
 #     results = cscrub.run()
 #     # Load in censored image and confounds tsv

--- a/.circleci/tests/test_Reg.py
+++ b/.circleci/tests/test_Reg.py
@@ -5,8 +5,8 @@ import numpy as np
 import scipy
 
 from xcp_d.interfaces.regression import Regress
-from xcp_d.utils.write_save import read_ndata
 from xcp_d.utils.confounds import load_confound_matrix
+from xcp_d.utils.write_save import read_ndata
 
 
 def test_regression_nifti(data_dir, tmp_path_factory):

--- a/.circleci/tests/test_Reg.py
+++ b/.circleci/tests/test_Reg.py
@@ -38,7 +38,7 @@ def test_Reg_Nifti(data_dir):
     )
     results = test_nifti.run()
     # Read in confounds
-    df = load_confound_matrix(in_file, confound_tsv=confounds, params="36P")
+    df = load_confound_matrix(confound_tsv=confounds, params="36P")
     assert df.shape[1] == 36
 
     # Loop through each column in the confounds matrix, creating a list of
@@ -94,7 +94,7 @@ def test_Reg_Cifti(data_dir):
     results = test_cifti.run()
 
     # Read in confounds
-    df = load_confound_matrix(in_file, confound_tsv=confounds, params="36P")
+    df = load_confound_matrix(confound_tsv=confounds, params="36P")
     assert df.shape[1] == 36
     # Loop through each column in the confounds matrix, creating a list of
     # regressors for correlation

--- a/.circleci/tests/test_Reg.py
+++ b/.circleci/tests/test_Reg.py
@@ -9,11 +9,13 @@ from xcp_d.utils.write_save import read_ndata
 from xcp_d.utils.confounds import load_confound_matrix
 
 
-def test_Reg_Nifti(data_dir):
+def test_regression_nifti(data_dir, tmp_path_factory):
     """Test NIFTI regression."""
-    data_dir = os.path.join(data_dir,
-                            "fmriprepwithfreesurfer")
-    #  Specify inputs
+    data_dir = os.path.join(data_dir, "fmriprepwithfreesurfer")
+    temp_dir = tmp_path_factory.mktemp("test_regression_nifti")
+
+    # Specify inputs
+    TR = 0.5
     in_file = (
         data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz"
@@ -22,24 +24,27 @@ def test_Reg_Nifti(data_dir):
         data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-2_desc-confounds_timeseries.tsv"
     )
-    TR = 0.5
     mask = (
         data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
     )
+
+    # Read in confounds. Confounds must be selected before running Regress.
+    df = load_confound_matrix(confound_tsv=confounds, params="36P")
+    assert df.shape[1] == 36
+    selected_confounds_file = os.path.join(temp_dir, "temp.tsv")
+    df.to_csv(selected_confounds_file, sep="\t", index=False)
+
     # Run regression
-    test_nifti = Regress(
+    regression = Regress(
         mask=mask,
         in_file=in_file,
         original_file=in_file,
-        confounds=confounds,
+        confounds=selected_confounds_file,
         TR=TR,
         params="36P",
     )
-    results = test_nifti.run()
-    # Read in confounds
-    df = load_confound_matrix(confound_tsv=confounds, params="36P")
-    assert df.shape[1] == 36
+    results = regression.run(cwd=temp_dir)
 
     # Loop through each column in the confounds matrix, creating a list of
     # regressors for correlation
@@ -63,39 +68,47 @@ def test_Reg_Nifti(data_dir):
     assert (max(regressed_correlations)) < 0.01
 
 
-def test_Reg_Cifti(data_dir):
+def test_regression_cifti(data_dir, tmp_path_factory):
     """Test CIFTI regression."""
     # Specify inputs
-    data_dir = os.path.join(data_dir,
-                            "fmriprepwithfreesurfer")
-    in_file = (
-        data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
-        "sub-colornest001_ses-1_task-rest_run-1_space-fsLR_den-91k_bold.dtseries.nii"
-    )
-    confounds = (
-        data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
-        "sub-colornest001_ses-1_task-rest_run-1_desc-confounds_timeseries.tsv"
-    )
+    data_dir = os.path.join(data_dir, "fmriprepwithfreesurfer")
+    temp_dir = tmp_path_factory.mktemp("test_regression_cifti")
+
     TR = 0.5
-    mask = (
-        data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
-        "sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
+    in_file = os.path.join(
+        data_dir,
+        "fmriprep/sub-colornest001/ses-1/func",
+        "sub-colornest001_ses-1_task-rest_run-1_space-fsLR_den-91k_bold.dtseries.nii",
     )
+    confounds = os.path.join(
+        data_dir,
+        "fmriprep/sub-colornest001/ses-1/func",
+        "sub-colornest001_ses-1_task-rest_run-1_desc-confounds_timeseries.tsv",
+    )
+    mask = os.path.join(
+        data_dir,
+        "fmriprep/sub-colornest001/ses-1/func",
+        "sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz",
+    )
+
+    # Read in confounds. Confounds must be selected before running Regress.
+    df = load_confound_matrix(confound_tsv=confounds, params="36P")
+    assert df.shape[1] == 36
+    selected_confounds_file = os.path.join(temp_dir, "temp.tsv")
+    df.to_csv(selected_confounds_file, sep="\t", index=False)
+
     # Run regression
-    test_cifti = Regress(
+    regression = Regress(
         mask=mask,
         in_file=in_file,
         original_file=in_file,
-        confounds=confounds,
+        confounds=selected_confounds_file,
         TR=TR,
         params="36P",
     )
+    regression.base_dir = temp_dir
+    results = regression.run(cwd=temp_dir)
 
-    results = test_cifti.run()
-
-    # Read in confounds
-    df = load_confound_matrix(confound_tsv=confounds, params="36P")
-    assert df.shape[1] == 36
     # Loop through each column in the confounds matrix, creating a list of
     # regressors for correlation
     list_of_regressors = []

--- a/.circleci/tests/test_Reg.py
+++ b/.circleci/tests/test_Reg.py
@@ -39,7 +39,6 @@ def test_regression_nifti(data_dir, tmp_path_factory):
     regression = Regress(
         mask=mask,
         in_file=in_file,
-        original_file=in_file,
         confounds=selected_confounds_file,
         TR=TR,
         params="36P",
@@ -101,7 +100,6 @@ def test_regression_cifti(data_dir, tmp_path_factory):
     regression = Regress(
         mask=mask,
         in_file=in_file,
-        original_file=in_file,
         confounds=selected_confounds_file,
         TR=TR,
         params="36P",

--- a/.circleci/tests/test_TR.py
+++ b/.circleci/tests/test_TR.py
@@ -17,22 +17,27 @@ from xcp_d.interfaces.prepostcleaning import RemoveTR
 def test_RemoveTR_nifti(data_dir):
     """Test RemoveTR() for NIFTI input data."""
     # Define inputs
-    data_dir = os.path.join(data_dir,
-                            "fmriprepwithoutfreesurfer/fmriprep/")
-    boldfile = data_dir + "sub-01/func/" \
+    data_dir = os.path.join(data_dir, "fmriprepwithoutfreesurfer/fmriprep/")
+    boldfile = (
+        data_dir + "sub-01/func/"
         "sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz"
-    confounds_file = data_dir + "sub-01/func/" \
+    )
+    confounds_file = (
+        data_dir + "sub-01/func/"
         "sub-01_task-mixedgamblestask_run-1_desc-confounds_timeseries.tsv"
+    )
 
     # Find the original number of volumes acc. to nifti & confounds timeseries
-    original_confounds = pd.read_csv(confounds_file, sep="\t")
+    original_confounds = pd.read_table(confounds_file)
     original_nvols_nifti = nb.load(boldfile).get_fdata().shape[3]
 
     # Test a nifti file with 0 volumes to remove
     remove_nothing = RemoveTR(
         bold_file=boldfile,
         fmriprep_confounds_file=confounds_file,
-        dummy_scans=0)
+        confounds_file=confounds_file,
+        dummy_scans=0,
+    )
     results = remove_nothing.run()
     undropped_confounds = pd.read_table(results.outputs.fmriprep_confounds_file_dropped_TR)
     # Were the files created?
@@ -41,15 +46,15 @@ def test_RemoveTR_nifti(data_dir):
     # Have the confounds stayed the same shape?
     assert undropped_confounds.shape == original_confounds.shape
     # Has the nifti stayed the same shape?
-    assert nb.load(results.
-                   outputs.bold_file_dropped_TR).get_fdata().shape[3] == original_nvols_nifti
+    assert (
+        nb.load(results.outputs.bold_file_dropped_TR).get_fdata().shape[3] == original_nvols_nifti
+    )
 
     # Test a nifti file with 1-10 volumes to remove
     for n in range(0, 10):
         remove_n_vols = RemoveTR(
-            bold_file=boldfile,
-            fmriprep_confounds_file=confounds_file,
-            dummy_scans=n)
+            bold_file=boldfile, fmriprep_confounds_file=confounds_file, dummy_scans=n
+        )
         results = remove_n_vols.run()
         dropped_confounds = pd.read_table(results.outputs.fmriprep_confounds_file_dropped_TR)
         # Were the files created?
@@ -59,8 +64,10 @@ def test_RemoveTR_nifti(data_dir):
         assert dropped_confounds.shape[0] == original_confounds.shape[0] - n
         # Has the nifti changed correctly?
         try:
-            assert nb.load(results.outputs.bold_file_dropped_TR).get_fdata().shape[3]\
+            assert (
+                nb.load(results.outputs.bold_file_dropped_TR).get_fdata().shape[3]
                 == original_nvols_nifti - n
+            )
         except Exception as exc:
             exc = nb.load(results.outputs.bold_file_dropped_TR).get_fdata().shape[3]
             print(f"Tests failing at N = {n}.")
@@ -70,22 +77,27 @@ def test_RemoveTR_nifti(data_dir):
 def test_RemoveTR_cifti(data_dir):
     """Test RemoveTR() for CIFTI input data."""
     # Define inputs
-    data_dir = os.path.join(data_dir,
-                            "fmriprepwithfreesurfer")
-    boldfile = data_dir + "/fmriprep/sub-colornest001/ses-1/func/" \
+    data_dir = os.path.join(data_dir, "fmriprepwithfreesurfer")
+    boldfile = (
+        data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-1_space-fsLR_den-91k_bold.dtseries.nii"
-    confounds_file = data_dir + "/fmriprep/sub-colornest001/ses-1/func/" \
+    )
+    confounds_file = (
+        data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-1_desc-confounds_timeseries.tsv"
+    )
 
     # Find the original number of volumes acc. to cifti & confounds timeseries
-    original_confounds = pd.read_csv(confounds_file, sep="\t")
+    original_confounds = pd.read_table(confounds_file)
     original_nvols_cifti = nb.load(boldfile).get_fdata().shape[0]
 
     # Test a cifti file with 0 volumes to remove
     remove_nothing = RemoveTR(
         bold_file=boldfile,
         fmriprep_confounds_file=confounds_file,
-        dummy_scans=0)
+        confounds_file=confounds_file,
+        dummy_scans=0,
+    )
     results = remove_nothing.run()
     undropped_confounds = pd.read_table(results.outputs.fmriprep_confounds_file_dropped_TR)
     # Were the files created?
@@ -94,16 +106,16 @@ def test_RemoveTR_cifti(data_dir):
     # Have the confounds stayed the same shape?
     assert undropped_confounds.shape == original_confounds.shape
     # Has the cifti stayed the same shape?
-    assert nb.load(results.outputs.bold_file_dropped_TR).get_fdata(
-    ).shape[0] == original_nvols_cifti
+    assert (
+        nb.load(results.outputs.bold_file_dropped_TR).get_fdata().shape[0] == original_nvols_cifti
+    )
 
     # Test a cifti file with 1-10 volumes to remove
     for n in range(0, 10):
         remove_n_vols = RemoveTR(
-            bold_file=boldfile,
-            fmriprep_confounds_file=confounds_file,
-            dummy_scans=n)
-#         print(n)
+            bold_file=boldfile, fmriprep_confounds_file=confounds_file, dummy_scans=n
+        )
+        #         print(n)
         results = remove_n_vols.run()
         dropped_confounds = pd.read_table(results.outputs.fmriprep_confounds_file_dropped_TR)
         # Were the files created?
@@ -113,12 +125,15 @@ def test_RemoveTR_cifti(data_dir):
         assert dropped_confounds.shape[0] == original_confounds.shape[0] - n
         # Has the cifti changed correctly?
         try:
-            assert nb.load(results.outputs.bold_file_dropped_TR).get_fdata().shape[0]\
+            assert (
+                nb.load(results.outputs.bold_file_dropped_TR).get_fdata().shape[0]
                 == original_nvols_cifti - n
+            )
         except Exception as exc:
             exc = nb.load(results.outputs.bold_file_dropped_TR).get_fdata().shape[0]
             print(f"Tests failing at N = {n}.")
             raise Exception(f"Number of volumes in dropped cifti is {exc}.")
+
 
 # Testing with CUSTOM CONFOUNDS
 # Note: I had to test this locally as I don't have the permissions to share the

--- a/.circleci/tests/test_TR.py
+++ b/.circleci/tests/test_TR.py
@@ -14,10 +14,12 @@ import pandas as pd
 from xcp_d.interfaces.prepostcleaning import RemoveTR
 
 
-def test_RemoveTR_nifti(data_dir):
+def test_RemoveTR_nifti(data_dir, tmp_path_factory):
     """Test RemoveTR() for NIFTI input data."""
     # Define inputs
     data_dir = os.path.join(data_dir, "fmriprepwithoutfreesurfer/fmriprep/")
+    temp_dir = tmp_path_factory.mktemp("test_RemoveTR_nifti")
+
     boldfile = (
         data_dir + "sub-01/func/"
         "sub-01_task-mixedgamblestask_run-1_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz"
@@ -38,7 +40,7 @@ def test_RemoveTR_nifti(data_dir):
         confounds_file=confounds_file,
         dummy_scans=0,
     )
-    results = remove_nothing.run()
+    results = remove_nothing.run(cwd=temp_dir)
     undropped_confounds = pd.read_table(results.outputs.fmriprep_confounds_file_dropped_TR)
     # Were the files created?
     assert op.exists(results.outputs.bold_file_dropped_TR)
@@ -53,9 +55,12 @@ def test_RemoveTR_nifti(data_dir):
     # Test a nifti file with 1-10 volumes to remove
     for n in range(0, 10):
         remove_n_vols = RemoveTR(
-            bold_file=boldfile, fmriprep_confounds_file=confounds_file, dummy_scans=n
+            bold_file=boldfile,
+            fmriprep_confounds_file=confounds_file,
+            confounds_file=confounds_file,
+            dummy_scans=n,
         )
-        results = remove_n_vols.run()
+        results = remove_n_vols.run(cwd=temp_dir)
         dropped_confounds = pd.read_table(results.outputs.fmriprep_confounds_file_dropped_TR)
         # Were the files created?
         assert op.exists(results.outputs.bold_file_dropped_TR)
@@ -74,10 +79,12 @@ def test_RemoveTR_nifti(data_dir):
             raise Exception(f"Number of volumes in dropped nifti is {exc}.")
 
 
-def test_RemoveTR_cifti(data_dir):
+def test_RemoveTR_cifti(data_dir, tmp_path_factory):
     """Test RemoveTR() for CIFTI input data."""
     # Define inputs
     data_dir = os.path.join(data_dir, "fmriprepwithfreesurfer")
+    temp_dir = tmp_path_factory.mktemp("test_RemoveTR_cifti")
+
     boldfile = (
         data_dir + "/fmriprep/sub-colornest001/ses-1/func/"
         "sub-colornest001_ses-1_task-rest_run-1_space-fsLR_den-91k_bold.dtseries.nii"
@@ -98,7 +105,7 @@ def test_RemoveTR_cifti(data_dir):
         confounds_file=confounds_file,
         dummy_scans=0,
     )
-    results = remove_nothing.run()
+    results = remove_nothing.run(cwd=temp_dir)
     undropped_confounds = pd.read_table(results.outputs.fmriprep_confounds_file_dropped_TR)
     # Were the files created?
     assert op.exists(results.outputs.bold_file_dropped_TR)
@@ -113,10 +120,13 @@ def test_RemoveTR_cifti(data_dir):
     # Test a cifti file with 1-10 volumes to remove
     for n in range(0, 10):
         remove_n_vols = RemoveTR(
-            bold_file=boldfile, fmriprep_confounds_file=confounds_file, dummy_scans=n
+            bold_file=boldfile,
+            fmriprep_confounds_file=confounds_file,
+            confounds_file=confounds_file,
+            dummy_scans=n,
         )
         #         print(n)
-        results = remove_n_vols.run()
+        results = remove_n_vols.run(cwd=temp_dir)
         dropped_confounds = pd.read_table(results.outputs.fmriprep_confounds_file_dropped_TR)
         # Were the files created?
         assert op.exists(results.outputs.bold_file_dropped_TR)
@@ -151,7 +161,7 @@ def test_RemoveTR_cifti(data_dir):
 #     remvtr.inputs.fmriprep_confounds_file = confounds_tsv
 #     remvtr.inputs.custom_confounds = custom_confounds_tsv
 #     remvtr.inputs.dummy_scans = 5
-#     results = remvtr.run()
+#     results = remvtr.run(cwd=temp_dir)
 
 #     # Load in dropped image and confounds tsv
 #     dropped_image = nb.load(results.outputs.bold_file_dropped_TR)
@@ -178,7 +188,7 @@ def test_RemoveTR_cifti(data_dir):
 #     remvtr.inputs.fmriprep_confounds_file = confounds_tsv
 #     remvtr.inputs.custom_confounds = custom_confounds_tsv
 #     remvtr.inputs.dummy_scans = 5
-#     results = remvtr.run()
+#     results = remvtr.run(cwd=temp_dir)
 
 #     # Load in dropped image and confounds tsv
 #     dropped_image = nb.load(results.outputs.bold_file_dropped_TR)

--- a/.circleci/tests/test_confounds.py
+++ b/.circleci/tests/test_confounds.py
@@ -41,17 +41,6 @@ def test_custom_confounds(data_dir, tmp_path_factory):
     )
     custom_confounds.to_csv(custom_confounds_file, sep="\t", index=False)
 
-    bold_file = os.path.join(
-        data_dir,
-        "fmriprep",
-        "sub-colornest001",
-        "ses-1",
-        "func",
-        (
-            "sub-colornest001_ses-1_task-rest_run-1_"
-            "space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz"
-        ),
-    )
     confounds_file = os.path.join(
         data_dir,
         "fmriprep",
@@ -61,7 +50,6 @@ def test_custom_confounds(data_dir, tmp_path_factory):
         "sub-colornest001_ses-1_task-rest_run-1_desc-confounds_timeseries.tsv",
     )
     combined_confounds = load_confound_matrix(
-        original_file=bold_file,
         params="24P",
         confound_tsv=confounds_file,
         custom_confounds=custom_confounds_file,

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -129,7 +129,7 @@ class RemoveTR(SimpleInterface):
 
         # Drop the first N rows from the confounds file
         confounds_df = pd.read_table(self.inputs.confounds_file)
-        confounds_tsv_dropped = confounds_df.drop[np.arange(dummy_scans)]
+        confounds_tsv_dropped = confounds_df.drop(np.arange(dummy_scans))
 
         # Save out results
         dropped_fmriprep_confounds_df.to_csv(

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -138,7 +138,7 @@ class RemoveTR(SimpleInterface):
             index=False,
         )
         confounds_tsv_dropped.to_csv(
-            self._results["confounds_dropped"],
+            self._results["confounds_file_dropped_TR"],
             sep="\t",
             index=False,
         )

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -38,37 +38,36 @@ class _RemoveTRInputSpec(BaseInterfaceInputSpec):
             "and repetition time."
         ),
     )
+    confounds_file = File(
+        exists=True,
+        mandatory=True,
+        desc="TSV file with selected confounds for denoising.",
+    )
     fmriprep_confounds_file = File(
         exists=True,
-        mandatory=False,
-        desc="fmriprep confounds tsv",
-    )
-    custom_confounds = traits.Either(
-        None,
-        File(exists=True),
-        desc="Name of custom confounds file",
-        mandatory=False,
-        usedefault=True,
+        mandatory=True,
+        desc="fMRIPrep confounds tsv. Used for motion-based censoring.",
     )
 
 
 class _RemoveTROutputSpec(TraitedSpec):
+    confounds_file_dropped_TR = File(
+        exists=True,
+        mandatory=True,
+        desc="TSV file with selected confounds for denoising, after removing TRs.",
+    )
+
     fmriprep_confounds_file_dropped_TR = File(
-        exists=True, mandatory=True, desc="fmriprep confounds tsv after removing TRs,"
+        exists=True,
+        mandatory=True,
+        desc="fMRIPrep confounds tsv after removing TRs. Used for motion-based censoring.",
     )
 
     bold_file_dropped_TR = File(
-        exists=True, mandatory=True, desc="bold or cifti with volumes dropped"
+        exists=True,
+        mandatory=True,
+        desc="bold or cifti with volumes dropped",
     )
-
-    custom_confounds_dropped = traits.Either(
-        None,
-        File(exists=True),
-        desc="Custom confounds file with volumes dropped.",
-        mandatory=False,
-        usedefault=True,
-    )
-
     dummy_scans = traits.Int(desc="Number of volumes dropped.")
 
 
@@ -97,53 +96,52 @@ class RemoveTR(SimpleInterface):
             self._results[
                 "fmriprep_confounds_file_dropped_TR"
             ] = self.inputs.fmriprep_confounds_file
+            self._results["confounds_file_dropped_TR"] = self.inputs.confounds_file
             return runtime
 
         # get the file names to output to
-        dropped_bold_file = fname_presuffix(
-            self.inputs.bold_file, newpath=runtime.cwd, suffix="_dropped", use_ext=True
-        )
-        dropped_confounds_file = fname_presuffix(
-            self.inputs.fmriprep_confounds_file,
+        self._results["bold_file_dropped_TR"] = fname_presuffix(
+            self.inputs.bold_file,
             newpath=runtime.cwd,
             suffix="_dropped",
             use_ext=True,
         )
+        self._results["fmriprep_confounds_file_dropped_TR"] = fname_presuffix(
+            self.inputs.fmriprep_confounds_file,
+            newpath=runtime.cwd,
+            suffix="_fmriprepDropped",
+            use_ext=True,
+        )
+        self._results["confounds_file_dropped_TR"] = fname_presuffix(
+            self.inputs.bold_file,
+            suffix="_selected_confounds_dropped.tsv",
+            newpath=os.getcwd(),
+            use_ext=False,
+        )
 
         # Remove the dummy volumes
         dropped_image = _drop_dummy_scans(self.inputs.bold_file, dummy_scans=dummy_scans)
-        dropped_image.to_filename(dropped_bold_file)
+        dropped_image.to_filename(self._results["bold_file_dropped_TR"])
 
         # Drop the first N rows from the pandas dataframe
         fmriprep_confounds_df = pd.read_table(self.inputs.fmriprep_confounds_file)
-        dropped_confounds_df = fmriprep_confounds_df.drop(np.arange(dummy_scans))
+        dropped_fmriprep_confounds_df = fmriprep_confounds_df.drop(np.arange(dummy_scans))
 
-        # Drop the first N rows from the custom confounds file, if provided:
-        if self.inputs.custom_confounds:
-            custom_confounds_df = pd.read_table(self.inputs.custom_confounds)
-            custom_confounds_tsv_dropped = custom_confounds_df.drop[np.arange(dummy_scans)]
-        else:
-            LOGGER.warning("No custom confounds were found or had their volumes dropped.")
+        # Drop the first N rows from the confounds file
+        confounds_df = pd.read_table(self.inputs.confounds_file)
+        confounds_tsv_dropped = confounds_df.drop[np.arange(dummy_scans)]
 
         # Save out results
-        dropped_confounds_df.to_csv(dropped_confounds_file, sep="\t", index=False)
-
-        # Write to output node
-        self._results["bold_file_dropped_TR"] = dropped_bold_file
-        self._results["fmriprep_confounds_file_dropped_TR"] = dropped_confounds_file
-
-        if self.inputs.custom_confounds:
-            self._results["custom_confounds_dropped"] = fname_presuffix(
-                self.inputs.bold_file,
-                suffix="_custom_confounds_dropped.tsv",
-                newpath=os.getcwd(),
-                use_ext=False,
-            )
-            custom_confounds_tsv_dropped.to_csv(
-                self._results["custom_confounds_dropped"],
-                index=False,
-                sep="\t",
-            )
+        dropped_fmriprep_confounds_df.to_csv(
+            self._results["fmriprep_confounds_file_dropped_TR"],
+            sep="\t",
+            index=False,
+        )
+        confounds_tsv_dropped.to_csv(
+            self._results["confounds_dropped"],
+            sep="\t",
+            index=False,
+        )
 
         return runtime
 
@@ -155,17 +153,15 @@ class _CensorScrubInputSpec(BaseInterfaceInputSpec):
         default_value=0.2,
         desc="Framewise displacement threshold. All values above this will be dropped.",
     )
-    custom_confounds = traits.Either(
-        None,
-        File(exists=True),
-        desc="Name of custom confounds file",
-        mandatory=False,
-        usedefault=True,
+    confounds_file = File(
+        exists=True,
+        mandatory=True,
+        desc="File with selected confounds for denoising.",
     )
     fmriprep_confounds_file = File(
         exists=True,
         mandatory=True,
-        desc="fMRIPrep confounds tsv after removing dummy time, if any",
+        desc="fMRIPrep confounds tsv. Used for flagging high-motion volumes.",
     )
     head_radius = traits.Float(mandatory=False, default_value=50, desc="Head radius in mm ")
     motion_filter_type = traits.Either(
@@ -193,13 +189,14 @@ class _CensorScrubOutputSpec(TraitedSpec):
     bold_censored = File(exists=True, mandatory=True, desc="FD-censored bold file")
 
     fmriprep_confounds_censored = File(
-        exists=True, mandatory=True, desc="fmriprep_confounds_tsv censored"
+        exists=True,
+        mandatory=True,
+        desc="fmriprep_confounds_file censored",
     )
-    custom_confounds_censored = traits.Either(
-        None,
-        File(exists=True),
-        desc="Name of censored custom confounds file",
-        usedefault=True,
+    confounds_censored = File(
+        exists=True,
+        mandatory=True,
+        desc="confounds_file censored",
     )
     tmask = File(
         exists=True,
@@ -252,12 +249,9 @@ class CensorScrub(SimpleInterface):
         )
         motion_df["framewise_displacement"] = fd_timeseries_uncensored
 
-        # Read in custom confounds file (if any) and bold file to be censored
+        # Read in confounds file and bold file to be censored
+        confounds_tsv_uncensored = pd.read_table(self.inputs.confounds_file)
         bold_file_uncensored = nb.load(self.inputs.in_file).get_fdata()
-        if self.inputs.custom_confounds:
-            custom_confounds_tsv_uncensored = pd.read_table(self.inputs.custom_confounds)
-        else:
-            LOGGER.warning("No custom confounds were found or censored.")
 
         # Generate temporal mask with all timepoints have FD over threshold
         # set to 1 and then dropped.
@@ -272,15 +266,12 @@ class CensorScrub(SimpleInterface):
                 bold_file_censored = bold_file_uncensored[tmask == 0, :]
 
             fmriprep_confounds_tsv_censored = fmriprep_confounds_tsv_uncensored.loc[tmask == 0]
-            if self.inputs.custom_confounds:
-                # If custom regressors are present
-                custom_confounds_tsv_censored = custom_confounds_tsv_uncensored.loc[tmask == 0]
+            confounds_tsv_censored = confounds_tsv_uncensored.loc[tmask == 0]
 
         else:  # No censoring needed
             bold_file_censored = bold_file_uncensored
             fmriprep_confounds_tsv_censored = fmriprep_confounds_tsv_uncensored
-            if self.inputs.custom_confounds:
-                custom_confounds_tsv_censored = custom_confounds_tsv_uncensored
+            confounds_tsv_censored = confounds_tsv_uncensored
 
         # Turn censored bold into image
         if nb.load(self.inputs.in_file).ndim > 2:
@@ -323,13 +314,12 @@ class CensorScrub(SimpleInterface):
             newpath=runtime.cwd,
             use_ext=False,
         )
-        if self.inputs.custom_confounds:
-            self._results["custom_confounds_censored"] = fname_presuffix(
-                self.inputs.in_file,
-                suffix="_custom_confounds_censored.tsv",
-                newpath=runtime.cwd,
-                use_ext=False,
-            )
+        self._results["confounds_censored"] = fname_presuffix(
+            self.inputs.in_file,
+            suffix="_selected_confounds_censored.tsv",
+            newpath=runtime.cwd,
+            use_ext=False,
+        )
 
         self._results["tmask"] = fname_presuffix(
             self.inputs.in_file,
@@ -366,13 +356,11 @@ class CensorScrub(SimpleInterface):
             header=True,
             sep="\t",
         )
-        if self.inputs.custom_confounds:
-            # Assuming input is tab separated!
-            custom_confounds_tsv_censored.to_csv(
-                self._results["custom_confounds_censored"],
-                index=False,
-                sep="\t",
-            )
+        confounds_tsv_censored.to_csv(
+            self._results["confounds_censored"],
+            index=False,
+            sep="\t",
+        )
         return runtime
 
 

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -21,27 +21,14 @@ LOGGER = logging.getLogger("nipype.interface")
 class _RegressInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc="The bold file to be regressed")
     confounds = File(
-        exists=True, mandatory=True, desc="The fMRIPrep confounds tsv after censoring"
+        exists=True,
+        mandatory=True,
+        desc="The selected confounds for regression, in a TSV file.",
     )
     # TODO: Use Enum maybe?
     params = traits.Str(mandatory=True, desc="Parameter set to use.")
     TR = traits.Float(mandatory=True, desc="Repetition time")
     mask = File(exists=True, mandatory=False, desc="Brain mask for nifti files")
-    original_file = traits.File(
-        exists=True,
-        mandatory=False,
-        desc=(
-            "Name of original bold file- helps load in the confounds "
-            "file down the line using the original path name"
-        ),
-    )
-    custom_confounds = traits.Either(
-        None,
-        File(exists=True),
-        desc="Name of custom confounds file",
-        mandatory=False,
-        usedefault=True,
-    )
 
 
 class _RegressOutputSpec(TraitedSpec):

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -1,7 +1,7 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Regression interfaces."""
-
+import pandas as pd
 from nipype import logging
 from nipype.interfaces.base import (
     BaseInterfaceInputSpec,
@@ -11,7 +11,6 @@ from nipype.interfaces.base import (
     traits,
 )
 
-from xcp_d.utils.confounds import load_confound_matrix
 from xcp_d.utils.filemanip import fname_presuffix
 from xcp_d.utils.utils import demean_detrend_data, linear_regression
 from xcp_d.utils.write_save import despikedatacifti, read_ndata, write_ndata
@@ -66,20 +65,7 @@ class Regress(SimpleInterface):
     def _run_interface(self, runtime):
 
         # Get the confound matrix
-        # Do we have custom confounds?
-        if self.inputs.custom_confounds:
-            confound = load_confound_matrix(
-                original_file=self.inputs.original_file,
-                custom_confounds=self.inputs.custom_confounds,
-                confound_tsv=self.inputs.confounds,
-                params=self.inputs.params,
-            )
-        else:  # No custom confounds
-            confound = load_confound_matrix(
-                original_file=self.inputs.original_file,
-                confound_tsv=self.inputs.confounds,
-                params=self.inputs.params,
-            )
+        confound = pd.read_table(self.inputs.confounds)
 
         confound = confound.to_numpy().T  # Transpose confounds matrix to line up with bold matrix
         # Get the nifti/cifti matrix

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -436,7 +436,7 @@ def load_aroma(confounds_df):
         The AROMA noise components.
     """
     aroma_noise = [c for c in confounds_df.columns if c.startswith("aroma_motion_")]
-    aroma = melodic.drop(aroma_noise, axis=1)
+    aroma = confounds_df.drop(aroma_noise, axis=1)
 
     return aroma
 

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -421,44 +421,21 @@ def load_confound_matrix(original_file, params, custom_confounds=None, confound_
     return confound
 
 
-def load_aroma(datafile):
+def load_aroma(confounds_df):
     """Extract aroma confounds from a confounds TSV file.
 
     Parameters
     ----------
-    datafile : str
-        Path to the preprocessed BOLD file for which to extract AROMA confounds.
+    confounds_df : :obj:`pandas.DataFrame`
+        The confounds DataFrame.
 
     Returns
     -------
-    aroma : pandas.DataFrame
+    pandas.DataFrame
         The AROMA noise components.
     """
-    #  Pull out aroma and melodic_ts files
-    if "space" in os.path.basename(datafile):
-        aroma_noise = datafile.replace(
-            "_space-" + datafile.split("space-")[1], "_AROMAnoiseICs.csv"
-        )
-        melodic_ts = datafile.replace(
-            "_space-" + datafile.split("space-")[1], "_desc-MELODIC_mixing.tsv"
-        )
-    else:
-        aroma_noise = datafile.split("_desc-preproc_bold.nii.gz")[0] + "_AROMAnoiseICs.csv"
-        melodic_ts = datafile.split("_desc-preproc_bold.nii.gz")[0] + "_desc-MELODIC_mixing.tsv"
-    # Load data
-    aroma_noise = np.genfromtxt(
-        aroma_noise,
-        delimiter=",",
-    )
-    aroma_noise = [np.int(i) - 1 for i in aroma_noise]  # change to 0-based index
-
-    # Load in meloditc_ts
-    melodic = pd.read_csv(melodic_ts, header=None, delimiter="\t", encoding="utf-8")
-
-    # Drop aroma_noise from melodic_ts
-    aroma = melodic.drop(aroma_noise, axis=1)
-
-    return aroma
+    aroma_motion_columns = [c for c in confounds_df.columns if c.startswith("aroma_motion_")]
+    return confounds_df[aroma_motion_columns]
 
 
 @fill_doc

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -655,10 +655,9 @@ def consolidate_confounds(
     from xcp_d.utils.confounds import load_confound_matrix
 
     confounds_df = load_confound_matrix(
-        original_file=namesource,
-        custom_confounds=custom_confounds_file,
         confound_tsv=fmriprep_confounds_file,
         params=params,
+        custom_confounds=custom_confounds_file,
     )
 
     out_file = os.path.abspath("confounds.tsv")

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -628,7 +628,6 @@ def demean_detrend_data(data):
 
 def consolidate_confounds(
     fmriprep_confounds_file,
-    namesource,
     params,
     custom_confounds_file=None,
 ):
@@ -638,8 +637,6 @@ def consolidate_confounds(
     ----------
     fmriprep_confounds_file : file
         file to fmriprep confounds tsv
-    namesource : file
-        file to extract entities from
     custom_confounds_file : file
         file to custom confounds tsv
     params : string

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -414,7 +414,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
             ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
         ]),
         (get_custom_confounds_file, consolidate_confounds_node, [
-            ("custom_confounds", "custom_confounds_file"),
+            ("custom_confounds_file", "custom_confounds_file"),
         ]),
     ])
     # fmt:on

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -394,7 +394,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
             input_names=[
                 "fmriprep_confounds_file",
                 "custom_confounds_file",
-                "namesource",
                 "params",
             ],
             output_names=["out_file"],
@@ -412,7 +411,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
             ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
         ]),
         (inputnode, consolidate_confounds_node, [
-            ("bold_file", "namesource"),
             ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
         ]),
         (get_custom_confounds_file, consolidate_confounds_node, [

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -429,7 +429,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     )
 
     regression_wf = pe.Node(
-        Regress(TR=TR, original_file=bold_file, params=params),
+        Regress(TR=TR, params=params),
         name="regression_wf",
         mem_gb=mem_gbx["timeseries"],
         n_procs=omp_nthreads,

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -615,7 +615,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
                 ("confounds_file_dropped_TR", "confounds_file"),
                 # fMRIPrep confounds file is needed for filtered motion.
                 # The selected confounds are not guaranteed to include motion params.
-                ("fmriprep_confounds_file_dropped_TR", "fmriprep_confounds_tsv"),
+                ("fmriprep_confounds_file_dropped_TR", "fmriprep_confounds_file"),
             ]),
             (remove_dummy_scans, censor_report, [
                 ("dummy_scans", "dummy_scans"),

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -455,7 +455,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
                 ("confounds_file_dropped_TR", "confounds_file"),
                 # fMRIPrep confounds file is needed for filtered motion.
                 # The selected confounds are not guaranteed to include motion params.
-                ("fmriprep_confounds_file_dropped_TR", "fmriprep_confounds_tsv"),
+                ("fmriprep_confounds_file_dropped_TR", "fmriprep_confounds_file"),
             ]),
             (remove_dummy_scans, censor_report, [
                 ("dummy_scans", "dummy_scans"),

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -377,7 +377,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
             ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
         ]),
         (get_custom_confounds_file, consolidate_confounds_node, [
-            ("custom_confounds", "custom_confounds_file"),
+            ("custom_confounds_file", "custom_confounds_file"),
         ]),
     ])
     # fmt:on

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -331,13 +331,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         omp_nthreads=omp_nthreads,
     )
 
-    bold_holder_node = pe.Node(
-        niu.IdentityInterface(
-            fields=["bold_file", "fmriprep_confounds_tsv", "custom_confounds"],
-        ),
-        name="bold_holder_node",
-    )
-
     resdsmoothing_wf = init_resd_smoothing(
         mem_gb=mem_gbx["timeseries"],
         smoothing=smoothing,
@@ -373,6 +366,23 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         name="consolidate_confounds_node",
     )
     consolidate_confounds_node.inputs.params = params
+
+    # Load and filter confounds
+    # fmt:off
+    workflow.connect([
+        (inputnode, get_custom_confounds_file, [
+            ("custom_confounds_folder", "custom_confounds_folder"),
+            ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
+        ]),
+        (inputnode, consolidate_confounds_node, [
+            ("bold_file", "namesource"),
+            ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
+        ]),
+        (get_custom_confounds_file, consolidate_confounds_node, [
+            ("custom_confounds", "custom_confounds_file"),
+        ]),
+    ])
+    # fmt:on
 
     plot_design_matrix_node = pe.Node(
         Function(
@@ -433,60 +443,50 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         # fmt:off
         workflow.connect([
             (inputnode, remove_dummy_scans, [
-                ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
                 ("bold_file", "bold_file"),
                 ("dummy_scans", "dummy_scans"),
+                # fMRIPrep confounds file is needed for filtered motion.
+                # The selected confounds are not guaranteed to include motion params.
+                ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
             ]),
-            (get_custom_confounds_file, remove_dummy_scans, [
-                ("custom_confounds_file", "custom_confounds"),
+            (consolidate_confounds_node, remove_dummy_scans, [
+                ("out_file", "confounds_file"),
             ]),
             (remove_dummy_scans, censor_scrub, [
                 ("bold_file_dropped_TR", "in_file"),
-                ("fmriprep_confounds_file_dropped_TR", "fmriprep_confounds_file"),
-                ("custom_confounds_dropped", "custom_confounds"),
+                ("confounds_file_dropped_TR", "confounds_file"),
+                # fMRIPrep confounds file is needed for filtered motion.
+                # The selected confounds are not guaranteed to include motion params.
+                ("fmriprep_confounds_file_dropped_TR", "fmriprep_confounds_tsv"),
             ]),
             (remove_dummy_scans, censor_report, [
                 ("dummy_scans", "dummy_scans"),
             ]),
             (remove_dummy_scans, qcreport, [
                 ("dummy_scans", "dummy_scans"),
-            ])
+            ]),
         ])
         # fmt:on
 
-    else:  # No need to remove TR
+    else:
         # fmt:off
         workflow.connect([
             (inputnode, censor_scrub, [
-                ('fmriprep_confounds_tsv', 'fmriprep_confounds_file'),
                 ('bold_file', 'in_file'),
+                # fMRIPrep confounds file is needed for filtered motion.
+                # The selected confounds are not guaranteed to include motion params.
+                ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
             ]),
-            (get_custom_confounds_file, censor_scrub, [
-                ("custom_confounds_file", "custom_confounds"),
+            (consolidate_confounds_node, censor_scrub, [
+                ("out_file", "confounds_file"),
             ]),
         ])
         # fmt:on
 
     # fmt:off
     workflow.connect([
-        (inputnode, bold_holder_node, [("bold_file", "bold_file")]),
-        (inputnode, get_custom_confounds_file, [
-            ("custom_confounds_folder", "custom_confounds_folder"),
-            ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
-        ]),
-        (censor_scrub, bold_holder_node, [
-            ("fmriprep_confounds_censored", "fmriprep_confounds_tsv"),
-            ("custom_confounds_censored", "custom_confounds"),
-        ]),
-    ])
-    workflow.connect([
-        (inputnode, consolidate_confounds_node, [('bold_file', 'namesource')]),
-        (bold_holder_node, consolidate_confounds_node, [
-            ('fmriprep_confounds_tsv', 'fmriprep_confounds_file'),
-            ('custom_confounds', 'custom_confounds_file'),
-        ]),
-        (consolidate_confounds_node, plot_design_matrix_node, [
-            ("out_file", "design_matrix"),
+        (censor_scrub, plot_design_matrix_node, [
+            ("confounds_censored", "design_matrix"),
         ]),
     ])
     # fmt:on
@@ -500,24 +500,24 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         )
 
         # fmt:off
-        workflow.connect([(censor_scrub, despike3d, [('bold_censored', 'in_file')])])
-        # Censor Scrub:
         workflow.connect([
-            (despike3d, regression_wf, [
-                ('des_file', 'in_file')]),
-            (censor_scrub, regression_wf,
-             [('fmriprep_confounds_censored', 'confounds'),
-              ('custom_confounds_censored', 'custom_confounds')])])
+            (censor_scrub, despike3d, [("bold_censored", "in_file")]),
+            (despike3d, regression_wf, [("des_file", "in_file")]),
+        ])
         # fmt:on
 
-    else:  # If we don't despike
-        # regression workflow
+    else:
         # fmt:off
-        workflow.connect([(censor_scrub, regression_wf,
-                         [('bold_censored', 'in_file'),
-                          ('fmriprep_confounds_censored', 'confounds'),
-                          ('custom_confounds_censored', 'custom_confounds')])])
+        workflow.connect([
+            (censor_scrub, regression_wf, [('bold_censored', 'in_file')]),
+        ])
         # fmt:on
+
+    # fmt:off
+    workflow.connect([
+        (censor_scrub, regression_wf, [('confounds_censored', 'confounds')]),
+    ])
+    # fmt:on
 
     # interpolation workflow
     # fmt:off

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -392,7 +392,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     )
 
     regression_wf = pe.Node(
-        Regress(TR=TR, original_file=bold_file, params=params),
+        Regress(TR=TR, params=params),
         name="regression_wf",
         mem_gb=mem_gbx["timeseries"],
         n_procs=omp_nthreads,

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -357,7 +357,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
             input_names=[
                 "fmriprep_confounds_file",
                 "custom_confounds_file",
-                "namesource",
                 "params",
             ],
             output_names=["out_file"],
@@ -375,7 +374,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
             ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
         ]),
         (inputnode, consolidate_confounds_node, [
-            ("bold_file", "namesource"),
             ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
         ]),
         (get_custom_confounds_file, consolidate_confounds_node, [


### PR DESCRIPTION
Here's what I'm thinking. We currently load the custom confounds, drop dummy volumes from the custom and fMRIPrep confounds, censor the custom and fMRIPrep confounds, then select the desired regressors from the confounds and combine the two files. This means that, when we get around to selecting regressors, we are no longer working on the original fMRIPrep confounds file, so we need the BOLD file to find the confounds' metadata. This is suboptimal, because it's another place where we are splitting up filenames and hardcoding entities to find new files. 

Instead, I want to select and consolidate our regressors at the beginning of the workflows, then remove dummy volumes and censor the files _afterwards_. This allows us to simplify the confound-selection code considerably, since we no longer need the preprocessed BOLD file to select our confounds.
 
## Changes proposed in this pull request

- Remove optional `custom_confounds` input from `RemoveTR` and add required `confounds_file` input.
    - Keep `fmriprep_confounds_file`, because we need to pass this on to `CensorScrub` in order to identify high-motion volumes.
- Remove optional `custom_confounds` input from `CensorScrub` and add required `confounds_file` input.
- Use consolidated confounds in `Regress`, instead of loading the confounds from scratch.
- Remove optional `custom_confounds` and `original_file` inputs from `Regress`.
- Remove unnecessary `bold_holder_node`.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
