### PR TITLE
Use appropriate intent codes for cifti outputs

### DIFF
--- a/.circleci/tests/test_ALFF.py
+++ b/.circleci/tests/test_ALFF.py
@@ -165,7 +165,7 @@ def test_cifti_alff(data_dir, tmp_path_factory):
         (
             "compute_alff_wf/alff_compt/sub-color"
             "nest001_ses-1_task-rest_run-2_space-fsLR_den-91k_"
-            "bold_alff.dtseries.nii"
+            "bold_alff.dscalar.nii"
         )
     )
     original_alff_data_mean = nb.load(original_alff).get_fdata().mean()
@@ -202,7 +202,7 @@ def test_cifti_alff(data_dir, tmp_path_factory):
 
     # Let's get the new ALFF mean
     new_alff = os.path.join(
-        tempdir, "compute_alff_wf/alff_compt/editedfile_alff.dtseries.nii"
+        tempdir, "compute_alff_wf/alff_compt/editedfile_alff.dscalar.nii"
     )
     assert os.path.isfile(new_alff)
     new_alff_data_mean = nb.load(new_alff).get_fdata().mean()

--- a/xcp_d/interfaces/resting_state.py
+++ b/xcp_d/interfaces/resting_state.py
@@ -149,7 +149,7 @@ class ComputeALFF(SimpleInterface):
         # Write out the data
 
         if self.inputs.in_file.endswith(".dtseries.nii"):
-            suffix = "_alff.dtseries.nii"
+            suffix = "_alff.dscalar.nii"
         elif self.inputs.in_file.endswith(".nii.gz"):
             suffix = "_alff.nii.gz"
 

--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -25,6 +25,7 @@ class CiftiSmooth(_CiftiSmooth, CopyHeaderInterface):
     We've added the CopyHeaderInterface because -cifti-smooth overwrites the output file's
     intent to match a dtseries extension, even when it is a dscalar file.
     """
+
     _copy_header_map = {"out_file": "in_file"}
 
 

--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -8,11 +8,17 @@ from nipype.interfaces.base import (
     TraitedSpec,
     traits,
 )
+from nipype.interfaces.mixins.fixheader import CopyHeaderInterface
 from nipype.interfaces.workbench.base import WBCommand
+from nipype.interfaces.workbench.cifti import CiftiSmooth as _CiftiSmooth
 
 from xcp_d.utils.filemanip import fname_presuffix
 
 iflogger = logging.getLogger("nipype.interface")
+
+
+class CiftiSmooth(_CiftiSmooth, CopyHeaderInterface):
+    _copy_header_map = {"out_file": "in_file"}
 
 
 class _ConvertAffineInputSpec(CommandLineInputSpec):

--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -1,7 +1,8 @@
 """Custom wb_command interfaces."""
-
+import nibabel as nb
 from nipype import logging
 from nipype.interfaces.base import (
+    BaseInterfaceInputSpec,
     CommandLineInputSpec,
     File,
     SimpleInterface,
@@ -9,32 +10,62 @@ from nipype.interfaces.base import (
     traits,
 )
 from nipype.interfaces.workbench.base import WBCommand
-from nipype.interfaces.workbench.cifti import CiftiSmooth as _CiftiSmooth
 
-from xcp_d.utils.filemanip import fname_presuffix
-from xcp_d.utils.write_save import _modify_cifti_intent
+from xcp_d.utils.filemanip import fname_presuffix, split_filename
+from xcp_d.utils.write_save import get_cifti_intents
 
 iflogger = logging.getLogger("nipype.interface")
 
 
-class CiftiSmooth(_CiftiSmooth):
-    """Modified interface for wb_command's -cifti-smooth command.
+class _FixCiftiIntentInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc="CIFTI file to check.")
 
-    Notes
-    -----
-    We've added a custom _post_run_hook method because -cifti-smooth overwrites the
-    output file's intent to match a dtseries extension, even when it is a dscalar file.
+
+class _FixCiftiIntentOutputSpec(TraitedSpec):
+    out_file = File(exists=True, mandatory=True, desc="Fixed CIFTI file.")
+
+
+class FixCiftiIntent(SimpleInterface):
+    """This is not technically a Connectome Workbench interface, but it is related.
+
+    CiftiSmooth (-cifti-smooth) overwrites the output file's intent to match a dtseries extension,
+    even when it is a dscalar file.
+    This interface sets the appropriate intent based on the extension.
+
+    We initially tried using a _post_run_hook in a modified version of the CiftiSmooth interface,
+    but felt that the errors being raised were too opaque.
+
+    If in_file has the correct intent code, it will be returned without modification.
     """
 
