### PR TITLE
Retain noise components instead of dropping them in load_aroma

### DIFF
--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -436,7 +436,7 @@ def load_aroma(confounds_df):
         The AROMA noise components.
     """
     aroma_noise = [c for c in confounds_df.columns if c.startswith("aroma_motion_")]
-    aroma = confounds_df.drop(aroma_noise, axis=1)
+    aroma = confounds_df[aroma_noise]
 
     return aroma
 


### PR DESCRIPTION
Closes #669.

## Changes proposed in this pull request

- Retain noise components instead of signal components when loading AROMA confounds. 
