### PR TITLE
Move QC/censoring plots into new workflow

### DIFF
--- a/.circleci/NiftiWithoutFreeSurferTest.sh
+++ b/.circleci/NiftiWithoutFreeSurferTest.sh
@@ -34,6 +34,7 @@ $XCPD_CMD \
     -vv \
     --nuisance-regressors 27P \
     --disable-bandpass-filter \
-    --dcan-qc
+    --dcan-qc \
+    --dummy-scans 1
 
 echo $XCPD_CMD

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -13,13 +13,13 @@ BOLD Workflow
 
     from pkg_resources import resource_filename as pkgrf
 
-    from xcp_d.utils.bids import collect_data, extract_t1w_seg, select_registrationfile
+    from xcp_d.utils.bids import collect_data
     from xcp_d.workflow.bold import init_boldpostprocess_wf
 
     fmri_dir = pkgrf('xcp_d', 'data/fmriprep')
-    layout,subj_data = collect_data(
+    layout, subj_data = collect_data(
         bids_dir=fmri_dir,
-        participant_label='sub-colornest001',
+        participant_label='colornest001',
         task='rest',
         bids_validate=False,
     )
@@ -28,28 +28,25 @@ BOLD Workflow
         'xcp_d',
         'data/fmriprep/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz',
     )
-    custom_confounds = pkgrf(
-        'xcp_d',
-        'data/fmriprep/sub-colornest001/ses-1/func/sub-colornest001_ses-1_task-rest_run-1_desc-confounds_timeseries.tsv',
-    )
+    custom_confounds_folder = pkgrf('xcp_d', 'data/fmriprep/sub-colornest001/ses-1/func/')
 
-    tseg = pkgrf('xcp_d','data/fmriprep/sub-colornest001/ses-1/anat/sub-colornest001_ses-1_rec-refaced_desc-preproc_T1w.nii.gz')
-    t1w = pkgrf('xcp_d','data/fmriprep/sub-colornest001/ses-1/anat/sub-colornest001_ses-1_rec-refaced_dseg.nii.gz')
+    tseg = pkgrf('xcp_d', 'data/fmriprep/sub-colornest001/ses-1/anat/sub-colornest001_ses-1_rec-refaced_desc-preproc_T1w.nii.gz')
+    t1w = pkgrf('xcp_d', 'data/fmriprep/sub-colornest001/ses-1/anat/sub-colornest001_ses-1_rec-refaced_dseg.nii.gz')
 
     wf = init_boldpostprocess_wf(
-        bold_file=str(bold_file),
+        bold_file=bold_file,
         bandpass_filter=True,
         upper_bpf=0.08,
         lower_bpf=0.01,
         bpf_order=2,
         motion_filter_order=4,
-        motion_filter_type='notch',
+        motion_filter_type=None,
         band_stop_min=0.,
         band_stop_max=0.,
         smoothing=6,
         head_radius=50.,
         params='27P',
-        custom_confounds=custom_confounds,
+        custom_confounds_folder=custom_confounds_folder,
         omp_nthreads=1,
         dummy_scans=0,
         output_dir='output_dir',
@@ -57,6 +54,8 @@ BOLD Workflow
         n_runs=1,
         layout=layout,
         despike=False,
+        dummytime=0,
+        dcan_qc=False,
         name='bold_postprocess_wf',
     )
     wf.inputs.inputnode.t1w = t1w

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -33,25 +33,11 @@ class _CensoringPlotInputSpec(BaseInterfaceInputSpec):
         mandatory=True,
         desc="Raw bold file from fMRIPrep. Used only to identify the right confounds file.",
     )
-    tmask = File(exists=True, mandatory=False, desc="Temporal mask. Current unused.")
-    dummy_scans = traits.Int(
-        mandatory=False,
-        default_value=0,
-        usedefault=True,
-        desc="Dummy time to drop",
-    )
+    tmask = File(exists=True, mandatory=True, desc="Temporal mask.")
+    dummy_scans = traits.Int(mandatory=True, desc="Dummy time to drop")
     TR = traits.Float(mandatory=True, desc="Repetition Time")
-    head_radius = traits.Float(
-        mandatory=False,
-        default_value=50,
-        usedefault=True,
-        desc="Head radius; recommended value is 40 for babies",
-    )
-    motion_filter_type = traits.Either(
-        None,
-        traits.Str,
-        mandatory=True,
-    )
+    head_radius = traits.Float(mandatory=True, desc="Head radius for FD calculation")
+    motion_filter_type = traits.Either(None, traits.Str, mandatory=True)
     motion_filter_order = traits.Int(mandatory=True)
     band_stop_min = traits.Either(
         None,
@@ -124,6 +110,18 @@ class CensoringPlot(SimpleInterface):
                 color=palette[1],
             )
 
+        # Plot censored volumes as vertical lines
+        tmask_df = pd.read_table(self.inputs.tmask)
+        tmask_arr = tmask_df["framewise_displacement"].values
+        tmask_idx = np.where(tmask_arr)[0]
+        for i_idx, idx in enumerate(tmask_idx):
+            if i_idx == 0:
+                label = "Censored Volumes"
+            else:
+                label = ""
+
+            ax.axvline(idx * self.inputs.TR, label=label, color=palette[3], alpha=0.5)
+
         # Compute filtered framewise displacement to plot censoring
         if self.inputs.motion_filter_type:
             filtered_motion_df = load_motion(
@@ -147,21 +145,6 @@ class CensoringPlot(SimpleInterface):
             )
         else:
             filtered_fd_timeseries = preproc_fd_timeseries.copy()