-    def _post_run_hook(self, runtime):
-        """Ensure output file has appropriate intent in header."""
-        runtime = super()._post_run_hook(runtime)
+    input_spec = _FixCiftiIntentInputSpec
+    output_spec = _FixCiftiIntentOutputSpec
 
-        outputs = self.aggregate_outputs(runtime=runtime).get_traitsfree()
-        # only modify the out_file if it is not a dtseries
-        if not outputs["out_file"].endswith(".dtseries"):
-            _modify_cifti_intent(filename=outputs["out_file"])
+    def _run_interface(self, runtime):
+        in_file = self.inputs.in_file
 
+        cifti_intents = get_cifti_intents()
+        _, _, out_extension = split_filename(in_file)
+        target_intent = cifti_intents.get(out_extension, None)
+
+        if target_intent is None:
+            raise ValueError(f"Unknown CIFTI extension '{out_extension}'")
+
+        img = nb.load(in_file)
+        out_file = in_file
+        # modify the intent if necessary, and write out the modified file
+        if img.nifti_header.get_intent()[0] != target_intent:
+            out_file = fname_presuffix(
+                self.inputs.in_file,
+                suffix="_modified",
+                newpath=runtime.cwd,
+                use_ext=True,
+            )
+
+            img.nifti_header.set_intent(target_intent)
+            img.to_filename(out_file)
+
+        self._results["out_file"] = out_file
         return runtime
 
 

--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -18,6 +18,13 @@ iflogger = logging.getLogger("nipype.interface")
 
 
 class CiftiSmooth(_CiftiSmooth, CopyHeaderInterface):
+    """Interface for wb_command's -cifti-smooth command.
+
+    Notes
+    -----
+    We've added the CopyHeaderInterface because -cifti-smooth overwrites the output file's
+    intent to match a dtseries extension, even when it is a dscalar file.
+    """
     _copy_header_map = {"out_file": "in_file"}
 
 

--- a/xcp_d/utils/filemanip.py
+++ b/xcp_d/utils/filemanip.py
@@ -22,11 +22,12 @@ fmlogger = logging.getLogger("nipype.utils")
 
 related_filetype_sets = [(".hdr", ".img", ".mat"), (".nii", ".mat"), (".BRIK", ".HEAD")]
 
-# TODO: Fix non-binary mask bug in Nibabel 22.1.3
-
 
 def check_binary_mask(mask_file):
-    """Check if the mask is binary."""
+    """Check if the mask is binary.
+
+    TODO: Fix non-binary mask bug in nibabies 22.1.3
+    """
     is_binary = 1
     if len(np.unique(nb.load(mask_file).get_fdata())) > 2:
         is_binary = 0
@@ -108,6 +109,9 @@ def split_filename(fname):
         ".dtraj.nii",
         ".pconnseries.nii",
         ".pconnscalar.nii",
+        ".dfan.nii",
+        ".dfibersamp.nii",
+        ".dfansamp.nii",
     ]
 
     pth = op.dirname(fname)

--- a/xcp_d/utils/write_save.py
+++ b/xcp_d/utils/write_save.py
@@ -80,24 +80,24 @@ def _modify_cifti_intent(filename, img=None):
     from xcp_d.utils.filemanip import split_filename
     from xcp_d.utils.write_save import get_cifti_intents
 
-    return_img = True
-    if img is None:
-        return_img = False
-        img = nb.load(filename)
-
     cifti_intents = get_cifti_intents()
-
     _, _, out_extension = split_filename(filename)
     target_intent = cifti_intents.get(out_extension, None)
 
     if target_intent is None:
         raise ValueError(f"Unknown CIFTI extension '{out_extension}'")
 
+    return_img = True
+    if img is None:
+        return_img = False
+        img = nb.load(filename)
+
     img.nifti_header.set_intent(target_intent)
 
     if return_img:
         return img
     else:
