### PR TITLE
Select best volumetric space even when using `--cifti` flag

### DIFF
--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -263,10 +263,8 @@ def collect_data(
             default_allowed_spaces,
         )["nifti"]
         for space in temp_allowed_spaces:
-            nifti_bold_data = layout.get(
-                space=space,
-                **temp_bold_query,
-            )
+            temp_bold_query["space"] = space
+            nifti_bold_data = layout.get(**temp_bold_query)
             if nifti_bold_data:
                 queries["t1w_to_template_xform"]["to"] = space
                 queries["template_to_t1w_xform"]["from"] = space


### PR DESCRIPTION
Related to #684.

## Changes proposed in this pull request
- When using the `--cifti` flag, find the best volumetric space for the `template_to_t1w_xform` and `t1w_to_template_xform` files based on both the preferred spaces and what nifti BOLD files are available. This way, the transforms won't default to MNI152NLin6, the transforms for which are generated automatically, even when it's not an output space. In situations where it's _not_ an output space, the transforms for it were being selected, but then the volumetric BOLD file in another space was selected elsewhere, raising an exception.
- Tangentially, I also fixed a bug in `collect_data` where "bold"["space"] in the filter file was not respected (and indeed raised an exception).

## Documentation that should be reviewed
None.
