### PR TITLE
Change input type from HPC to HCP

### DIFF
--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -196,7 +196,7 @@ def get_parser():
         "--input-type",
         required=False,
         default="fmriprep",
-        choices=["fmriprep", "dcan", "hpc", "nibabies"],
+        choices=["fmriprep", "dcan", "hcp", "nibabies"],
         help=(
             "The pipeline used to generate the preprocessed derivatives. "
             "The default pipeline is 'fmriprep'. "


### PR DESCRIPTION
Reimplements #560 (which fixed #554 and was probably overwritten by a mistake in a merge).