-
-        # NOTE: TS- Probably should replace with the actual tmask file.
-        tmask = filtered_fd_timeseries >= self.inputs.fd_thresh
-        tmask[:dummy_scans] = 0
-
-        # Only plot censored volumes if any were flagged
-        if sum(tmask) > 0:
-            tmask_idx = np.where(tmask)[0]
-            for i_idx, idx in enumerate(tmask_idx):
-                if i_idx == 0:
-                    label = "Censored Volumes"
-                else:
-                    label = ""
-
-                ax.axvline(idx * self.inputs.TR, label=label, color=palette[3], alpha=0.5)
 
         ax.set_xlim(0, max(time_array))
         y_max = (
@@ -195,27 +178,19 @@ class CensoringPlot(SimpleInterface):
 
 class _QCPlotInputSpec(BaseInterfaceInputSpec):
     bold_file = File(exists=True, mandatory=True, desc="Raw bold file from fMRIPrep")
-    mask_file = File(exists=True, mandatory=False, desc="Mask file from nifti")
-    seg_file = File(exists=True, mandatory=False, desc="Seg file for nifti")
+    dummy_scans = traits.Int(mandatory=True, desc="Dummy time to drop")
+    tmask = File(exists=True, mandatory=True, desc="Temporal mask")
     cleaned_file = File(exists=True, mandatory=True, desc="Processed file")
-    tmask = File(exists=True, mandatory=False, desc="Temporal mask")
-    dummy_scans = traits.Int(
-        mandatory=False,
-        default_value=0,
-        usedefault=True,
-        desc="Dummy time to drop",
-    )
     TR = traits.Float(mandatory=True, desc="Repetition Time")
-    head_radius = traits.Float(
-        mandatory=False,
-        default_value=50,
-        usedefault=True,
-        desc="Head radius; recommended value is 40 for babies",
-    )
+    head_radius = traits.Float(mandatory=True, desc="Head radius for FD calculation")
+    template_mask = File(exists=True, mandatory=True, desc="Template mask")
+    mask_file = File(exists=True, mandatory=True, desc="Mask file from nifti")
+    t1w_mask = File(exists=True, mandatory=True, desc="Mask in T1W")
+
+    # Inputs used only for nifti data
+    seg_file = File(exists=True, mandatory=False, desc="Seg file for nifti")
     bold2T1w_mask = File(exists=True, mandatory=False, desc="Bold mask in MNI")
     bold2temp_mask = File(exists=True, mandatory=False, desc="Bold mask in T1W")
-    template_mask = File(exists=True, mandatory=False, desc="Template mask")
-    t1w_mask = File(exists=True, mandatory=False, desc="Mask in T1W")
 
 
 class _QCPlotOutputSpec(TraitedSpec):

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -15,6 +15,7 @@ from nipype.interfaces.base import (
     TraitedSpec,
     traits,
 )
+from nipype.interfaces.base.traits_extension import isdefined
 
 from xcp_d.utils.confounds import load_confound, load_motion
 from xcp_d.utils.filemanip import fname_presuffix
@@ -109,6 +110,11 @@ class CensoringPlot(SimpleInterface):
         ax.axhline(self.inputs.fd_thresh, label="Outlier Threshold", color="gray", alpha=0.5)
 
         dummy_scans = self.inputs.dummy_scans
+        # This check is necessary, because init_qc_report_wf connects dummy_scans from the
+        # inputnode, forcing it to be undefined instead of using the default when not set.
+        if not isdefined(dummy_scans):
+            dummy_scans = 0
+
         if self.inputs.dummy_scans:
             ax.axvspan(
                 0,
@@ -144,7 +150,7 @@ class CensoringPlot(SimpleInterface):
 
         # NOTE: TS- Probably should replace with the actual tmask file.
         tmask = filtered_fd_timeseries >= self.inputs.fd_thresh
-        tmask[:dummy_scans] = False
+        tmask[:dummy_scans] = 0
 
         # Only plot censored volumes if any were flagged
         if sum(tmask) > 0:

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -183,12 +183,17 @@ class _QCPlotInputSpec(BaseInterfaceInputSpec):
     cleaned_file = File(exists=True, mandatory=True, desc="Processed file")
     TR = traits.Float(mandatory=True, desc="Repetition Time")
     head_radius = traits.Float(mandatory=True, desc="Head radius for FD calculation")
-    template_mask = File(exists=True, mandatory=True, desc="Template mask")
-    mask_file = File(exists=True, mandatory=True, desc="Mask file from nifti")
-    t1w_mask = File(exists=True, mandatory=True, desc="Mask in T1W")
+    mask_file = traits.Either(
+        None,
+        File(exists=True),
+        mandatory=True,
+        desc="Mask file from nifti. May be None, for CIFTI processing.",
+    )
 
     # Inputs used only for nifti data
     seg_file = File(exists=True, mandatory=False, desc="Seg file for nifti")
+    t1w_mask = File(exists=True, mandatory=False, desc="Mask in T1W")
+    template_mask = File(exists=True, mandatory=False, desc="Template mask")
     bold2T1w_mask = File(exists=True, mandatory=False, desc="Bold mask in MNI")
     bold2temp_mask = File(exists=True, mandatory=False, desc="Bold mask in T1W")
 

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -104,7 +104,7 @@ class CensoringPlot(SimpleInterface):
         if self.inputs.dummy_scans:
             ax.axvspan(
                 0,
-                self.inputs.dummy_scans,
+                self.inputs.dummy_scans * self.inputs.TR,
                 label="Dummy Volumes",
                 alpha=0.5,
                 color=palette[1],
@@ -120,7 +120,13 @@ class CensoringPlot(SimpleInterface):
             else:
                 label = ""
 
-            ax.axvline(idx * self.inputs.TR, label=label, color=palette[3], alpha=0.5)
+            idx_after_dummy_scans = idx + dummy_scans
+            ax.axvline(
+                idx_after_dummy_scans * self.inputs.TR,
+                label=label,
+                color=palette[3],
+                alpha=0.5,
+            )
 
         # Compute filtered framewise displacement to plot censoring
         if self.inputs.motion_filter_type:

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -459,6 +459,9 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     else:
         # fmt:off
         workflow.connect([
+            (inputnode, qc_report_wf, [
+                ("dummy_scans", "inputnode.dummy_scans"),
+            ]),
             (inputnode, censor_scrub, [
                 ('bold_file', 'in_file'),
                 # fMRIPrep confounds file is needed for filtered motion.

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -26,7 +26,7 @@ from xcp_d.workflow.connectivity import init_nifti_functional_connectivity_wf
 from xcp_d.workflow.execsummary import init_execsummary_wf
 from xcp_d.workflow.outputs import init_writederivatives_wf
 from xcp_d.workflow.plotting import init_qc_report_wf
-from xcp_d.workflow.postprocessing import init_resd_smoothing
+from xcp_d.workflow.postprocessing import init_resd_smoothing_wf
 from xcp_d.workflow.restingstate import init_compute_alff_wf, init_nifti_reho_wf
 
 LOGGER = logging.getLogger("nipype.workflow")
@@ -321,7 +321,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         omp_nthreads=omp_nthreads,
     )
 
-    resdsmoothing_wf = init_resd_smoothing(
+    resd_smoothing_wf = init_resd_smoothing_wf(
         mem_gb=mem_gbx["timeseries"],
         smoothing=smoothing,
         cifti=False,
@@ -533,7 +533,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
                                                        'in_file')])])
 
     # residual smoothing
-    workflow.connect([(filtering_wf, resdsmoothing_wf,
+    workflow.connect([(filtering_wf, resd_smoothing_wf,
                        [('filtered_file', 'inputnode.bold_file')])])
 
     # functional connect workflow
@@ -576,7 +576,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         (qc_report_wf, write_derivative_wf, [
             ('outputnode.qc_file', 'inputnode.qc_file'),
         ]),
-        (resdsmoothing_wf, write_derivative_wf, [
+        (resd_smoothing_wf, write_derivative_wf, [
             ('outputnode.smoothed_bold', 'inputnode.smoothed_bold'),
         ]),
         (censor_scrub, write_derivative_wf, [

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -21,11 +21,7 @@ from xcp_d.utils.bids import collect_run_data
 from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.filemanip import check_binary_mask
 from xcp_d.utils.plot import plot_design_matrix
-from xcp_d.utils.utils import (
-    consolidate_confounds,
-    get_customfile,
-    stringforparams,
-)
+from xcp_d.utils.utils import consolidate_confounds, get_customfile, stringforparams
 from xcp_d.workflow.connectivity import init_nifti_functional_connectivity_wf
 from xcp_d.workflow.execsummary import init_execsummary_wf
 from xcp_d.workflow.outputs import init_writederivatives_wf

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -433,7 +433,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     workflow.connect([
         (inputnode, qc_report_wf, [
             ("bold_file", "inputnode.preprocessed_bold_file"),
-            ("mask_file", "inputnode.mask_file"),
+            ("bold_mask", "inputnode.bold_mask"),
             ("t1w_mask", "inputnode.t1w_mask"),
             ("mni_to_t1w", "inputnode.mni_to_t1w"),
             ("t1w_to_native", "inputnode.t1w_to_native"),

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -148,25 +148,6 @@ def init_boldpostprocess_wf(
     fmriprep_confounds_tsv
         Loaded in this workflow.
 
-    Outputs
-    -------
-    processed_bold
-        clean bold after regression and filtering
-    smoothed_bold
-        smoothed clean bold
-    alff_out
-        ALFF file. Only generated if bandpass filtering is performed.
-    smoothed_alff
-        Smoothed ALFF file. Only generated if bandpass filtering is performed.
-    reho_out
-        reho output computed by afni.3dreho
-    %(atlas_names)s
-    %(timeseries)s
-    %(correlations)s
-    qc_file
-        quality control files
-    filtered_motion
-
     References
     ----------
     .. footbibliography::
@@ -433,7 +414,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     workflow.connect([
         (inputnode, qc_report_wf, [
             ("bold_file", "inputnode.preprocessed_bold_file"),
-            ("ref_file", "boldref"),
+            ("ref_file", "inputnode.boldref"),
             ("bold_mask", "inputnode.bold_mask"),
             ("t1w_mask", "inputnode.t1w_mask"),
             ("mni_to_t1w", "inputnode.mni_to_t1w"),
@@ -583,19 +564,30 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     # write derivatives
     # fmt:off
     workflow.connect([
-        (consolidate_confounds_node, write_derivative_wf, [('out_file',
-                                                            'inputnode.confounds_file')]),
-        (filtering_wf, write_derivative_wf, [('filtered_file',
-                                              'inputnode.processed_bold')]),
-        (resdsmoothing_wf, write_derivative_wf, [('outputnode.smoothed_bold',
-                                                  'inputnode.smoothed_bold')]),
-        (censor_scrub, write_derivative_wf, [('filtered_motion', 'inputnode.filtered_motion'),
-                                             ('tmask', 'inputnode.tmask')]),
-        (reho_compute_wf, write_derivative_wf, [('outputnode.reho_out',
-                                                 'inputnode.reho_out')]),
-        (fcon_ts_wf, write_derivative_wf, [('outputnode.atlas_names', 'inputnode.atlas_names'),
-                                           ('outputnode.correlations', 'inputnode.correlations'),
-                                           ('outputnode.timeseries', 'inputnode.timeseries')]),
+        (consolidate_confounds_node, write_derivative_wf, [
+            ('out_file', 'inputnode.confounds_file'),
+        ]),
+        (filtering_wf, write_derivative_wf, [
+            ('filtered_file', 'inputnode.processed_bold'),
+        ]),
+        (qc_report_wf, write_derivative_wf, [
+            ('outputnode.qc_file', 'inputnode.qc_file'),
+        ]),
+        (resdsmoothing_wf, write_derivative_wf, [
+            ('outputnode.smoothed_bold', 'inputnode.smoothed_bold'),
+        ]),
+        (censor_scrub, write_derivative_wf, [
+            ('filtered_motion', 'inputnode.filtered_motion'),
+            ('tmask', 'inputnode.tmask'),
+        ]),
+        (reho_compute_wf, write_derivative_wf, [
+            ('outputnode.reho_out', 'inputnode.reho_out'),
+        ]),
+        (fcon_ts_wf, write_derivative_wf, [
+            ('outputnode.atlas_names', 'inputnode.atlas_names'),
+            ('outputnode.correlations', 'inputnode.correlations'),
+            ('outputnode.timeseries', 'inputnode.timeseries'),
+        ]),
     ])
     # fmt:on
 

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -448,6 +448,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         head_radius=head_radius,
         mem_gb=mem_gbx["timeseries"],
         omp_nthreads=omp_nthreads,
+        cifti=False,
         name="qc_report_wf",
     )
 

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -433,6 +433,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     workflow.connect([
         (inputnode, qc_report_wf, [
             ("bold_file", "inputnode.preprocessed_bold_file"),
+            ("ref_file", "boldref"),
             ("bold_mask", "inputnode.bold_mask"),
             ("t1w_mask", "inputnode.t1w_mask"),
             ("mni_to_t1w", "inputnode.mni_to_t1w"),

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -24,7 +24,7 @@ from xcp_d.workflow.connectivity import init_cifti_functional_connectivity_wf
 from xcp_d.workflow.execsummary import init_execsummary_wf
 from xcp_d.workflow.outputs import init_writederivatives_wf
 from xcp_d.workflow.plotting import init_qc_report_wf
-from xcp_d.workflow.postprocessing import init_resd_smoothing
+from xcp_d.workflow.postprocessing import init_resd_smoothing_wf
 from xcp_d.workflow.restingstate import init_cifti_reho_wf, init_compute_alff_wf
 
 LOGGER = logging.getLogger("nipype.workflow")
@@ -291,7 +291,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         omp_nthreads=omp_nthreads,
     )
 
-    resdsmoothing_wf = init_resd_smoothing(
+    resd_smoothing_wf = init_resd_smoothing_wf(
         mem_gb=mem_gbx["timeseries"],
         smoothing=smoothing,
         cifti=True,
@@ -489,7 +489,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
                                                        'in_file')])])
 
     # residual smoothing
-    workflow.connect([(filtering_wf, resdsmoothing_wf,
+    workflow.connect([(filtering_wf, resd_smoothing_wf,
                        [('filtered_file', 'inputnode.bold_file')])])
 
     # functional connect workflow
@@ -522,7 +522,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         (qc_report_wf, write_derivative_wf, [
             ('outputnode.qc_file', 'inputnode.qc_file'),
         ]),
-        (resdsmoothing_wf, write_derivative_wf, [
+        (resd_smoothing_wf, write_derivative_wf, [
             ('outputnode.smoothed_bold', 'inputnode.smoothed_bold'),
         ]),
         (censor_scrub, write_derivative_wf, [

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -425,6 +425,9 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     else:
         # fmt:off
         workflow.connect([
+            (inputnode, qc_report_wf, [
+                ("dummy_scans", "inputnode.dummy_scans"),
+            ]),
             (inputnode, censor_scrub, [
                 ('bold_file', 'in_file'),
                 # fMRIPrep confounds file is needed for filtered motion.

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -132,26 +132,6 @@ def init_ciftipostprocess_wf(
     %(mni_to_t1w)s
     fmriprep_confounds_tsv
 
-    Outputs
-    -------
-    processed_bold
-        clean bold after regression and filtering
-    smoothed_bold
-        smoothed clean bold
-    alff_out
-        ALFF file. Only generated if bandpass filtering is performed.
-    smoothed_alff
-        Smoothed ALFF file. Only generated if bandpass filtering is performed.
-    reho_lh
-        reho left hemisphere
-    reho_rh
-        reho right hemisphere
-    %(atlas_names)s
-    %(timeseries)s
-    %(correlations)s
-    qc_file
-        quality control files
-
     References
     ----------
     .. footbibliography::
@@ -530,21 +510,30 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
 
     # write derivatives
     workflow.connect([
-        (consolidate_confounds_node, write_derivative_wf, [('out_file',
-                                                            'inputnode.confounds_file')]),
-        (filtering_wf, write_derivative_wf, [('filtered_file',
-                                              'inputnode.processed_bold')]),
-        (resdsmoothing_wf, write_derivative_wf, [('outputnode.smoothed_bold',
-                                                  'inputnode.smoothed_bold')]),
-        (censor_scrub, write_derivative_wf, [('filtered_motion', 'inputnode.filtered_motion'),
-                                             ('tmask', 'inputnode.tmask')]),
-        (reho_compute_wf, write_derivative_wf, [
-            ('outputnode.reho_out', 'inputnode.reho_out')
+        (consolidate_confounds_node, write_derivative_wf, [
+            ('out_file', 'inputnode.confounds_file'),
         ]),
-        (fcon_ts_wf, write_derivative_wf,
-            [('outputnode.atlas_names', 'inputnode.atlas_names'),
-             ('outputnode.correlations', 'inputnode.correlations'),
-             ('outputnode.timeseries', 'inputnode.timeseries')]),
+        (filtering_wf, write_derivative_wf, [
+            ('filtered_file', 'inputnode.processed_bold'),
+        ]),
+        (qc_report_wf, write_derivative_wf, [
+            ('outputnode.qc_file', 'inputnode.qc_file'),
+        ]),
+        (resdsmoothing_wf, write_derivative_wf, [
+            ('outputnode.smoothed_bold', 'inputnode.smoothed_bold'),
+        ]),
+        (censor_scrub, write_derivative_wf, [
+            ('filtered_motion', 'inputnode.filtered_motion'),
+            ('tmask', 'inputnode.tmask'),
+        ]),
+        (reho_compute_wf, write_derivative_wf, [
+            ('outputnode.reho_out', 'inputnode.reho_out'),
+        ]),
+        (fcon_ts_wf, write_derivative_wf, [
+            ('outputnode.atlas_names', 'inputnode.atlas_names'),
+            ('outputnode.correlations', 'inputnode.correlations'),
+            ('outputnode.timeseries', 'inputnode.timeseries'),
+        ]),
     ])
 
     if bandpass_filter:

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -402,10 +402,10 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
 
     # fmt:off
     workflow.connect([
-        (inputnode, qc_report_wf, [(
+        (inputnode, qc_report_wf, [
             ("bold_file", "inputnode.preprocessed_bold_file"),
             ("mni_to_t1w", "inputnode.mni_to_t1w"),
-        )]),
+        ]),
     ])
     # fmt:on
 

--- a/xcp_d/workflow/outputs.py
+++ b/xcp_d/workflow/outputs.py
@@ -33,8 +33,10 @@ def init_writederivatives_wf(
             from xcp_d.workflow.outputs import init_writederivatives_wf
             wf = init_writederivatives_wf(
                 bold_file="/path/to/file.nii.gz",
-                lowpass=6.,
-                highpass=60.,
+                bandpass_filter=True,
+                lowpass=0.1,
+                highpass=0.008,
+                motion_filter_type=None,
                 smoothing=6,
                 params="36P",
                 cifti=False,

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -258,7 +258,7 @@ def init_qc_report_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, functional_qc, [("preprocessed_bold_file", "bold_file")])
+        (inputnode, functional_qc, [("preprocessed_bold_file", "bold_file")]),
         (qcreport, functional_qc, [("qc_file", "qc_file")]),
     ])
     # fmt:on

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -281,8 +281,6 @@ def init_qc_report_wf(
     workflow.connect([
         (inputnode, qcreport, [
             ("preprocessed_bold_file", "bold_file"),
-            ("t1w_mask", "t1w_mask"),
-            ("bold_mask", "mask_file"),
             ("cleaned_file", "cleaned_file"),
             ("tmask", "tmask"),
             ("dummy_scans", "dummy_scans"),
@@ -296,6 +294,10 @@ def init_qc_report_wf(
     if not cifti:
         # fmt:off
         workflow.connect([
+            (inputnode, qcreport, [
+                ("t1w_mask", "t1w_mask"),
+                ("bold_mask", "mask_file"),
+            ])
             (resample_parc, qcreport, [
                 ("output_image", "seg_file"),
             ]),
@@ -307,6 +309,8 @@ def init_qc_report_wf(
             ]),
         ])
         # fmt:on
+    else:
+        qcreport.inputnode.inputs.mask_file = None
 
     functional_qc = pe.Node(
         FunctionalSummary(TR=TR),

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -283,7 +283,9 @@ def init_qc_report_wf(
             ("preprocessed_bold_file", "bold_file"),
             ("t1w_mask", "t1w_mask"),
             ("bold_mask", "mask_file"),
-            ("cleaned_file", "cleaned_file")
+            ("cleaned_file", "cleaned_file"),
+            ("tmask", "tmask"),
+            ("dummy_scans", "dummy_scans"),
         ]),
         (qcreport, outputnode, [
             ("qc_file", "qc_file"),

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -1,0 +1,278 @@
+"""Plotting workflows."""
+from nipype import Function
+from nipype.interfaces import utility as niu
+from nipype.pipeline import engine as pe
+from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
+from templateflow.api import get as get_template
+
+from xcp_d.interfaces.bids import DerivativesDataSink
+from xcp_d.interfaces.qc_plot import CensoringPlot, QCPlot
+from xcp_d.interfaces.report import FunctionalSummary
+from xcp_d.utils.utils import get_std2bold_xforms
+
+
+def init_qc_report_wf(
+    output_dir,
+    TR,
+    motion_filter_type,
+    band_stop_max,
+    band_stop_min,
+    motion_filter_order,
+    fd_thresh,
+    head_radius,
+    mem_gb,
+    omp_nthreads,
+    name="qc_report_wf",
+):
+    """Generate quality control figures and a QC file."""
+    workflow = Workflow(name=name)
+
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=[
+                "preprocessed_bold_file",
+                "mask_file",
+                "t1w_mask",
+                "bold_to_std_xforms",
+                "bold_to_std_xforms_invert",
+                "bold_to_t1w_xforms",
+                "bold_to_t1w_xforms_invert",
+                "dummy_scans",
+                "cleaned_file",
+                "tmask",
+            ],
+        ),
+        name="inputnode",
+    )
+
+    censor_report = pe.Node(
+        CensoringPlot(
+            TR=TR,
+            head_radius=head_radius,
+            motion_filter_type=motion_filter_type,
+            band_stop_max=band_stop_max,
+            band_stop_min=band_stop_min,
+            motion_filter_order=motion_filter_order,
+            fd_thresh=fd_thresh,
+        ),
+        name="censor_report",
+        mem_gb=mem_gb,
+        n_procs=omp_nthreads,
+    )
+
+    # fmt:off
+    workflow.connect([
+        (inputnode, censor_report, [
+            ("tmask", "tmask"),
+            ("dummy_scans", "dummy_scans"),
+            ("preprocessed_bold_file", "bold_file"),
+        ]),
+    ])
+    # fmt:on
+
+    warp_boldmask_to_t1w = pe.Node(
+        ApplyTransforms(
+            dimension=3,
+            interpolation="NearestNeighbor",
+        ),
+        name="warp_boldmask_to_t1w",
+        n_procs=omp_nthreads,
+        mem_gb=mem_gb,
+    )
+
+    # fmt:off
+    workflow.connect([
+        (inputnode, warp_boldmask_to_t1w, [
+            ("mask_file", "input_image"),
+            ('t1w_mask', 'reference_image'),
+            ('bold_to_t1w_xforms', 'transforms'),
+            ("bold_to_t1w_xforms_invert", "invert_transform_flags"),
+        ]),
+    ])
+    # fmt:on
+
+    warp_boldmask_to_mni = pe.Node(
+        ApplyTransforms(
+            dimension=3,
+            reference_image=str(
+                get_template(
+                    "MNI152NLin2009cAsym",
+                    resolution=2,
+                    desc="brain",
+                    suffix="mask",
+                    extension=[".nii", ".nii.gz"],
+                ),
+            ),
+            interpolation="NearestNeighbor",
+        ),
+        name="warp_boldmask_to_mni",
+        n_procs=omp_nthreads,
+        mem_gb=mem_gb,
+    )
+
+    # fmt:off
+    workflow.connect([
+        (inputnode, warp_boldmask_to_mni, [
+            ("mask_file", "input_image"),
+            ('bold_to_std_xforms', 'transforms'),
+            ("bold_to_std_xforms_invert", "invert_transform_flags"),
+        ]),
+    ])
+    # fmt:on
+
+    # Obtain transforms for QC report
+    get_std2native_transform = pe.Node(
+        Function(
+            input_names=["bold_file", "mni_to_t1w", "t1w_to_native"],
+            output_names=["transform_list"],
+            function=get_std2bold_xforms,
+        ),
+        name="get_std2native_transform",
+    )
+
+    # fmt:off
+    workflow.connect([
+        (inputnode, get_std2native_transform, [
+            ("bold_file", "bold_file"),
+            ("mni_to_t1w", "mni_to_t1w"),
+            ("t1w_to_native", "t1w_to_native"),
+        ]),
+    ])
+    # fmt:on
+
+    # Resample discrete segmentation for QCPlot into the appropriate space.
+    resample_parc = pe.Node(
+        ApplyTransforms(
+            dimension=3,
+            input_image=str(
+                get_template(
+                    "MNI152NLin2009cAsym",
+                    resolution=1,
+                    desc="carpet",
+                    suffix="dseg",
+                    extension=[".nii", ".nii.gz"],
+                )
+            ),
+            interpolation="MultiLabel",
+        ),
+        name="resample_parc",
+        n_procs=omp_nthreads,
+        mem_gb=mem_gb,
+    )
+
+    # fmt:off
+    workflow.connect([
+        (inputnode, resample_parc, [('ref_file', 'reference_image')]),
+        (get_std2native_transform, resample_parc, [('transform_list', 'transforms')]),
+    ])
+    # fmt:on
+
+    qcreport = pe.Node(
+        QCPlot(
+            TR=TR,
+            template_mask=str(
+                get_template(
+                    "MNI152NLin2009cAsym",
+                    resolution=2,
+                    desc="brain",
+                    suffix="mask",
+                    extension=[".nii", ".nii.gz"],
+                )
+            ),
+            head_radius=head_radius,
+        ),
+        name="qc_report",
+        mem_gb=mem_gb,
+        n_procs=omp_nthreads,
+    )
+
+    # fmt:off
+    workflow.connect([
+        (inputnode, qcreport, [
+            ("bold_file", "bold_file"),
+            ("t1w_mask", "t1w_mask"),
+            ('bold_mask', 'mask_file'),
+        ]),
+        (resample_parc, qcreport, [
+            ('output_image', 'seg_file'),
+        ]),
+        (warp_boldmask_to_t1w, qcreport, [
+            ('output_image', 'bold2T1w_mask'),
+        ]),
+        (warp_boldmask_to_mni, qcreport, [
+            ('output_image', 'bold2temp_mask'),
+        ]),
+    ])
+    # fmt:on
+
+    functional_qc = pe.Node(
+        FunctionalSummary(TR=TR),
+        name="qcsummary",
+        run_without_submitting=False,
+        mem_gb=mem_gb,
+    )
+
+    # fmt:off
+    workflow.connect([
+        (inputnode, functional_qc, [("namesource", "bold_file")])
+        (qcreport, functional_qc, [('qc_file', 'qc_file')]),
+    ])
+    # fmt:on
+
+    ds_report_censoring = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            datatype="figures",
+            desc="censoring",
+            suffix="motion",
+            extension=".svg",
+        ),
+        name="ds_report_censoring",
+        run_without_submitting=False,
+    )
+
+    ds_report_qualitycontrol = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            desc="qualitycontrol",
+            datatype="figures",
+        ),
+        name="ds_report_qualitycontrol",
+        run_without_submitting=False,
+    )
+
+    ds_report_preprocessing = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            desc="preprocessing",
+            datatype="figures",
+        ),
+        name="ds_report_preprocessing",
+        run_without_submitting=False,
+    )
+
+    ds_report_postprocessing = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            desc="postprocessing",
+            datatype="figures",
+        ),
+        name="ds_report_postprocessing",
+        run_without_submitting=False,
+    )
+
+    # fmt:off
+    workflow.connect([
+        (inputnode, ds_report_censoring, [("namesource", "source_file")]),
+        (inputnode, ds_report_qualitycontrol, [("namesource", "source_file")]),
+        (inputnode, ds_report_preprocessing, [("namesource", "source_file")]),
+        (inputnode, ds_report_postprocessing, [("namesource", "source_file")]),
+        (censor_report, ds_report_censoring, [("out_file", "in_file")]),
+        (functional_qc, ds_report_qualitycontrol, [('out_report', 'in_file')]),
+        (qcreport, ds_report_preprocessing, [('raw_qcplot', 'in_file')]),
+        (qcreport, ds_report_postprocessing, [('clean_qcplot', 'in_file')]),
+    ])
+    # fmt:on
+
+    return workflow

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -297,7 +297,7 @@ def init_qc_report_wf(
             (inputnode, qcreport, [
                 ("t1w_mask", "t1w_mask"),
                 ("bold_mask", "mask_file"),
-            ])
+            ]),
             (resample_parc, qcreport, [
                 ("output_image", "seg_file"),
             ]),
@@ -310,7 +310,7 @@ def init_qc_report_wf(
         ])
         # fmt:on
     else:
-        qcreport.inputnode.inputs.mask_file = None
+        qcreport.inputs.mask_file = None
 
     functional_qc = pe.Node(
         FunctionalSummary(TR=TR),

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -235,6 +235,7 @@ def init_qc_report_wf(
     # fmt:on
 
     if not cifti:
+        # fmt:off
         workflow.connect([
             (resample_parc, qcreport, [
                 ("output_image", "seg_file"),
@@ -246,6 +247,7 @@ def init_qc_report_wf(
                 ("output_image", "bold2temp_mask"),
             ]),
         ])
+        # fmt:on
 
     functional_qc = pe.Node(
         FunctionalSummary(TR=TR),

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -70,6 +70,7 @@ def init_qc_report_wf(
     Inputs
     ------
     preprocessed_bold_file
+    boldref
     bold_mask
     t1w_mask
     %(mni_to_t1w)s
@@ -88,6 +89,7 @@ def init_qc_report_wf(
         niu.IdentityInterface(
             fields=[
                 "preprocessed_bold_file",
+                "boldref",
                 "bold_mask",
                 "t1w_mask",
                 "mni_to_t1w",
@@ -259,7 +261,7 @@ def init_qc_report_wf(
 
         # fmt:off
         workflow.connect([
-            (inputnode, resample_parc, [("ref_file", "reference_image")]),
+            (inputnode, resample_parc, [("boldref", "reference_image")]),
             (get_std2native_transform, resample_parc, [("transform_list", "transforms")]),
         ])
         # fmt:on
@@ -362,10 +364,10 @@ def init_qc_report_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, ds_report_censoring, [("namesource", "source_file")]),
-        (inputnode, ds_report_qualitycontrol, [("namesource", "source_file")]),
-        (inputnode, ds_report_preprocessing, [("namesource", "source_file")]),
-        (inputnode, ds_report_postprocessing, [("namesource", "source_file")]),
+        (inputnode, ds_report_censoring, [("preprocessed_bold_file", "source_file")]),
+        (inputnode, ds_report_qualitycontrol, [("preprocessed_bold_file", "source_file")]),
+        (inputnode, ds_report_preprocessing, [("preprocessed_bold_file", "source_file")]),
+        (inputnode, ds_report_postprocessing, [("preprocessed_bold_file", "source_file")]),
         (censor_report, ds_report_censoring, [("out_file", "in_file")]),
         (functional_qc, ds_report_qualitycontrol, [("out_report", "in_file")]),
         (qcreport, ds_report_preprocessing, [("raw_qcplot", "in_file")]),

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -9,9 +9,11 @@ from templateflow.api import get as get_template
 from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.qc_plot import CensoringPlot, QCPlot
 from xcp_d.interfaces.report import FunctionalSummary
+from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.utils import get_bold2std_and_t1w_xforms, get_std2bold_xforms
 
 
+@fill_doc
 def init_qc_report_wf(
     output_dir,
     TR,
@@ -26,7 +28,60 @@ def init_qc_report_wf(
     cifti,
     name="qc_report_wf",
 ):
-    """Generate quality control figures and a QC file."""
+    """Generate quality control figures and a QC file.
+
+    Workflow Graph
+        .. workflow::
+            :graph2use: orig
+            :simple_form: yes
+
+            from xcp_d.workflow.plotting import init_qc_report_wf
+            wf = init_qc_report_wf(
+                output_dir=".",
+                TR=0.5,
+                motion_filter_type=None,
+                band_stop_max=0,
+                band_stop_min=0,
+                motion_filter_order=1,
+                fd_thresh=0.2,
+                head_radius=50,
+                mem_gb=0.1,
+                omp_nthreads=1,
+                cifti=False,
+                name="qc_report_wf",
+            )
+
+    Parameters
+    ----------
+    %(output_dir)s
+    TR
+    %(motion_filter_type)s
+    %(band_stop_max)s
+    %(band_stop_min)s
+    %(motion_filter_order)s
+    %(fd_thresh)s
+    %(head_radius)s
+    %(mem_gb)s
+    %(omp_nthreads)s
+    %(cifti)s
+    %(name)s
+        Default is "qc_report_wf".
+
+    Inputs
+    ------
+    preprocessed_bold_file
+    mask_file
+    t1w_mask
+    %(mni_to_t1w)s
+    t1w_to_native
+    %(dummy_scans)s
+    cleaned_file
+    tmask
+
+    Outputs
+    -------
+    qc_file
+    """
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -70,7 +70,7 @@ def init_qc_report_wf(
     Inputs
     ------
     preprocessed_bold_file
-    mask_file
+    bold_mask
     t1w_mask
     %(mni_to_t1w)s
     t1w_to_native
@@ -88,7 +88,7 @@ def init_qc_report_wf(
         niu.IdentityInterface(
             fields=[
                 "preprocessed_bold_file",
-                "mask_file",
+                "bold_mask",
                 "t1w_mask",
                 "mni_to_t1w",
                 "t1w_to_native",
@@ -184,7 +184,7 @@ def init_qc_report_wf(
         # fmt:off
         workflow.connect([
             (inputnode, warp_boldmask_to_t1w, [
-                ("mask_file", "input_image"),
+                ("bold_mask", "input_image"),
                 ("t1w_mask", "reference_image"),
             ]),
             (get_native2space_transforms, warp_boldmask_to_t1w, [
@@ -208,7 +208,7 @@ def init_qc_report_wf(
         # fmt:off
         workflow.connect([
             (inputnode, warp_boldmask_to_mni, [
-                ("mask_file", "input_image"),
+                ("bold_mask", "input_image"),
             ]),
             (get_native2space_transforms, warp_boldmask_to_mni, [
                 ("bold_to_std_xforms", "transforms"),
@@ -280,7 +280,7 @@ def init_qc_report_wf(
         (inputnode, qcreport, [
             ("preprocessed_bold_file", "bold_file"),
             ("t1w_mask", "t1w_mask"),
-            ("mask_file", "mask_file"),
+            ("bold_mask", "mask_file"),
             ("cleaned_file", "cleaned_file")
         ]),
         (qcreport, outputnode, [

--- a/xcp_d/workflow/postprocessing.py
+++ b/xcp_d/workflow/postprocessing.py
@@ -8,44 +8,82 @@ from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from pkg_resources import resource_filename as pkgrf
 
 from xcp_d.interfaces.nilearn import Smooth
+from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.utils import fwhm2sigma
 
 
-def init_resd_smoothing(
+@fill_doc
+def init_resd_smoothing_wf(
     mem_gb,
     smoothing,
     omp_nthreads,
     cifti=False,
-    name="smoothing",
+    name="resd_smoothing_wf",
 ):
-    """Smooth BOLD residuals."""
+    """Smooth BOLD residuals.
+
+    Workflow Graph
+        .. workflow::
+            :graph2use: orig
+            :simple_form: yes
+
+            from xcp_d.workflow.postprocessing import init_resd_smoothing_wf
+            wf = init_resd_smoothing_wf(
+                mem_gb=0.1,
+                smoothing=6,
+                omp_nthreads=1,
+                cifti=False,
+                name="qc_report_wf",
+            )
+
+    Parameters
+    ----------
+    %(mem_gb)s
+    smoothing
+    %(omp_nthreads)s
+    %(cifti)s
+    %(name)s
+        Default is "resd_smoothing_wf".
+
+    Inputs
+    ------
+    bold_file
+
+    Outputs
+    -------
+    smoothed_bold
+    """
     workflow = Workflow(name=name)
     inputnode = pe.Node(niu.IdentityInterface(fields=["bold_file"]), name="inputnode")
     outputnode = pe.Node(niu.IdentityInterface(fields=["smoothed_bold"]), name="outputnode")
 
-    sigma_lx = fwhm2sigma(smoothing)  # Turn specified FWHM (Full-Width at Half Maximum)
-    # to standard deviation.
-    if cifti:  # For ciftis
+    # Turn specified FWHM (Full-Width at Half Maximum) to standard deviation.
+    sigma_lx = fwhm2sigma(smoothing)
+    if cifti:
         workflow.__desc__ = f""" \
 The processed BOLD  was smoothed using Connectome Workbench with a gaussian kernel
 size of {str(smoothing)} mm  (FWHM).
 """
 
+        # Call connectome workbench to smooth for each hemisphere
         smooth_data = pe.Node(
-            CiftiSmooth(  # Call connectome workbench to smooth for each
-                #  hemisphere
+            CiftiSmooth(
                 sigma_surf=sigma_lx,  # the size of the surface kernel
                 sigma_vol=sigma_lx,  # the volume of the surface kernel
                 direction="COLUMN",  # which direction to smooth along@
                 right_surf=pkgrf(  # pull out atlases for each hemisphere
                     "xcp_d",
-                    "data/ciftiatlas/"
-                    "Q1-Q6_RelatedParcellation210.R.midthickness_32k_fs_LR.surf.gii",
+                    (
+                        "data/ciftiatlas/"
+                        "Q1-Q6_RelatedParcellation210.R.midthickness_32k_fs_LR.surf.gii"
+                    ),
                 ),
                 left_surf=pkgrf(
                     "xcp_d",
-                    "data/ciftiatlas/"
-                    "Q1-Q6_RelatedParcellation210.L.midthickness_32k_fs_LR.surf.gii",
+                    (
+                        "data/ciftiatlas/"
+                        "Q1-Q6_RelatedParcellation210.L.midthickness_32k_fs_LR.surf.gii"
+                    ),
                 ),
             ),
             name="cifti_smoothing",
@@ -53,29 +91,24 @@ size of {str(smoothing)} mm  (FWHM).
             n_procs=omp_nthreads,
         )
 
-        #  Connect to workflow
-        # fmt:off
-        workflow.connect([(inputnode, smooth_data, [('bold_file', 'in_file')]),
-                          (smooth_data, outputnode, [('out_file',
-                                                      'smoothed_bold')])])
-        # fmt:on
-
-    else:  # for Nifti
+    else:
         workflow.__desc__ = f""" \
 The processed BOLD was smoothed using Nilearn with a gaussian kernel size of {str(smoothing)} mm
 (FWHM).
 """
+        # Use nilearn to smooth the image
         smooth_data = pe.Node(
             Smooth(fwhm=smoothing),  # FWHM = kernel size
             name="nifti_smoothing",
             mem_gb=mem_gb,
             n_procs=omp_nthreads,
-        )  # Use nilearn to smooth the image
+        )
 
-        #  Connect to workflow
-        # fmt:off
-        workflow.connect([(inputnode, smooth_data, [('bold_file', 'in_file')]),
-                          (smooth_data, outputnode, [('out_file', 'smoothed_bold')])])
-        # fmt:on
+    # fmt:off
+    workflow.connect([
+        (inputnode, smooth_data, [("bold_file", "in_file")]),
+        (smooth_data, outputnode, [("out_file", "smoothed_bold")]),
+    ])
+    # fmt:on
 
     return workflow

--- a/xcp_d/workflow/restingstate.py
+++ b/xcp_d/workflow/restingstate.py
@@ -43,9 +43,9 @@ def init_compute_alff_wf(
             wf = init_compute_alff_wf(
                 mem_gb=0.1,
                 TR=2.,
-                bold_file = bold_file,
-                lowpass=6.,
-                highpass=60.,
+                bold_file="/path/to/file.nii.gz",
+                lowpass=0.1,
+                highpass=0.009,
                 smoothing=6,
                 cifti=False,
                 omp_nthreads=1,
@@ -201,7 +201,7 @@ def init_cifti_reho_wf(
             from xcp_d.workflow.restingstate import init_cifti_reho_wf
             wf = init_cifti_reho_wf(
                 mem_gb=0.1,
-                bold_file = bold_file,
+                bold_file="/path/to/bold.dtseries.nii",
                 omp_nthreads=1,
                 name="cifti_reho_wf",
             )
@@ -342,7 +342,7 @@ def init_nifti_reho_wf(
             from xcp_d.workflow.restingstate import init_nifti_reho_wf
             wf = init_nifti_reho_wf(
                 mem_gb=0.1,
-                bold_file = bold_file,
+                bold_file="/path/to/bold.nii.gz",
                 omp_nthreads=1,
                 name="nifti_reho_wf",
             )


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request

- Create new workflows submodule, `plotting`, with `init_qc_report_wf` function. This function generates the censoring plot, the QC plots, and the QC file.
- Use the new function in both the nifti and cifti postprocessing workflows.

## Documentation that should be reviewed

- The new workflow's API.