### PR TITLE
Infer volumetric space from transform in executive summary with cifti data

### DIFF
--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -511,6 +511,7 @@ def find_nifti_bold_files(bold_file, mni_to_t1w):
         Path to the volumetric (nifti) BOLD reference file associated with nifti_bold_file.
     """
     import glob
+    import os
     import re
 
     # Get the nifti reference file

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -485,3 +485,68 @@ def _get_tr(img):
     except AttributeError:  # Error out if not in cifti
         return img.header.get_zooms()[-1]
     raise RuntimeError("Could not extract TR - unknown data structure type")
+
+
+def find_nifti_bold_files(bold_file, mni_to_t1w):
+    """Find nifti bold and boldref files associated with a given input file.
+
+    Parameters
+    ----------
+    bold_file : str
+        Path to the preprocessed BOLD file that XCPD will denoise elsewhere.
+        If this is a cifti file, then the appropriate nifti file will be determined based on
+        entities in this file, as well as the space and, potentially, cohort in the mni_to_t1w
+        file.
+        When this is a nifti file, it is returned without modification.
+    mni_to_t1w : str
+        The transform from standard space to T1w space.
+        This is used to determine the volumetric template when bold_file is a cifti file.
+        When bold_file is a nifti file, this is not used.
+
+    Returns
+    -------
+    nifti_bold_file : str
+        Path to the volumetric (nifti) preprocessed BOLD file.
+    nifti_boldref_file : str
+        Path to the volumetric (nifti) BOLD reference file associated with nifti_bold_file.
+    """
+    import glob
+    import re
+
+    # Get the nifti reference file
+    if bold_file.endswith(".nii.gz"):
+        nifti_bold_file = bold_file
+        nifti_boldref_file = bold_file.split("desc-preproc_bold.nii.gz")[0] + "boldref.nii.gz"
+        if not os.path.isfile(nifti_boldref_file):
+            raise FileNotFoundError(f"boldref file not found: {nifti_boldref_file}")
+
+    else:  # Get the cifti reference file
+        # Infer the volumetric space from the transform
+        nifti_template = re.findall("from-([a-zA-Z0-9+]+)", os.path.basename(mni_to_t1w))[0]
+        if "+" in nifti_template:
+            nifti_template, cohort = nifti_template.split("+")
+            search_substring = f"space-{nifti_template}_cohort-{cohort}"
+        else:
+            search_substring = f"space-{nifti_template}"
+
+        bb_file_prefix = bold_file.split("space-fsLR_den-91k_bold.dtseries.nii")[0]
+
+        # Find the appropriate _bold file.
+        bold_search_str = bb_file_prefix + search_substring + "*preproc_bold.nii.gz"
+        nifti_bold_file = sorted(glob.glob(bold_search_str))
+        if len(nifti_bold_file) > 1:
+            LOGGER.warn(f"More than one nifti bold file found: {', '.join(nifti_bold_file)}")
+        elif len(nifti_bold_file) == 0:
+            raise FileNotFoundError(f"bold file not found: {bold_search_str}")
+        nifti_bold_file = nifti_bold_file[0]
+
+        # Find the associated _boldref file.
+        boldref_search_str = bb_file_prefix + search_substring + "*boldref.nii.gz"
+        nifti_boldref_file = sorted(glob.glob(boldref_search_str))
+        if len(nifti_boldref_file) > 1:
+            LOGGER.warn(f"More than one nifti boldref found: {', '.join(nifti_boldref_file)}")
+        elif len(nifti_boldref_file) == 0:
+            raise FileNotFoundError(f"boldref file not found: {boldref_search_str}")
+        nifti_boldref_file = nifti_boldref_file[0]
+
+    return nifti_bold_file, nifti_boldref_file

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -28,18 +28,23 @@ def _t12native(fname):
 
     Returns
     -------
-    t12ref : str
+    t1w_to_native_xform : str
         Path to the T1w-to-scanner transform.
 
     Notes
     -----
     Only used in get_segfile, which should be removed ASAP.
     """
