### PR TITLE
Downcast >32-bit files to 32-bit

### DIFF
--- a/.circleci/tests/test_prepostcleaning.py
+++ b/.circleci/tests/test_prepostcleaning.py
@@ -3,6 +3,7 @@ import os
 
 import nibabel as nb
 import numpy as np
+import pytest
 
 from xcp_d.interfaces.prepostcleaning import ConvertTo32
 
@@ -70,6 +71,7 @@ def test_conversion_to_32bit_nifti(data_dir, tmp_path_factory):
     assert int32_img.dataobj.dtype == np.int32
 
 
+@pytest.mark.skip(reason="Cannot make a cifti with float64 data.")
 def test_conversion_to_32bit_cifti(data_dir, tmp_path_factory):
     """Convert nifti files to 32-bit."""
     tmpdir = tmp_path_factory.mktemp("test_conversion_to_32bit")

--- a/.circleci/tests/test_prepostcleaning.py
+++ b/.circleci/tests/test_prepostcleaning.py
@@ -1,0 +1,124 @@
+"""Tests for prepostcleaning interfaces."""
+import os
+
+import nibabel as nb
+import numpy as np
+
+from xcp_d.interfaces.prepostcleaning import ConvertTo32
+
+
+def test_conversion_to_32bit_nifti(data_dir, tmp_path_factory):
+    """Convert nifti files to 32-bit."""
+    tmpdir = tmp_path_factory.mktemp("test_conversion_to_32bit")
+
+    data_dir = os.path.join(data_dir, "fmriprepwithfreesurfer")
+    float_file = os.path.join(
+        data_dir,
+        "fmriprep/sub-colornest001/ses-1/func",
+        (
+            "sub-colornest001_ses-1_task-rest_run-1_"
+            "space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz"
+        ),
+    )
+    int_file = os.path.join(
+        data_dir,
+        "fmriprep/sub-colornest001/ses-1/func",
+        "sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz",
+    )
+    float64_file = os.path.join(tmpdir, "float64.nii.gz")
+    int64_file = os.path.join(tmpdir, "int64.nii.gz")
+
+    # Create a float64 image to downcast
+    float_img = nb.load(float_file)
+    float64_img = nb.Nifti1Image(
+        np.random.random(float_img.shape[:3]).astype(np.float64),
+        affine=float_img.affine,
+        header=float_img.header,
+    )
+    float64_img.header.set_data_dtype(np.float64)  # need to set data dtype too
+    assert float64_img.dataobj.dtype == np.float64
+    float64_img.to_filename(float64_file)
+
+    # Create an int64 image to downcast
+    int_img = nb.load(int_file)
+    int64_img = nb.Nifti1Image(
+        np.random.randint(0, 2, size=int_img.shape[:3], dtype=np.int64),
+        affine=int_img.affine,
+        header=int_img.header,
+    )
+    int64_img.header.set_data_dtype(np.int64)  # need to set data dtype too
+    assert int64_img.dataobj.dtype == np.int64
+    int64_img.to_filename(int64_file)
+    int64_img_2 = nb.load(int64_file)
+    assert int64_img_2.dataobj.dtype == np.int64
+
+    # Run converter
+    converter_interface = ConvertTo32()
+    converter_interface.inputs.ref_file = float64_file
+    converter_interface.inputs.bold_mask = int64_file
+    results = converter_interface.run(cwd=tmpdir)
+    float32_file = results.outputs.ref_file
+    int32_file = results.outputs.bold_mask
+
+    # Check that new files were created
+    assert float64_file != float32_file
+    assert int64_file != int32_file
+
+    float32_img = nb.load(float32_file)
+    assert float32_img.dataobj.dtype == np.float32
+    int32_img = nb.load(int32_file)
+    assert int32_img.dataobj.dtype == np.int32
+
+
+def test_conversion_to_32bit_cifti(data_dir, tmp_path_factory):
+    """Convert nifti files to 32-bit."""
+    tmpdir = tmp_path_factory.mktemp("test_conversion_to_32bit")
+
+    data_dir = os.path.join(data_dir, "fmriprepwithfreesurfer")
+    float_file = os.path.join(
+        data_dir,
+        "fmriprep/sub-colornest001/ses-1/func",
+        "sub-colornest001_ses-1_task-rest_run-1_space-fsLR_den-91k_bold.dtseries.nii",
+    )
+    float64_file = os.path.join(tmpdir, "float64.nii.gz")
+    int64_file = os.path.join(tmpdir, "int64.nii.gz")
+
+    # Create a float64 image to downcast
+    float_img = nb.load(float_file)
+    float64_img = nb.Cifti2Image(
+        np.random.random(float_img.shape).astype(np.float64),
+        header=float_img.header,
+        nifti_header=float_img.nifti_header,
+    )
+    float64_img.nifti_header.set_data_dtype(np.float64)  # need to set data dtype too
+    assert float64_img.dataobj.dtype == np.float64
+    float64_img.to_filename(float64_file)
+
+    # Create an int64 image to downcast
+    int64_img = nb.Cifti2Image(
+        np.random.randint(0, 2, size=float_img.shape, dtype=np.int64),
+        header=float_img.header,
+        nifti_header=float_img.nifti_header,
+    )
+    int64_img.nifti_header.set_data_dtype(np.int64)  # need to set data dtype too
+    assert int64_img.dataobj.dtype == np.int64
+    int64_img.to_filename(int64_file)
+    int64_img_2 = nb.load(int64_file)
+    assert int64_img_2.dataobj.dtype == np.int64
+
+    # Run converter
+    converter_interface = ConvertTo32()
+    converter_interface.inputs.ref_file = float64_file
+    converter_interface.inputs.bold_mask = int64_file
+    results = converter_interface.run(cwd=tmpdir)
+    float32_file = results.outputs.ref_file
+    int32_file = results.outputs.bold_mask
+
+    # Check that new files were created
+    assert float64_file != float32_file
+    assert int64_file != int32_file
+
+    float32_img = nb.load(float32_file)
+    assert float32_img.dataobj.dtype == np.float32
+    int32_img = nb.load(int32_file)
+    assert int32_img.dataobj.dtype == np.int32

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -26,6 +26,109 @@ from xcp_d.utils.write_save import read_ndata, write_ndata
 LOGGER = logging.getLogger("nipype.interface")
 
 
