### PR TITLE
Load basic AROMA confounds

### DIFF
--- a/docs/generalworkflow.rst
+++ b/docs/generalworkflow.rst
@@ -92,6 +92,17 @@ Processing Steps
 
     For more information about confound regressor selection, please refer to :footcite:t:`benchmarkp`.
 
+    .. warning::
+
+      In XCP-D versions prior to 0.3.1, the selected AROMA confounds were incorrect.
+      We strongly advise users of these versions not to use the ``aroma`` or ``aroma_gsr`` options.
+
+    .. warning::
+
+      In XCP-D version 0.3.1, AROMA motion components are loaded without modification.
+      This means that XCP-D performs "aggressive" denoising.
+      This is a suboptimal approach to denoising, so we recommend against using the ``aroma`` or ``aroma_gsr`` options.
+
     After the selection of confound regressors,
     the respiratory effects can optionally be filtered out from the motion estimates with band-stop or low-pass filtering to improve fMRI data quality.
     Please refer to :footcite:t:`fair2020correction` and :footcite:t:`gratton2020removal` for more information.

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -196,28 +196,27 @@ def load_confound_matrix(params, img_file, custom_confounds=None):
         # as well as acompcor and cosine
         confound = load_confounds(
             img_file,
-            strategy=(
-                [
-                    "motion",
-                    "high_pass",
-                    "compcor",
-                ]
-            ),
+            strategy=["motion", "high_pass", "compcor"],
             motion="derivatives",
             compcor="anat_separated",
             n_compcor=5,
         )[0]
     elif params == "aroma":  # Get the WM, CSF, and aroma values
+        # NOTE: This works with *aggressive* denoising!
         confound = load_confounds(
-            img_file, strategy=(["wm_csf", "ica_aroma"]), wm_csf="basic", ica_aroma="full"
+            img_file,
+            strategy=(["wm_csf", "ica_aroma"]),
+            wm_csf="basic",
+            ica_aroma="basic",
         )[0]
     elif params == "aroma_gsr":  # Get the WM, CSF, and aroma values, as well as global signal
+        # NOTE: This works with *aggressive* denoising!
         confound = load_confounds(
             img_file,
             strategy=(["wm_csf", "ica_aroma", "global_signal"]),
             wm_csf="basic",
             global_signal="basic",
-            ica_aroma="full",
+            ica_aroma="basic",
         )[0]
     elif params == "acompcor_gsr":  # Get the rot and trans values, as well as their derivative,
         # acompcor and cosine values as well as global signal


### PR DESCRIPTION
Nilearn's load_confounds requires users to provide the `desc-smoothAROMAnonaggr_bold` file in order to use the "full" ICA AROMA confounds. Since we provide the regular, preprocessed BOLD file, the "full" confounds will fail.

_However_, by loading the AROMA motion components and using those in our design matrix, we are performing "aggressive" denoising, which is not good. Basically, this PR fixes a loading bug, but commits (temporarily) to a subpar denoising strategy. I plan to switch to another strategy (e.g., non-aggressive or orthogonalization) in a future PR.

## Changes proposed in this pull request
- Change the ica_aroma regressor flag from "full" to "basic".

## Documentation to review

generalworkflow.rst