-    directx = os.path.dirname(fname)
-    filename = os.path.basename(fname)
-    fileup = filename.split("desc-preproc_bold.nii.gz")[0].split("space-")[0]
-    t12ref = directx + "/" + fileup + "from-T1w_to-scanner_mode-image_xfm.txt"
-    return t12ref
+    import os
+
+    pth, fname = os.path.split(fname)
+    file_prefix = fname.split("space-")[0]
+    t1w_to_native_xform = os.path.join(pth, f"{file_prefix}from-T1w_to-scanner_mode-image_xfm.txt")
+
+    if not os.path.isfile(t1w_to_native_xform):
+        raise FileNotFoundError(f"File not found: {t1w_to_native_xform}")
+
+    return t1w_to_native_xform
 
 
 def get_segfile(bold_file):

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -2,7 +2,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Workflows for generating the executive summary."""
 import fnmatch
-import glob
 import os
 from pathlib import Path
 
@@ -240,17 +239,49 @@ def init_execsummary_wf(
         all_files, "*" + bb_register_prefix + registration_file[0]
     )[0]
 
-    # Get the nifti reference file
-    if bold_file.endswith(".nii.gz"):
-        bold_reference_file = bold_file.split("desc-preproc_bold.nii.gz")[0] + "boldref.nii.gz"
+    find_nifti_files = pe.Node(
+        Function(
+            function=_find_nifti_files,
+            input_names=["bold_file", "mni_to_t1w"],
+            output_names=["bold_file", "bold_reference_file"],
+        )
+    )
 
-    else:  # Get the cifti reference file
-        bb_file_prefix = bold_file.split("space-fsLR_den-91k_bold.dtseries.nii")[0]
-        bold_reference_file = glob.glob(bb_file_prefix + "*boldref.nii.gz")[0]
-        bold_file = glob.glob(bb_file_prefix + "*preproc_bold.nii.gz")[0]
+    # fmt:off
+    workflow.connect([
+        (inputnode, find_nifti_files, [
+            ("bold_file", "bold_file"),
+            ("mni_to_t1w", "mni_to_t1w"),
+        ]),
+    ])
+    # fmt:on
 
     # Plot the reference bold image
-    plotrefbold_wf = pe.Node(PlotImage(in_file=bold_reference_file), name="plotrefbold_wf")
+    plotrefbold_wf = pe.Node(PlotImage(), name="plotrefbold_wf")
+
+    # fmt:off
+    workflow.connect([
+        (find_nifti_files, plotrefbold_wf, [
+            ("bold_reference_file", "in_file"),
+        ]),
+    ])
+    # fmt:on
+
+    find_t1_to_native = pe.Node(
+        Function(
+            function=t1_to_native,
+            input_names=["bold_file"],
+            output_names=["t1w_to_native_xform"],
+        )
+    )
+
+    # fmt:off
+    workflow.connect([
+        (find_nifti_files, find_t1_to_native, [
+            ("bold_file", "bold_file"),
+        ]),
+    ])
+    # fmt:on
 
     # Get the transform file to native space
     get_std2native_transform = pe.Node(
@@ -261,8 +292,17 @@ def init_execsummary_wf(
         ),
         name="get_std2native_transform",
     )
-    get_std2native_transform.inputs.bold_file = bold_file
-    get_std2native_transform.inputs.t1w_to_native = t1_to_native(bold_file)
+
+    # fmt:off
+    workflow.connect([
+        (find_nifti_files, get_std2native_transform, [
+            ("bold_file", "bold_file"),
+        ]),
+        (find_t1_to_native, get_std2native_transform, [
+            ("t1w_to_native_xform", "t1w_to_native"),
+        ]),
+    ])
+    # fmt:on
 
     # Transform the file to native space
     resample_parc = pe.Node(
@@ -278,20 +318,35 @@ def init_execsummary_wf(
                 )
             ),
             interpolation="MultiLabel",
-            reference_image=bold_reference_file,
         ),
         name="resample_parc",
         n_procs=omp_nthreads,
         mem_gb=mem_gb * 3 * omp_nthreads,
     )
 
+    # fmt:off
+    workflow.connect([
+        (find_nifti_files, resample_parc, [
+            ("bold_reference_file", "reference_image"),
+        ]),
+    ])
+    # fmt:on
+
     # Plot the SVG files
     plot_svgx_wf = pe.Node(
-        PlotSVGData(TR=TR, rawdata=bold_file),
+        PlotSVGData(TR=TR),
         name="plot_svgx_wf",
         mem_gb=mem_gb,
         n_procs=omp_nthreads,
     )
+
+    # fmt:off
+    workflow.connect([
+        (find_nifti_files, plot_svgx_wf, [
+            ("bold_file", "rawdata"),
+        ]),
+    ])
+    # fmt:on
 
     # Write out the necessary files:
     # Reference file
@@ -375,3 +430,38 @@ def t1_to_native(file_name):
         dir_name + "/" + file_name_prefix + "from-T1w_to-scanner_mode-image_xfm.txt"
     )
     return t1_to_native_file
+
+
+def _find_nifti_files(bold_file, mni_to_t1w):
+    """Find nifti files associated with a given input file."""
+    import glob
+    import re
+
+    # Get the nifti reference file
+    if bold_file.endswith(".nii.gz"):
+        bold_reference_file = bold_file.split("desc-preproc_bold.nii.gz")[0] + "boldref.nii.gz"
+
+    else:  # Get the cifti reference file
+        # Infer the volumetric space from the transform
+        nifti_template = re.findall("from-([a-zA-Z0-9+]+)", os.path.basename(mni_to_t1w))[0]
+        if "+" in nifti_template:
+            nifti_template, cohort = nifti_template.split("+")
+            search_substring = f"space-{nifti_template}_cohort-{cohort}"
+        else:
+            search_substring = f"space-{nifti_template}"
+
+        bb_file_prefix = bold_file.split("space-fsLR_den-91k_bold.dtseries.nii")[0]
+
+        bold_reference_file = sorted(
+            glob.glob(bb_file_prefix + search_substring + "*boldref.nii.gz")
+        )
+        if len(bold_reference_file) > 1:
+            LOGGER.warn(f"More than one nifti boldref found: {', '.join(bold_reference_file)}")
+            bold_reference_file = bold_reference_file[0]
+
+        bold_file = sorted(glob.glob(bb_file_prefix + search_substring + "*preproc_bold.nii.gz"))
+        if len(bold_file) > 1:
+            LOGGER.warn(f"More than one nifti bold file found: {', '.join(bold_file)}")
+            bold_file = bold_file[0]
+
+    return bold_file, bold_reference_file

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -245,7 +245,8 @@ def init_execsummary_wf(
             function=find_nifti_bold_files,
             input_names=["bold_file", "mni_to_t1w"],
             output_names=["bold_file", "bold_reference_file"],
-        )
+        ),
+        name="find_nifti_files",
     )
 
     # fmt:off
@@ -273,7 +274,8 @@ def init_execsummary_wf(
             function=t1_to_native,
             input_names=["bold_file"],
             output_names=["t1w_to_native_xform"],
-        )
+        ),
+        name="find_t1_to_native",
     )
 
     # fmt:off

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -343,14 +343,6 @@ def init_execsummary_wf(
         n_procs=omp_nthreads,
     )
 
-    # fmt:off
-    workflow.connect([
-        (find_nifti_files, plot_svgx_wf, [
-            ("nifti_bold_file", "rawdata"),
-        ]),
-    ])
-    # fmt:on
-
     # Write out the necessary files:
     # Reference file
     ds_plot_bold_reference_file_wf = pe.Node(

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -244,7 +244,7 @@ def init_execsummary_wf(
         Function(
             function=find_nifti_bold_files,
             input_names=["bold_file", "mni_to_t1w"],
-            output_names=["bold_file", "bold_reference_file"],
+            output_names=["nifti_bold_file", "nifti_boldref_file"],
         ),
         name="find_nifti_files",
     )
@@ -349,7 +349,7 @@ def init_execsummary_wf(
         DerivativesDataSink(
             base_directory=output_dir, dismiss_entities=["den"], datatype="figures", desc="boldref"
         ),
-        name="plotbold_reference_file",
+        name="ds_plot_bold_reference_file_wf",
         run_without_submitting=True,
     )
 

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -272,7 +272,7 @@ def init_execsummary_wf(
     find_t1_to_native = pe.Node(
         Function(
             function=_t12native,
-            input_names=["bold_file"],
+            input_names=["fname"],
             output_names=["t1w_to_native_xform"],
         ),
         name="find_t1_to_native",
@@ -281,7 +281,7 @@ def init_execsummary_wf(
     # fmt:off
     workflow.connect([
         (find_nifti_files, find_t1_to_native, [
-            ("nifti_bold_file", "bold_file"),
+            ("nifti_bold_file", "fname"),
         ]),
     ])
     # fmt:on


### PR DESCRIPTION
Partially addresses #684, along with #688.

## Changes proposed in this pull request
- Use the `from` entity in the `mni_to_t1w` transform filename to determine the template space (and possibly cohort) when selecting the appropriate nifti BOLD file and BOLD reference file for the executive summary. This should only take effect when using both `--cifti` and `--dcan-qc`, and should only _matter_ when there are multiple output spaces in the derivatives.
- Break up a number of function calls in the executive summary workflow into nodes.
- Create a new function, `_find_nifti_files`, that grabs the appropriate nifti files.

## Documentation that should be reviewed
None.