+class _Convert64to32InputSpec(BaseInterfaceInputSpec):
+    bold_file = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+    ref_file = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+    bold_mask = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+    t1w = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+    t1seg = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+    t1w_mask = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+
+
+class _Convert64to32OutputSpec(TraitedSpec):
+    bold_file = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+    ref_file = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+    bold_mask = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+    t1w = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+    t1seg = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+    t1w_mask = traits.Either(
+        None,
+        File(exists=True),
+        desc="Name of custom confounds file",
+        mandatory=False,
+        usedefault=True,
+    )
+
+
+class Convert64to32(SimpleInterface):
+    input_spec = _Convert64to32InputSpec
+    output_spec = _Convert64to32OutputSpec
+
+    def _run_interface(self, runtime):
+        if self.inputs.bold_file:
+            img = nb.load(self.inputs.bold_file)
+            if img.dtype == np.float64:
+                ...
+
+        return runtime
+
+
 class _RemoveTRInputSpec(BaseInterfaceInputSpec):
     bold_file = File(exists=True, mandatory=True, desc="Either cifti or nifti ")
     dummy_scans = traits.Either(

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -111,6 +111,7 @@ class _Convert64to32OutputSpec(TraitedSpec):
 
 
 class Convert64to32(SimpleInterface):
+    """Downcast files from >32-bit to 32-bit if necessary."""
     input_spec = _Convert64to32InputSpec
     output_spec = _Convert64to32OutputSpec
 
@@ -126,6 +127,7 @@ class Convert64to32(SimpleInterface):
 
 
 def downcast_to_32(in_file):
+    """Downcast a file from >32-bit to 32-bit if necessary."""
     if in_file is None:
         return in_file
 

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -112,6 +112,7 @@ class _Convert64to32OutputSpec(TraitedSpec):
 
 class Convert64to32(SimpleInterface):
     """Downcast files from >32-bit to 32-bit if necessary."""
+
     input_spec = _Convert64to32InputSpec
     output_spec = _Convert64to32OutputSpec
 

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -162,7 +162,25 @@ def _drop_dummy_scans(bold_file, dummy_scans):
 
 
 def downcast_to_32(in_file):
-    """Downcast a file from >32-bit to 32-bit if necessary."""
+    """Downcast a file from >32-bit to 32-bit if necessary.
+
+    Parameters
+    ----------
+    in_file : None or str
+        Path to a file to downcast.
+        If None, None will be returned.
+        If the file is lower-precision than 32-bit,
+        then it will be returned without modification.
+
+    Returns
+    -------
+    None or str
+        Path to the downcast file.
+        If in_file is None, None will be returned.
+        If in_file is a file with lower than 32-bit precision,
+        then it will be returned without modification.
+        Otherwise, a new path will be returned.
+    """
     if in_file is None:
         return in_file
 
@@ -189,6 +207,7 @@ def downcast_to_32(in_file):
         out_file = fname_presuffix(in_file, newpath=os.getcwd(), suffix="_downcast", use_ext=True)
         img.to_filename(out_file)
     else:
+        raise Exception(dtype)
         out_file = in_file
 
     return out_file

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -207,7 +207,6 @@ def downcast_to_32(in_file):
         out_file = fname_presuffix(in_file, newpath=os.getcwd(), suffix="_downcast", use_ext=True)
         img.to_filename(out_file)
     else:
-        raise Exception(dtype)
         out_file = in_file
 
     return out_file

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -18,7 +18,7 @@ from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.filtering import FilteringData
 from xcp_d.interfaces.prepostcleaning import (
     CensorScrub,
-    Convert64to32,
+    ConvertTo32,
     Interpolate,
     RemoveTR,
 )
@@ -310,7 +310,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     mem_gbx = _create_mem_gb(bold_file)
 
     downcast_data = pe.Node(
-        Convert64to32(),
+        ConvertTo32(),
         name="downcast_data",
         mem_gb=mem_gbx["timeseries"],
         n_procs=omp_nthreads,

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -548,10 +548,8 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     # interpolation workflow
     # fmt:off
     workflow.connect([
-        (downcast_data, interpolate_wf, [
-            ('bold_file', 'bold_file'),
-            ('bold_mask', 'mask_file'),
-        ]),
+        (downcast_data, interpolate_wf, [('bold_file', 'bold_file'),
+                                         ('bold_mask', 'mask_file')]),
         (censor_scrub, interpolate_wf, [('tmask', 'tmask')]),
         (regression_wf, interpolate_wf, [('res_file', 'in_file')])
     ])
@@ -567,10 +565,8 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
 
     # functional connect workflow
     workflow.connect([
-        (downcast_data, fcon_ts_wf, [
-            ('bold_file', 'inputnode.bold_file'),
-            ('ref_file', 'inputnode.ref_file'),
-        ]),
+        (downcast_data, fcon_ts_wf, [('bold_file', 'inputnode.bold_file'),
+                                     ('ref_file', 'inputnode.ref_file')]),
         (inputnode, fcon_ts_wf, [('template_to_t1w', 'inputnode.template_to_t1w'),
                                  ('t1w_to_native', 'inputnode.t1w_to_native')]),
         (filtering_wf, fcon_ts_wf, [('filtered_file', 'inputnode.clean_bold')])

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -459,7 +459,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         # fmt:off
         workflow.connect([
             (inputnode, remove_dummy_scans, [
-                ("bold_file", "bold_file"),
                 ("dummy_scans", "dummy_scans"),
                 # fMRIPrep confounds file is needed for filtered motion.
                 # The selected confounds are not guaranteed to include motion params.
@@ -504,7 +503,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
 
     # fmt:off
     workflow.connect([
-        (inputnode, consolidate_confounds_node, [('bold_file', 'namesource')]),
         (censor_scrub, plot_design_matrix_node, [
             ("confounds_censored", "design_matrix"),
         ]),
@@ -530,11 +528,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         workflow.connect([
             (censor_scrub, despike3d, [('bold_censored', 'in_file')]),
             (despike3d, regression_wf, [('out_file', 'in_file')]),
-            (downcast_data, regression_wf, [('bold_mask', 'mask')]),
-            (censor_scrub, regression_wf, [
-                ('fmriprep_confounds_censored', 'confounds'),
-                ('custom_confounds_censored', 'custom_confounds'),
-            ]),
         ])
         # fmt:on
 
@@ -716,9 +709,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
 
         # fmt:off
         workflow.connect([
-            (inputnode, executivesummary_wf, [
-                ("mni_to_t1w", "inputnode.mni_to_t1w"),
-            ]),
             (downcast_data, executivesummary_wf, [
                 ("t1w", "inputnode.t1w"),
                 ("t1seg", "inputnode.t1seg"),

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -16,7 +16,12 @@ from templateflow.api import get as get_template
 
 from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.filtering import FilteringData
-from xcp_d.interfaces.prepostcleaning import CensorScrub, Convert64to32, Interpolate, RemoveTR
+from xcp_d.interfaces.prepostcleaning import (
+    CensorScrub,
+    Convert64to32,
+    Interpolate,
+    RemoveTR,
+)
 from xcp_d.interfaces.qc_plot import CensoringPlot, QCPlot
 from xcp_d.interfaces.regression import Regress
 from xcp_d.interfaces.report import FunctionalSummary

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -710,6 +710,8 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
                 ("t1seg", "inputnode.t1seg"),
                 ("bold_file", "inputnode.bold_file"),
                 ("bold_mask", "inputnode.mask"),
+            ]),
+            (inputnode, executivesummary_wf, [
                 ("template_to_t1w", "inputnode.template_to_t1w"),
             ]),
             (regression_wf, executivesummary_wf, [

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -16,7 +16,7 @@ from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.filtering import FilteringData
 from xcp_d.interfaces.prepostcleaning import (
     CensorScrub,
-    Convert64to32,
+    ConvertTo32,
     Interpolate,
     RemoveTR,
 )
@@ -275,7 +275,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     mem_gbx = _create_mem_gb(bold_file)
 
     downcast_data = pe.Node(
-        Convert64to32(),
+        ConvertTo32(),
         name="downcast_data",
         mem_gb=mem_gbx["timeseries"],
         n_procs=omp_nthreads,

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -404,7 +404,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
 
     # fmt:off
     workflow.connect([
-        (inputnode, qc_report_wf, [
+        (downcast_data, qc_report_wf, [
             ("bold_file", "inputnode.preprocessed_bold_file"),
         ]),
     ])
@@ -448,13 +448,13 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     else:
         # fmt:off
         workflow.connect([
-            (downcast_data, censor_scrub, [
-                ('bold_file', 'in_file'),
             (inputnode, qc_report_wf, [
                 ("dummy_scans", "inputnode.dummy_scans"),
             ]),
-            (inputnode, censor_scrub, [
+            (downcast_data, censor_scrub, [
                 ('bold_file', 'in_file'),
+            ]),
+            (inputnode, censor_scrub, [
                 # fMRIPrep confounds file is needed for filtered motion.
                 # The selected confounds are not guaranteed to include motion params.
                 ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
@@ -467,15 +467,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
 
     # fmt:off
     workflow.connect([
-        (downcast_data, bold_holder_node, [("bold_file", "bold_file")]),
-        (inputnode, get_custom_confounds_file, [
-            ("custom_confounds_folder", "custom_confounds_folder"),
-            ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
-        ]),
-        (censor_scrub, bold_holder_node, [
-            ("fmriprep_confounds_censored", "fmriprep_confounds_tsv"),
-            ("custom_confounds_censored", "custom_confounds"),
-        ]),
         (censor_scrub, plot_design_matrix_node, [
             ("confounds_censored", "design_matrix"),
         ]),
@@ -541,8 +532,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
 
     # qc report
     workflow.connect([
-        (downcast_data, qc_report_wf, [("bold_file", "bold_file")]),
-        (downcast_data, censor_report, [("bold_file", "bold_file")]),
         (filtering_wf, qc_report_wf, [("filtered_file", "inputnode.cleaned_file")]),
         (censor_scrub, qc_report_wf, [("tmask", "inputnode.tmask")]),
     ])
@@ -660,7 +649,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         # fmt:off
         workflow.connect([
             (inputnode, executivesummary_wf, [
-                ('mni_to_t1w', 'inputnode.mni_to_t1w'),
                 ('template_to_t1w', 'inputnode.template_to_t1w'),
             ]),
             (downcast_data, executivesummary_wf, [

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -460,7 +460,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
             ]),
             (downcast_data, remove_dummy_scans, [
                 ("bold_file", "bold_file"),
-            ])
+            ]),
             (get_custom_confounds_file, remove_dummy_scans, [
                 ("custom_confounds_file", "custom_confounds"),
             ]),
@@ -474,7 +474,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
             ]),
             (remove_dummy_scans, qcreport, [
                 ("dummy_scans", "dummy_scans"),
-            ])
+            ]),
         ])
         # fmt:on
 


### PR DESCRIPTION
Closes #422.

To do:

- [x] Write tests for the new interface

## Changes proposed in this pull request
- Create new function, `xcp_d.utils.modified_data.downcast_to_32`. This function should downcast a nifti or cifti image with either int64 (or higher) or float64 (or higher) to int32 or float32, respectively.
- Create new interface, `xcp_d.interfaces.prepostcleaning.ConvertTo32`. This interface takes specific files in, and downcasts them, as needed, to 32-bit.
- Integrate `ConvertTo32` into nifti and cifti postprocessing workflows.

## Documentation that should be reviewed

