### PR TITLE
Remove unused outputnodes from nifti and cifti workflows

### DIFF
--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -283,25 +283,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     inputnode.inputs.t1w_to_native = run_data["t1w_to_native_xform"]
     inputnode.inputs.dummy_scans = dummy_scans
 
-    outputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=[
-                "processed_bold",
-                "smoothed_bold",
-                "alff_out",
-                "smoothed_alff",
-                "reho_out",
-                "atlas_names",
-                "timeseries",
-                "correlations",
-                "qc_file",
-                "filtered_motion",
-                "tmask",
-            ],
-        ),
-        name="outputnode",
-    )
-
     mem_gbx = _create_mem_gb(bold_file)
 
     get_custom_confounds_file = pe.Node(
@@ -735,32 +716,8 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         (resample_parc, qcreport, [('output_image', 'seg_file')]),
         (warp_boldmask_to_t1w, qcreport, [('output_image', 'bold2T1w_mask')]),
         (warp_boldmask_to_mni, qcreport, [('output_image', 'bold2temp_mask')]),
-        (qcreport, outputnode, [('qc_file', 'qc_file')])
-    ])
-
-    # write  to the outputnode, may be use in future
-    workflow.connect([
-        (filtering_wf, outputnode, [('filtered_file', 'processed_bold')]),
-        (censor_scrub, outputnode, [('filtered_motion', 'filtered_motion'),
-                                    ('tmask', 'tmask')]),
-        (resdsmoothing_wf, outputnode, [('outputnode.smoothed_bold',
-                                         'smoothed_bold')]),
-        (reho_compute_wf, outputnode, [('outputnode.reho_out', 'reho_out')]),
-        (fcon_ts_wf, outputnode, [('outputnode.atlas_names', 'atlas_names'),
-                                  ('outputnode.correlations', 'correlations'),
-                                  ('outputnode.timeseries', 'timeseries')]),
     ])
     # fmt:on
-
-    if bandpass_filter:
-        # fmt:off
-        workflow.connect([
-            (alff_compute_wf, outputnode, [
-                ('outputnode.alff_out', 'alff_out'),
-                ('outputnode.smoothed_alff', 'smoothed_alff'),
-            ]),
-        ])
-        # fmt:on
 
     # write derivatives
     # fmt:off

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -248,25 +248,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     inputnode.inputs.fmriprep_confounds_tsv = run_data["confounds"]
     inputnode.inputs.dummy_scans = dummy_scans
 
-    outputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=[
-                "processed_bold",
-                "smoothed_bold",
-                "alff_out",
-                "smoothed_alff",
-                "reho_out",
-                "atlas_names",
-                "timeseries",
-                "correlations",
-                "qc_file",
-                "filtered_motion",
-                "tmask",
-            ],
-        ),
-        name="outputnode",
-    )
-
     mem_gbx = _create_mem_gb(bold_file)
 
     get_custom_confounds_file = pe.Node(
@@ -553,25 +534,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         (filtering_wf, qcreport, [('filtered_file', 'cleaned_file')]),
         (censor_scrub, qcreport, [("tmask", "tmask")]),
         (censor_scrub, censor_report, [('tmask', 'tmask')]),
-        (qcreport, outputnode, [('qc_file', 'qc_file')])
     ])
-
-    workflow.connect([
-        (filtering_wf, outputnode, [('filtered_file', 'processed_bold')]),
-        (censor_scrub, outputnode, [('filtered_motion', 'filtered_motion'),
-                                    ('tmask', 'tmask')]),
-        (resdsmoothing_wf, outputnode, [('outputnode.smoothed_bold',
-                                         'smoothed_bold')]),
-        (reho_compute_wf, outputnode, [('outputnode.reho_out', 'reho_out')]),
-        (fcon_ts_wf, outputnode, [('outputnode.atlas_names', 'atlas_names'),
-                                  ('outputnode.correlations', 'correlations'),
-                                  ('outputnode.timeseries', 'timeseries')]),
-    ])
-
-    if bandpass_filter:
-        workflow.connect([
-            (alff_compute_wf, outputnode, [('outputnode.alff_out', 'alff_out')]),
-        ])
 
     # write derivatives
     workflow.connect([


### PR DESCRIPTION
Closes None. The outputnodes are not currently used, and I'd rather simplify the code than keep them around.

## Changes proposed in this pull request
- Remove output node from nifti postprocessing workflow.
- Remove output node from cifti postprocessing workflow.
