### PR TITLE
Use input_type to determine order of preferred spaces

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -19,6 +19,7 @@ BOLD Workflow
     fmri_dir = pkgrf('xcp_d', 'data/fmriprep')
     layout, subj_data = collect_data(
         bids_dir=fmri_dir,
+        input_type="fmriprep",
         participant_label='colornest001',
         task='rest',
         bids_validate=False,

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -14,6 +14,7 @@ import yaml
 from bids import BIDSLayout
 from packaging.version import Version
 
+from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.filemanip import ensure_list
 
 LOGGER = logging.getLogger("nipype.utils")
@@ -124,8 +125,10 @@ def collect_participants(bids_dir, participant_label=None, strict=False, bids_va
     return found_label
 
 
+@fill_doc
 def collect_data(
     bids_dir,
+    input_type,
     participant_label,
     task=None,
     bids_validate=False,
@@ -137,10 +140,12 @@ def collect_data(
     Parameters
     ----------
     bids_dir
+    %(input_type)s
     participant_label
     task
     bids_validate
     bids_filters
+    %(cifti)s
 
     Returns
     -------
@@ -155,17 +160,21 @@ def collect_data(
     )
 
     # TODO: Add and test fsaverage.
-    PREFERRED_SPACES = {
-        False: [
-            "MNI152NLin6Asym",
-            "MNI152NLin2009cAsym",
-            "MNIInfant",
-        ],
-        True: [
-            "fsLR",
-        ],
-    }
-    allowed_spaces = PREFERRED_SPACES[cifti]
+    if cifti:
+        allowed_spaces = ["fsLR"]
+    else:
+        if input_type == "nibabies":
+            allowed_spaces = [
+                "MNIInfant",
+                "MNI152NLin6Asym",
+                "MNI152NLin2009cAsym",
+            ]
+        else:
+            allowed_spaces = [
+                "MNI152NLin6Asym",
+                "MNI152NLin2009cAsym",
+                "MNIInfant",
+            ]
 
     queries = {
         # all preprocessed BOLD files in the right space/resolution/density

--- a/xcp_d/workflow/base.py
+++ b/xcp_d/workflow/base.py
@@ -317,6 +317,7 @@ def init_subject_wf(
     """
     layout, subj_data = collect_data(
         bids_dir=fmri_dir,
+        input_type=input_type,
         participant_label=subject_id,
         task=task_id,
         bids_validate=False,

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -384,7 +384,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     workflow.connect([
         (inputnode, qc_report_wf, [
             ("bold_file", "inputnode.preprocessed_bold_file"),
-            ("mni_to_t1w", "inputnode.mni_to_t1w"),
         ]),
     ])
     # fmt:on

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -22,7 +22,7 @@ from xcp_d.interfaces.surfplotting import (
 )
 from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.plot import plot_ribbon_svg
-from xcp_d.utils.utils import get_std2bold_xforms
+from xcp_d.utils.utils import _t12native, get_std2bold_xforms
 
 LOGGER = logging.getLogger("nipype.workflow")
 
@@ -262,7 +262,7 @@ def init_execsummary_wf(
         name="get_std2native_transform",
     )
     get_std2native_transform.inputs.bold_file = bold_file
-    get_std2native_transform.inputs.t1w_to_native = t1_to_native(bold_file)
+    get_std2native_transform.inputs.t1w_to_native = _t12native(bold_file)
 
     # Transform the file to native space
     resample_parc = pe.Node(
@@ -364,14 +364,3 @@ def init_execsummary_wf(
     # fmt:on
 
     return workflow
-
-
-def t1_to_native(file_name):
-    """Get t1 to native transform file."""
-    dir_name = os.path.dirname(file_name)
-    filename = os.path.basename(file_name)
-    file_name_prefix = filename.split("desc-preproc_bold.nii.gz")[0].split("space-")[0]
-    t1_to_native_file = (
-        dir_name + "/" + file_name_prefix + "from-T1w_to-scanner_mode-image_xfm.txt"
-    )
-    return t1_to_native_file

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -74,7 +74,9 @@ def init_qc_report_wf(
     bold_mask
     t1w_mask
     %(mni_to_t1w)s
+        Only used with non-CIFTI data.
     t1w_to_native
+        Only used with non-CIFTI data.
     %(dummy_scans)s
     cleaned_file
     tmask


### PR DESCRIPTION
Partially addresses #684.

## Changes proposed in this pull request
- Set MNIInfant as the highest-priority space for nibabies volumetric data.
- Remove `xcp_d.workflow.execsummary.t1_to_native` in favor of `xcp_d.utils.utils.t12native`. The code is the same.
- Remove unnecessary `mni_to_t1w` input from `init_ciftipostprocess_wf` to `init_qc_report_wf`. This input is only used for non-CIFTI data, so there's no point in feeding it in from the CIFTI workflow.

## Documentation that should be reviewed
None