+        # Overwrite the original file
         img.to_filename(filename)
 
 

--- a/xcp_d/utils/write_save.py
+++ b/xcp_d/utils/write_save.py
@@ -7,8 +7,9 @@ import subprocess
 import nibabel as nb
 import numpy as np
 from nilearn import masking
-from nipype.utils.filemanip import split_filename
 from templateflow.api import get as get_template
+
+from xcp_d.utils.filemanip import split_filename
 
 
 def read_ndata(datafile, maskfile=None, scale=0):

--- a/xcp_d/workflow/postprocessing.py
+++ b/xcp_d/workflow/postprocessing.py
@@ -2,12 +2,13 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Workflows for post-processing BOLD data."""
 from nipype.interfaces import utility as niu
+from nipype.interfaces.workbench.cifti import CiftiSmooth
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from pkg_resources import resource_filename as pkgrf
 
 from xcp_d.interfaces.nilearn import Smooth
-from xcp_d.interfaces.workbench import CiftiSmooth
+from xcp_d.interfaces.workbench import FixCiftiIntent
 from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.utils import fwhm2sigma
 
@@ -91,6 +92,21 @@ size of {str(smoothing)} mm  (FWHM).
             n_procs=omp_nthreads,
         )
 
+        # Always check the intent code in CiftiSmooth's output file
+        fix_cifti_intent = pe.Node(
+            FixCiftiIntent(),
+            name="fix_cifti_intent",
+            mem_gb=mem_gb,
+            n_procs=omp_nthreads,
+        )
+
+        # fmt:off
+        workflow.connect([
+            (smooth_data, fix_cifti_intent, [("out_file", "in_file")]),
+            (fix_cifti_intent, outputnode, [("out_file", "smoothed_bold")]),
+        ])
+        # fmt:on
+
     else:
         workflow.__desc__ = f""" \
 The processed BOLD was smoothed using Nilearn with a gaussian kernel size of {str(smoothing)} mm
@@ -104,10 +120,15 @@ The processed BOLD was smoothed using Nilearn with a gaussian kernel size of {st
             n_procs=omp_nthreads,
         )
 
+        # fmt:off
+        workflow.connect([
+            (smooth_data, outputnode, [("out_file", "smoothed_bold")]),
+        ])
+        # fmt:on
+
     # fmt:off
     workflow.connect([
         (inputnode, smooth_data, [("bold_file", "in_file")]),
-        (smooth_data, outputnode, [("out_file", "smoothed_bold")]),
     ])
     # fmt:on
 

--- a/xcp_d/workflow/postprocessing.py
+++ b/xcp_d/workflow/postprocessing.py
@@ -2,12 +2,12 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Workflows for post-processing BOLD data."""
 from nipype.interfaces import utility as niu
-from nipype.interfaces.workbench import CiftiSmooth
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from pkg_resources import resource_filename as pkgrf
 
 from xcp_d.interfaces.nilearn import Smooth
+from xcp_d.interfaces.workbench import CiftiSmooth
 from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.utils import fwhm2sigma
 

--- a/xcp_d/workflow/restingstate.py
+++ b/xcp_d/workflow/restingstate.py
@@ -3,7 +3,6 @@
 """Workflows for calculating resting state-specific metrics."""
 from nipype import Function
 from nipype.interfaces import utility as niu
-from nipype.interfaces.workbench import CiftiSmooth
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from templateflow.api import get as get_template
@@ -14,6 +13,7 @@ from xcp_d.interfaces.workbench import (
     CiftiCreateDenseScalar,
     CiftiSeparateMetric,
     CiftiSeparateVolumeAll,
+    CiftiSmooth,
 )
 from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.plot import plot_alff_reho_surface, plot_alff_reho_volumetric


### PR DESCRIPTION
Closes #687.

## Changes proposed in this pull request
- Collect cifti extensions and associated intent codes from https://www.nitrc.org/forum/attachment.php?attachid=333&group_id=454&forum_id=1955, and add these to a dictionary in `write_ndata`.
- Select the appropriate cifti intent code base on the output filename's extension in `write_ndata`.

## Documentation that should be reviewed

None
