### PR TITLE
Enable non-aggressive denoising with signal regressors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,7 @@ release = xcp_d.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/generalworkflow.rst
+++ b/docs/generalworkflow.rst
@@ -7,9 +7,8 @@ General Workflow
 
 Input data
 ----------
-The default inputs to `XCP-D` are the outputs of  `fMRIPrep` and `Nibabies`.
-`xcp_d` can also minimally process `HCP` data,
- whichs require the `input-type` flag ( `hcp` ).
+The default inputs to ``xcp_d`` are the outputs of  ``fMRIPrep`` and ``Nibabies``.
+``xcp_d`` can also minimally process ``HCP`` data, which requires the ``--input-type hcp`` flag.
 
 
 Processing Steps

--- a/docs/generalworkflow.rst
+++ b/docs/generalworkflow.rst
@@ -97,12 +97,6 @@ Processing Steps
       In XCP-D versions prior to 0.3.1, the selected AROMA confounds were incorrect.
       We strongly advise users of these versions not to use the ``aroma`` or ``aroma_gsr`` options.
 
-    .. warning::
-
-      In XCP-D version 0.3.1, AROMA motion components are loaded without modification.
-      This means that XCP-D performs "aggressive" denoising.
-      This is a suboptimal approach to denoising, so we recommend against using the ``aroma`` or ``aroma_gsr`` options.
-
     After the selection of confound regressors,
     the respiratory effects can optionally be filtered out from the motion estimates with band-stop or low-pass filtering to improve fMRI data quality.
     Please refer to :footcite:t:`fair2020correction` and :footcite:t:`gratton2020removal` for more information.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -170,10 +170,41 @@ and provide a folder containing the custom confounds files for all of the subjec
 The individual confounds files should be tab-delimited, with one column for each regressor,
 and one row for each volume in the data being denoised.
 
-If you want to regress task-related signals out of your data, you can use the custom confounds option to do it.
+Signal Confounds for Non-Aggressive Denoising
+---------------------------------------------
+
+Let's say you have some nuisance regressors that are not necessarily orthogonal to some associated regressors that are ostensibly noise.
+For example, if you ran `tedana <https://tedana.readthedocs.io/en/stable/>`_ on multi-echo data,
+you would have a series of "rejected" (noise) and "accepted" (signal) ICA components.
+Because tedana uses a spatial ICA, these components' time series are not necessarily independent,
+and there can be shared variance between them.
+If you want to properly denoise your data using the noise components,
+you need to perform "non-aggressive" denoising so that variance from the signal components is not removed as well.
+In non-aggressive denoising, you fit a GLM using both the noise and signal regressors,
+then reconstruct the predicted data using just the noise regressors,
+and finally remove that predicted data from the real data.
+
+For more information about different types of denoising,
+see `tedana's documentation <https://tedana.readthedocs.io/en/latest/denoising.html>`_,
+`this NeuroStars topic <https://neurostars.org/t/aggressive-vs-nonaggressive-denoising/5612>`_,
+and/or `Pruim et al. (2015) <https://doi.org/10.1016/j.neuroimage.2015.02.064>`_.
+
+So how do we implement this in ``xcp_d``?
+In order to define regressors that should be treated as signal,
+and thus use non-aggressive denoising instead of the default aggressive denoising,
+you should include those regressors in your custom confounds file,
+with column names starting with ``signal__`` (lower-case "signal", followed by two underscores).
+
+.. important::
+
+   ``xcp_d`` will automatically perform non-aggressive denoising with any nuisance-regressor option that uses AROMA regressors
+   (e.g., ``aroma`` or ``aroma_gsr``).
+
 
 Task Regression
 ---------------
+
+If you want to regress task-related signals out of your data, you can use the custom confounds option to do it.
 
 Here we document how to include task effects as confounds.
 

--- a/xcp_d/data/boilerplate.bib
+++ b/xcp_d/data/boilerplate.bib
@@ -226,18 +226,6 @@ Publisher: Nature Publishing Group},
 	pages = {105--124},
 }
 
-@article{scikit-learn,
-	title = {Scikit-learn: {Machine} {Learning} in {Python}},
-	abstract = {Scikit-learn is a Python module integrating a wide range of state-of-the-art machine learning algorithms for medium-scale supervised and unsupervised problems. This package focuses on bringing machine learning to non-specialists using a general-purpose high-level language. Emphasis is put on ease of use, performance, documentation, and API consistency. It has minimal dependencies and is distributed under the simpliﬁed BSD license, encouraging its use in both academic and commercial settings. Source code, binaries, and documentation can be downloaded from http://scikit-learn.sourceforge.net.},
-	language = {en},
-	journal = {Journal of Machine Learning Research},
-	author = {Pedregosa, Fabian and Varoquaux, Gael and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and Vanderplas, Jake and Passos, Alexandre and Cournapeau, David},
-	volume          = {12},
-	pages = {2825-2830},
-	year = {2011},
-	file = {Full Text PDF:/Users/adebimpe/Zotero/storage/UIBQU4AK/Pedregosa et al. - 2011 - Scikit-learn Machine Learning in Python.pdf:application/pdf;Pedregosa et al. - Scikit-learn Machine Learning in Python.pdf:/Users/adebimpe/Zotero/storage/GHKMWPJD/Pedregosa et al. - Scikit-learn Machine Learning in Python.pdf:application/pdf},
-}
-
 @article{2020SciPy-NMeth,
 	title = {{SciPy} 1.0: fundamental algorithms for scientific computing in {Python}},
 	volume = {17},
@@ -551,4 +539,16 @@ Publisher: Nature Publishing Group},
   publisher={Elsevier},
   doi={10.1016/j.neuroimage.2020.116866},
   url={https://doi.org/10.1016/j.neuroimage.2020.116866}
+}
+
+@article{pruim2015ica,
+  title={ICA-AROMA: A robust ICA-based strategy for removing motion artifacts from fMRI data},
+  author={Pruim, Raimon HR and Mennes, Maarten and van Rooij, Daan and Llera, Alberto and Buitelaar, Jan K and Beckmann, Christian F},
+  journal={Neuroimage},
+  volume={112},
+  pages={267--277},
+  year={2015},
+  publisher={Elsevier},
+  doi={10.1016/j.neuroimage.2015.02.064},
+  url={https://doi.org/10.1016/j.neuroimage.2015.02.064}
 }

--- a/xcp_d/data/boilerplate.bib
+++ b/xcp_d/data/boilerplate.bib
@@ -552,3 +552,14 @@ Publisher: Nature Publishing Group},
   doi={10.1016/j.neuroimage.2015.02.064},
   url={https://doi.org/10.1016/j.neuroimage.2015.02.064}
 }
+
+@article{behzadi2007component,
+  title={A component based noise correction method (CompCor) for BOLD and perfusion based fMRI},
+  author={Behzadi, Yashar and Restom, Khaled and Liau, Joy and Liu, Thomas T},
+  journal={Neuroimage},
+  volume={37},
+  number={1},
+  pages={90--101},
+  year={2007},
+  publisher={Elsevier}
+}

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -70,7 +70,7 @@ class Regress(SimpleInterface):
         bold_arr = read_ndata(datafile=self.inputs.in_file, maskfile=self.inputs.mask)
         bold_arr = bold_arr.T  # transpose BOLD data to TxS
 
-        # Regress out the confounds via linear regression from sklearn
+        # Regress out the confounds via linear regression from numpy
         if bold_arr.shape[0] < confound_arr.shape[1]:
             LOGGER.warning(
                 "Warning: Regression might not be effective due to rank deficiency, "

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -3,6 +3,7 @@
 """Regression interfaces."""
 import numpy as np
 import pandas as pd
+from nilearn import signal
 from nipype import logging
 from nipype.interfaces.base import (
     BaseInterfaceInputSpec,
@@ -11,10 +12,8 @@ from nipype.interfaces.base import (
     TraitedSpec,
     traits,
 )
-from sklearn.linear_model import LinearRegression
 
 from xcp_d.utils.filemanip import fname_presuffix, split_filename
-from xcp_d.utils.utils import demean_detrend_data
 from xcp_d.utils.write_save import despikedatacifti, read_ndata, write_ndata
 
 LOGGER = logging.getLogger("nipype.interface")
@@ -55,6 +54,7 @@ class Regress(SimpleInterface):
 
         # Get the confound matrix
         confound = pd.read_table(self.inputs.confounds)
+        confound_arr = confound.to_numpy()
 
         # Any columns starting with "signal__" are assumed to be signal regressors
         signal_columns = [c for c in confound.columns if c.startswith("signal__")]
@@ -67,53 +67,75 @@ class Regress(SimpleInterface):
                 i for i, c in enumerate(confound.columns) if c not in signal_columns
             ]
 
-        # Transpose confounds matrix to line up with bold matrix
-        confound_arr = confound.to_numpy().T
-
         # Get the nifti/cifti matrix
-        bold_matrix = read_ndata(datafile=self.inputs.in_file, maskfile=self.inputs.mask)
-
-        # Demean and detrend the data
-        demeaned_detrended_data = demean_detrend_data(data=bold_matrix)
+        bold_arr = read_ndata(datafile=self.inputs.in_file, maskfile=self.inputs.mask)
+        bold_arr = bold_arr.T  # transpose BOLD data to TxS
 
         # Regress out the confounds via linear regression from sklearn
-        if demeaned_detrended_data.shape[1] < confound_arr.shape[0]:
+        if bold_arr.shape[0] < confound_arr.shape[1]:
             LOGGER.warning(
                 "Warning: Regression might not be effective due to rank deficiency, "
                 "i.e., the number of volumes in the bold file is smaller than the number "
                 "of regressors."
             )
 
-        regression = LinearRegression(n_jobs=1)
-        regression.fit(confound_arr.T, demeaned_detrended_data.T)
-
         if signal_columns:
-            betas = regression.coef_
-            pred_noise_data = np.dot(
-                betas[:, noise_columns_idx],
-                confound_arr[noise_columns_idx, :],
+            # Perform non-aggressive denoising.
+            # First, mean-center and detrend BOLD data
+            bold_arr = signal.clean(
+                signals=bold_arr,
+                detrend=True,  # this mean-centers and linearly detrends the data
+                standardize=False,
+                confounds=None,
+                filter=None,
+                ensure_finite=True,
             )
-            residuals = demeaned_detrended_data - pred_noise_data
+
+            # Fit to all regressors, including signal ones.
+            # NOTE: Could we replace with nilearn.glm.first_level.run_glm?
+            betas = np.linalg.lstsq(confound_arr, bold_arr, rcond=None)[0]
+
+            # Use the parameter estimates from the full fit to remove the *noise* only
+            pred_noise_data = np.dot(
+                confound_arr[:, noise_columns_idx],
+                betas[noise_columns_idx, :],
+            )
+            residuals = bold_arr - pred_noise_data
+
         else:
-            pred_noise_data = regression.predict(confound_arr.T)
-            residuals = demeaned_detrended_data - pred_noise_data.T
+            # Denoise the data the regular way
+            residuals = signal.clean(
+                signals=bold_arr,
+                detrend=True,  # this mean-centers and linearly detrends the data
+                standardize=False,
+                sample_mask=None,
+                confounds=confound,
+                standardize_confounds=False,  # do we want to set this to True?
+                filter=None,
+                low_pass=None,
+                high_pass=None,
+                t_r=None,  # unneeded unless we do temporal filtering
+                ensure_finite=True,
+            )
 
         # Write out the data
         _, _, extension = split_filename(self.inputs.in_file)
         suffix = f"_residualized{extension}"
-
         self._results["res_file"] = fname_presuffix(
             self.inputs.in_file,
             suffix=suffix,
             newpath=runtime.cwd,
             use_ext=False,
         )
-        self._results["res_file"] = write_ndata(
+
+        residuals = residuals.T  # transpose residual BOLD data back to SxT
+        write_ndata(
             data_matrix=residuals,
             template=self.inputs.in_file,
             filename=self._results["res_file"],
             mask=self.inputs.mask,
         )
+
         return runtime
 
 

--- a/xcp_d/interfaces/regression.py
+++ b/xcp_d/interfaces/regression.py
@@ -90,10 +90,10 @@ class Regress(SimpleInterface):
         if signal_columns:
             betas = regression.coef_
             pred_noise_data = np.dot(
+                betas[:, noise_columns_idx],
                 confound_arr[noise_columns_idx, :],
-                betas[noise_columns_idx, :],
             )
-            residuals = demeaned_detrended_data - pred_noise_data.T
+            residuals = demeaned_detrended_data - pred_noise_data
         else:
             pred_noise_data = regression.predict(confound_arr.T)
             residuals = demeaned_detrended_data - pred_noise_data.T

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -442,8 +442,10 @@ def get_preproc_pipeline_info(input_type, fmri_dir):
         with open(dataset_description) as f:
             dataset_dict = json.load(f)
 
+        info_dict["name"] = dataset_dict["GeneratedBy"][0]["Name"]
         info_dict["version"] = dataset_dict["GeneratedBy"][0]["Version"]
     else:
+        info_dict["name"] = input_type
         info_dict["version"] = "unknown"
 
     if input_type == "fmriprep":

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -195,7 +195,6 @@ def get_customfile(custom_confounds_folder, fmriprep_confounds_file):
     return custom_confounds_file
 
 
-@fill_doc
 def consolidate_confounds(
     img_file,
     params,
@@ -207,7 +206,7 @@ def consolidate_confounds(
     ----------
     img_file : str
         bold file
-    %(params)s
+    params
     custom_confounds_folder : str or None
         Path to custom confounds tsv. May be None.
 

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -175,59 +175,62 @@ def load_confound_matrix(params, img_file, custom_confounds=None):
     confound : pandas.DataFrame
         The loaded and selected confounds.
     """
-    if params == "24P":  # Get rot and trans values, as well as derivatives and square
-        confound = load_confounds(img_file, strategy=(["motion"]), motion="full")[0]
-    elif params == "27P":  # Get rot and trans values, as well as derivatives and square, WM, CSF,
-        # global signal
-        confound = load_confounds(
-            img_file, strategy=(["motion", "wm_csf", "global_signal"]), motion="full"
-        )[0]
-    elif params == "36P":  # Get rot and trans values, as well as derivatives, WM, CSF,
+    PARAM_KWARGS = {
+        # Get rot and trans values, as well as derivatives and square
+        "24P": {
+            "strategy": ["motion"],
+            "motion": "full",
+        },
+        # Get rot and trans values, as well as derivatives and square, WM, CSF,
+        "27P": {
+            "strategy": ["motion", "global_signal", "wm_csf"],
+            "motion": "full",
+        },
+        # Get rot and trans values, as well as derivatives, WM, CSF,
         # global signal, and square. Add the square and derivative of the WM, CSF
         # and global signal as well.
-        confound = load_confounds(
-            img_file,
-            strategy=(["motion", "wm_csf", "global_signal"]),
-            motion="full",
-            global_signal="full",
-            wm_csf="full",
-        )[0]
-    elif params == "acompcor":  # Get the rot and trans values, their derivative,
+        "36P": {
+            "strategy": ["motion", "global_signal", "wm_csf"],
+            "motion": "full",
+            "global_signal": "full",
+            "wm_csf": "full",
+        },
+        # Get the rot and trans values, their derivative,
         # as well as acompcor and cosine
-        confound = load_confounds(
-            img_file,
-            strategy=["motion", "high_pass", "compcor"],
-            motion="derivatives",
-            compcor="anat_separated",
-            n_compcor=5,
-        )[0]
-    elif params == "aroma":  # Get the WM, CSF, and aroma values
-        # NOTE: This works with *aggressive* denoising!
-        confound = load_confounds(
-            img_file,
-            strategy=(["wm_csf", "ica_aroma"]),
-            wm_csf="basic",
-            ica_aroma="basic",
-        )[0]
-    elif params == "aroma_gsr":  # Get the WM, CSF, and aroma values, as well as global signal
-        # NOTE: This works with *aggressive* denoising!
-        confound = load_confounds(
-            img_file,
-            strategy=(["wm_csf", "ica_aroma", "global_signal"]),
-            wm_csf="basic",
-            global_signal="basic",
-            ica_aroma="basic",
-        )[0]
-    elif params == "acompcor_gsr":  # Get the rot and trans values, as well as their derivative,
+        "acompcor": {
+            "strategy": ["motion", "high_pass", "compcor"],
+            "motion": "derivatives",
+            "compcor": "anat_separated",
+            "n_compcor": 5,
+        },
+        # Get the rot and trans values, as well as their derivative,
         # acompcor and cosine values as well as global signal
-        confound = load_confounds(
-            img_file,
-            strategy=(["motion", "high_pass", "compcor", "global_signal"]),
-            motion="derivatives",
-            compcor="anat_separated",
-            global_signal="basic",
-            n_compcor=5,
-        )[0]
+        "acompcor_gsr": {
+            "strategy": ["motion", "high_pass", "compcor", "global_signal"],
+            "motion": "derivatives",
+            "compcor": "anat_separated",
+            "global_signal": "basic",
+            "n_compcor": 5,
+        },
+        # Get the WM, CSF, and aroma values
+        "aroma": {
+            "strategy": ["ica_aroma", "wm_csf"],
+            "ica_aroma": "basic",
+            "wm_csf": "basic",
+        },
+        # Get the WM, CSF, and aroma values, as well as global signal
+        "aroma_gsr": {
+            "strategy": ["ica_aroma", "wm_csf", "global_signal"],
+            "ica_aroma": "basic",
+            "wm_csf": "basic",
+            "global_signal": "basic",
+        },
+    }
+
+    if params in PARAM_KWARGS.keys():
+        kwargs = PARAM_KWARGS[params]
+        confound = load_confounds(img_file, **kwargs)[0]
+
     elif params == "custom":
         # For custom confounds with no other confounds
         confound = pd.read_table(custom_confounds, sep="\t")

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -263,7 +263,7 @@ def _get_mixing_matrix(img_file):
     if not mixing_file:
         raise FileNotFoundError(f"Could not find mixing matrix for {img_file}")
 
-    return mixing_file
+    return mixing_file[0]
 
 
 def _get_aroma_noise_comps(img_file):
@@ -278,7 +278,7 @@ def _get_aroma_noise_comps(img_file):
     if not index_file:
         raise FileNotFoundError(f"Could not find AROMAnoiseICs file for {img_file}")
 
-    return index_file
+    return index_file[0]
 
 
 def _label_mixing_matrix(mixing_file, noise_index_file):

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -245,9 +245,7 @@ def describe_regression(params, custom_confounds_file):
         non_aggro = any([c.startswith("signal__") for c in custom_confounds.columns])
 
     BASE_DESCRIPTIONS = {
-        "custom": (
-            "A custom set of regressors was used, with no other regressors from XCP-D. "
-        ),
+        "custom": "A custom set of regressors was used, with no other regressors from XCP-D. ",
         "24P": (
             "In total, 24 nuisance regressors were selected  from the nuisance "
             "confound matrices of fMRIPrep output. These nuisance regressors included "
@@ -298,9 +296,7 @@ def describe_regression(params, custom_confounds_file):
 
     desc = BASE_DESCRIPTIONS[params]
     if use_custom_confounds and params != "custom":
-        desc += (
-            "Additionally, custom confounds were also included as nuisance regressors."
-        )
+        desc += "Additionally, custom confounds were also included as nuisance regressors."
 
     if "aroma" not in params and non_aggro:
         desc += (

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -214,16 +214,16 @@ def load_confound_matrix(params, img_file, custom_confounds=None):
             "global_signal": "basic",
             "n_compcor": 5,
         },
-        # Get the WM, CSF, and aroma values
+        # Get WM and CSF
+        # AROMA confounds are loaded separately
         "aroma": {
-            "strategy": ["ica_aroma", "wm_csf"],
-            "ica_aroma": "basic",
+            "strategy": ["wm_csf"],
             "wm_csf": "basic",
         },
-        # Get the WM, CSF, and aroma values, as well as global signal
+        # Get WM, CSF, and global signal
+        # AROMA confounds are loaded separately
         "aroma_gsr": {
-            "strategy": ["ica_aroma", "wm_csf", "global_signal"],
-            "ica_aroma": "basic",
+            "strategy": ["wm_csf", "global_signal"],
             "wm_csf": "basic",
             "global_signal": "basic",
         },

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -195,6 +195,7 @@ def get_customfile(custom_confounds_folder, fmriprep_confounds_file):
     return custom_confounds_file
 
 
+@fill_doc
 def consolidate_confounds(
     img_file,
     params,
@@ -204,17 +205,16 @@ def consolidate_confounds(
 
     Parameters
     ----------
-    params : str
     img_file : str
         bold file
-    fmriprep_confounds_file : str
-    custom_confounds_folder : str
-        file to custom confounds tsv
+    %(params)s
+    custom_confounds_folder : str or None
+        Path to custom confounds tsv. May be None.
 
     Returns
     -------
     out_file : str
-        file to combined tsv
+        Path to combined tsv.
     """
     import os
 
@@ -234,7 +234,18 @@ def consolidate_confounds(
 
 @fill_doc
 def describe_regression(params, custom_confounds_file):
-    """Build a text description of the regression that will be performed."""
+    """Build a text description of the regression that will be performed.
+
+    Parameters
+    ----------
+    %(params)s
+    custom_confounds_file : str or None
+
+    Returns
+    -------
+    desc : str
+        A text description of the regression.
+    """
     import nilearn
     import pandas as pd
 
@@ -247,46 +258,49 @@ def describe_regression(params, custom_confounds_file):
     BASE_DESCRIPTIONS = {
         "custom": "A custom set of regressors was used, with no other regressors from XCP-D. ",
         "24P": (
-            "In total, 24 nuisance regressors were selected  from the nuisance "
-            "confound matrices of fMRIPrep output. These nuisance regressors included "
+            "In total, 24 nuisance regressors were selected from the preprocessing confounds. "
+            "These nuisance regressors included "
             "six motion parameters with their temporal derivatives, "
             "and their quadratic expansion of those six motion parameters and their "
-            "temporal derivatives  [@benchmarkp;@satterthwaite_2013]. "
+            "temporal derivatives [@benchmarkp;@satterthwaite_2013]. "
         ),
         "27P": (
-            "In total, 27 nuisance regressors were selected from the nuisance "
-            "confound matrices of fMRIPrep output. These nuisance regressors included "
+            "In total, 27 nuisance regressors were selected from the preprocessing confounds. "
+            "These nuisance regressors included "
             "six motion parameters with their temporal derivatives, "
-            "the quadratic expansion of those six motion parameters and "
-            "their derivatives, the global signal, the mean white matter "
-            "signal, and the mean CSF signal [@benchmarkp;@satterthwaite_2013]. "
+            "the quadratic expansion of those six motion parameters and their derivatives, "
+            "mean global signal, mean white matter signal, and mean CSF signal "
+            "[@benchmarkp;@satterthwaite_2013]. "
         ),
         "36P": (
-            "In total, 36 nuisance regressors were selected from the nuisance "
-            "confound matrices of fMRIPrep output. These nuisance regressors included "
-            "six motion parameters, global signal, the mean white matter, "
-            "the mean CSF signal with their temporal derivatives, "
+            "In total, 36 nuisance regressors were selected from the preprocessing confounds. "
+            "These nuisance regressors included "
+            "six motion parameters, mean global signal, mean white matter signal, "
+            "mean CSF signal with their temporal derivatives, "
             "and the quadratic expansion of six motion parameters, tissues signals and "
             "their temporal derivatives [@benchmarkp;@satterthwaite_2013]. "
         ),
         "acompcor": (
-            "The top 5 principal aCompCor components from WM and CSF compartments "
-            "were selected as "
-            "nuisance regressors. Additionally, the six motion parameters and their temporal "
-            "derivatives were added as confounds [@benchmarkp;@satterthwaite_2013]. "
+            "The top 5 aCompCor principal components from the WM and CSF compartments "
+            "were selected as nuisance regressors [@behzadi2007component], "
+            "along with the six motion parameters and their temporal derivatives "
+            "[@benchmarkp;@satterthwaite_2013]. "
         ),
         "acompcor_gsr": (
-            "All the clean aroma components [@pruim2015ica] with the mean white matter "
-            "signal, and the mean CSF signal, and mean global signal were "
-            "selected as nuisance regressors [@benchmarkp;@satterthwaite_2013]. "
+            "The top 5 aCompCor principal components from the WM and CSF compartments "
+            "were selected as nuisance regressors [@behzadi2007component], "
+            "along with the six motion parameters and their temporal derivatives, "
+            "mean white matter signal, mean CSF signal, and mean global signal "
+            "[@benchmarkp;@satterthwaite_2013]. "
         ),
         "aroma": (
-            "AROMA motion-labeled components, mean white matter signal, and mean CSF signal were "
-            "selected as nuisance regressors [@benchmarkp;@satterthwaite_2013]. "
+            "AROMA motion-labeled components [@pruim2015ica], mean white matter signal, "
+            "and mean CSF signal were selected as nuisance regressors "
+            "[@benchmarkp;@satterthwaite_2013]. "
         ),
         "aroma_gsr": (
-            "AROMA motion-labeled components, mean white matter signal, mean CSF signal, "
-            "and mean global signal were selected as nuisance regressors "
+            "AROMA motion-labeled components [@pruim2015ica], mean white matter signal, "
+            "mean CSF signal, and mean global signal were selected as nuisance regressors "
             "[@benchmarkp;@satterthwaite_2013]. "
         ),
     }
@@ -296,7 +310,7 @@ def describe_regression(params, custom_confounds_file):
 
     desc = BASE_DESCRIPTIONS[params]
     if use_custom_confounds and params != "custom":
-        desc += "Additionally, custom confounds were also included as nuisance regressors."
+        desc += "Additionally, custom confounds were also included as nuisance regressors. "
 
     if "aroma" not in params and non_aggro:
         desc += (
@@ -337,8 +351,7 @@ def describe_regression(params, custom_confounds_file):
 
 @fill_doc
 def load_confound_matrix(params, img_file, custom_confounds=None):
-    """
-    Load a subset of the confounds associated with a given file.
+    """Load a subset of the confounds associated with a given file.
 
     Parameters
     ----------
@@ -433,6 +446,7 @@ def load_confound_matrix(params, img_file, custom_confounds=None):
 
 
 def _get_mixing_matrix(img_file):
+    """Find AROMA (i.e., MELODIC) mixing matrix file for a given BOLD file."""
     suffix = "_space-" + img_file.split("space-")[1]
 
     mixing_candidates = [
@@ -448,6 +462,7 @@ def _get_mixing_matrix(img_file):
 
 
 def _get_aroma_noise_comps(img_file):
+    """Find AROMA noise components file for a given BOLD file."""
     suffix = "_space-" + img_file.split("space-")[1]
 
     index_candidates = [
@@ -463,6 +478,7 @@ def _get_aroma_noise_comps(img_file):
 
 
 def _label_mixing_matrix(mixing_file, noise_index_file):
+    """Prepend 'signal__' to any non-noise components in AROMA mixing matrix."""
     mixing_matrix = np.loadtxt(mixing_file, delimiter="\t")
     noise_index = np.loadtxt(noise_index_file, delimiter=",", dtype=int)
     # shift noise index to start with zero

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -480,6 +480,8 @@ def get_customfile(custom_confounds_folder, fmriprep_confounds_file):
     custom_confounds_file : str or None
         The appropriate custom confounds file.
     """
+    import os
+
     if custom_confounds_folder is None:
         return None
 

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import nibabel as nb
 import numpy as np
 from nipype.interfaces.ants import ApplyTransforms
-from scipy.signal import butter, detrend, filtfilt
+from scipy.signal import butter, filtfilt
 from templateflow.api import get as get_template
 
 from xcp_d.utils.doc import fill_doc
@@ -582,30 +582,6 @@ def butter_bandpass(data, fs, lowpass, highpass, order=2):
         )
 
     return filtered_data
-
-
-def demean_detrend_data(data):
-    """Mean-center and remove linear trends over time from data.
-
-    Parameters
-    ----------
-    data : numpy.ndarray
-        vertices by timepoints for bold file
-
-    Returns
-    -------
-    detrended : numpy.ndarray
-        demeaned and detrended data
-    """
-    demeaned = detrend(
-        data, axis=-1, type="constant", bp=0, overwrite_data=False
-    )  # Demean data using "constant" detrend,
-    # which subtracts mean
-    detrended = detrend(
-        demeaned, axis=-1, type="linear", bp=0, overwrite_data=False
-    )  # Detrend data using linear method
-
-    return detrended  # Subtract these predicted values from the demeaned data
 
 
 def consolidate_confounds(

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -12,8 +12,6 @@ from nipype.interfaces.ants import ApplyTransforms
 from scipy.signal import butter, filtfilt
 from templateflow.api import get as get_template
 
-from xcp_d.utils.doc import fill_doc
-
 
 def _t12native(fname):
     """Select T1w-to-scanner transform associated with a given BOLD file.
@@ -383,125 +381,6 @@ def fwhm2sigma(fwhm):
     return fwhm / np.sqrt(8 * np.log(2))
 
 
-@fill_doc
-def stringforparams(params):
-    """Infer nuisance regression description from parameter set.
-
-    Parameters
-    ----------
-    %(params)s
-
-    Returns
-    -------
-    bsignal : str
-        String describing the parameters used for nuisance regression.
-    """
-    if params == "custom":
-        bsignal = "A custom set of regressors was used, with no other regressors from XCP-D"
-
-    elif params == "24P":
-        bsignal = (
-            "In total, 24 nuisance regressors were selected  from the nuisance "
-            "confound matrices of fMRIPrep output. These nuisance regressors included "
-            "six motion parameters with their temporal derivatives, "
-            "and their quadratic expansion of those six motion parameters and their "
-            "temporal derivatives"
-        )
-
-    elif params == "27P":
-        bsignal = (
-            "In total, 27 nuisance regressors were selected from the nuisance "
-            "confound matrices of fMRIPrep output. These nuisance regressors included "
-            "six motion parameters with their temporal derivatives, "
-            "the quadratic expansion of those six motion parameters and "
-            "their derivatives, the global signal, the mean white matter "
-            "signal, and the mean CSF signal"
-        )
-
-    elif params == "36P":
-        bsignal = (
-            "In total, 36 nuisance regressors were selected from the nuisance "
-            "confound matrices of fMRIPrep output. These nuisance regressors included "
-            "six motion parameters, global signal, the mean white matter, "
-            "the mean CSF signal with their temporal derivatives, "
-            "and the quadratic expansion of six motion parameters, tissues signals and "
-            "their temporal derivatives"
-        )
-
-    elif params == "aroma":
-        bsignal = (
-            "All the clean aroma components with the mean white matter "
-            "signal, and the mean CSF signal were selected as nuisance regressors"
-        )
-
-    elif params == "acompcor":
-        bsignal = (
-            "The top 5 principal aCompCor components from WM and CSF compartments "
-            "were selected as "
-            "nuisance regressors. Additionally, the six motion parameters and their temporal "
-            "derivatives were added as confounds."
-        )
-
-    elif params == "aroma_gsr":
-        bsignal = (
-            "All the clean aroma components with the mean white matter "
-            "signal, and the mean CSF signal, and mean global signal were "
-            "selected as nuisance regressors"
-        )
-
-    elif params == "acompcor_gsr":
-        bsignal = (
-            "The top 5 principal aCompCor components from WM and CSF "
-            "compartments were selected as "
-            "nuisance regressors. Additionally, the six motion parameters and their temporal "
-            "derivatives were added as confounds. The average global signal was also added as a "
-            "regressor."
-        )
-
-    else:
-        raise ValueError(f"Parameter string not understood: {params}")
-
-    return bsignal
-
-
-def get_customfile(custom_confounds_folder, fmriprep_confounds_file):
-    """Identify a custom confounds file.
-
-    Parameters
-    ----------
-    custom_confounds_folder : str or None
-        The path to the custom confounds file.
-    fmriprep_confounds_file : str
-        Path to the confounds file from the preprocessing pipeline.
-        We expect the custom confounds file to have the same name.
-
-    Returns
-    -------
-    custom_confounds_file : str or None
-        The appropriate custom confounds file.
-    """
-    import os
-
-    if custom_confounds_folder is None:
-        return None
-
-    if not os.path.isdir(custom_confounds_folder):
-        raise ValueError(f"Custom confounds location does not exist: {custom_confounds_folder}")
-
-    custom_confounds_filename = os.path.basename(fmriprep_confounds_file)
-    custom_confounds_file = os.path.abspath(
-        os.path.join(
-            custom_confounds_folder,
-            custom_confounds_filename,
-        )
-    )
-
-    if not os.path.isfile(custom_confounds_file):
-        raise FileNotFoundError(f"Custom confounds file not found: {custom_confounds_file}")
-
-    return custom_confounds_file
-
-
 def zscore_nifti(img, outputname, mask=None):
     """Normalize (z-score) a NIFTI image.
 
@@ -584,40 +463,3 @@ def butter_bandpass(data, fs, lowpass, highpass, order=2):
         )
 
     return filtered_data
-
-
-def consolidate_confounds(
-    img_file,
-    params,
-    custom_confounds_file=None,
-):
-    """Combine confounds files into a single tsv.
-
-    Parameters
-    ----------
-    img_file : file
-        bold file
-    custom_confounds_file : file
-        file to custom confounds tsv
-    params : string
-        confound parameters to load
-
-    Returns
-    -------
-    out_file : file
-        file to combined tsv
-    """
-    import os
-
-    from xcp_d.utils.confounds import load_confound_matrix
-
-    confounds_df = load_confound_matrix(
-        img_file=img_file,
-        params=params,
-        custom_confounds=custom_confounds_file,
-    )
-
-    out_file = os.path.abspath("confounds.tsv")
-    confounds_df.to_csv(out_file, sep="\t", index=False)
-
-    return out_file

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -10,7 +10,6 @@ import nibabel as nb
 import numpy as np
 from nipype.interfaces.ants import ApplyTransforms
 from scipy.signal import butter, detrend, filtfilt
-from sklearn.linear_model import LinearRegression
 from templateflow.api import get as get_template
 
 from xcp_d.utils.doc import fill_doc
@@ -583,28 +582,6 @@ def butter_bandpass(data, fs, lowpass, highpass, order=2):
         )
 
     return filtered_data
-
-
-def linear_regression(data, confound):
-    """Perform linear regression with sklearn's LinearRegression.
-
-    Parameters
-    ----------
-    data : numpy.ndarray
-        vertices by timepoints for bold file
-    confound : numpy.ndarray
-       nuisance regressors - vertices by timepoints for confounds matrix
-
-    Returns
-    -------
-    numpy.ndarray
-        residual matrix after regression
-    """
-    regression = LinearRegression(n_jobs=1)
-    regression.fit(confound.T, data.T)
-    y_predicted = regression.predict(confound.T)
-
-    return data - y_predicted.T
 
 
 def demean_detrend_data(data):

--- a/xcp_d/workflow/base.py
+++ b/xcp_d/workflow/base.py
@@ -364,7 +364,7 @@ def init_subject_wf(
     workflow.__desc__ = f"""
 ### Post-processing of {input_type} outputs
 The eXtensible Connectivity Pipeline (XCP) [@mitigating_2018;@satterthwaite_2013]
-was used to post-process the outputs of {input_type} version {info_dict["version"]}
+was used to post-process the outputs of {info_dict["name"]} version {info_dict["version"]}
 {info_dict["references"]}.
 XCP was built with *Nipype* {nipype_ver} [@nipype1, RRID:SCR_002502].
 """

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -5,7 +5,6 @@ import os
 
 import nibabel as nb
 import numpy as np
-import sklearn
 from nipype import Function, logging
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
@@ -23,10 +22,14 @@ from xcp_d.interfaces.prepostcleaning import (
 from xcp_d.interfaces.regression import Regress
 from xcp_d.interfaces.resting_state import DespikePatch
 from xcp_d.utils.bids import collect_run_data
+from xcp_d.utils.confounds import (
+    consolidate_confounds,
+    describe_regression,
+    get_customfile,
+)
 from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.filemanip import check_binary_mask
 from xcp_d.utils.plot import plot_design_matrix
-from xcp_d.utils.utils import consolidate_confounds, get_customfile, stringforparams
 from xcp_d.workflow.connectivity import init_nifti_functional_connectivity_wf
 from xcp_d.workflow.execsummary import init_execsummary_wf
 from xcp_d.workflow.outputs import init_writederivatives_wf
@@ -166,6 +169,15 @@ def init_boldpostprocess_wf(
     # and a new release is made, remove this.
     mask_file = check_binary_mask(run_data["boldmask"])
 
+    # Load custom confounds
+    # We need to run this function directly to access information in the confounds that is
+    # used for the boilerplate.
+    custom_confounds_file = get_customfile(
+        custom_confounds_folder,
+        run_data["confounds"],
+    )
+    regression_description = describe_regression(params, custom_confounds_file)
+
     workflow = Workflow(name=name)
 
     filter_str, filter_post_str = "", ""
@@ -210,10 +222,19 @@ def init_boldpostprocess_wf(
             "regressors were discarded, then "
         )
 
+    despike_str = ""
     if despike:
-        despike_str = "despiked, mean-centered, and linearly detrended"
-    else:
-        despike_str = "mean-centered and linearly detrended"
+        despike_str = (
+            "After censoring, but before nuisance regression, the BOLD data were despiked "
+            "with 3dDespike."
+        )
+
+    bandpass_str = ""
+    if bandpass_filter:
+        bandpass_str = (
+            "The interpolated timeseries were then band-pass filtered to retain signals within "
+            f"the {lower_bpf}-{upper_bpf} Hz frequency band."
+        )
 
     workflow.__desc__ = f"""\
 For each of the {num2words(n_runs)} BOLD series found per subject (across all tasks and sessions),
@@ -223,14 +244,12 @@ In order to identify high-motion outlier volumes, {fd_str}.
 Volumes with {'filtered ' if motion_filter_type else ''}framewise displacement greater than
 {fd_thresh} mm were flagged as outliers and excluded from nuisance regression [@power_fd_dvars].
 {filter_post_str}
-Before nuisance regression, but after censoring, the BOLD data were {despike_str}.
-{stringforparams(params=params)} [@benchmarkp;@satterthwaite_2013].
-These nuisance regressors were regressed from the BOLD data using linear regression -
-as implemented in Scikit-Learn {sklearn.__version__} [@scikit-learn].
+{despike_str}
+Next, the BOLD data and confounds were mean-centered and linearly detrended.
+{regression_description}
 Any volumes censored earlier in the workflow were then interpolated in the residual time series
 produced by the regression.
-The interpolated timeseries were then band-pass filtered to retain signals within the
-{lower_bpf}-{upper_bpf} Hz frequency band.
+{bandpass_str}
 """
 
     inputnode = pe.Node(
@@ -239,7 +258,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
                 "bold_file",
                 "ref_file",
                 "bold_mask",
-                "custom_confounds_folder",
+                "custom_confounds_file",
                 "template_to_t1w",
                 "t1w",
                 "t1seg",
@@ -255,7 +274,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     inputnode.inputs.bold_file = bold_file
     inputnode.inputs.ref_file = run_data["boldref"]
     inputnode.inputs.bold_mask = mask_file
-    inputnode.inputs.custom_confounds_folder = custom_confounds_folder
+    inputnode.inputs.custom_confounds_file = custom_confounds_file
     inputnode.inputs.fmriprep_confounds_tsv = run_data["confounds"]
     inputnode.inputs.t1w_to_native = run_data["t1w_to_native_xform"]
     inputnode.inputs.dummy_scans = dummy_scans
@@ -281,15 +300,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         ]),
     ])
     # fmt:on
-
-    get_custom_confounds_file = pe.Node(
-        Function(
-            input_names=["custom_confounds_folder", "fmriprep_confounds_file"],
-            output_names=["custom_confounds_file"],
-            function=get_customfile,
-        ),
-        name="get_custom_confounds_file",
-    )
 
     fcon_ts_wf = init_nifti_functional_connectivity_wf(
         mem_gb=mem_gbx["timeseries"],
@@ -384,14 +394,8 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     # Load and filter confounds
     # fmt:off
     workflow.connect([
-        (inputnode, get_custom_confounds_file, [
-            ("custom_confounds_folder", "custom_confounds_folder"),
-            ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
-        ]),
         (inputnode, consolidate_confounds_node, [
             ("bold_file", "img_file"),
-        ]),
-        (get_custom_confounds_file, consolidate_confounds_node, [
             ("custom_confounds_file", "custom_confounds_file"),
         ]),
     ])

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -5,7 +5,6 @@ import os
 
 import nibabel as nb
 import numpy as np
-import sklearn
 from nipype import Function, logging
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
@@ -24,7 +23,11 @@ from xcp_d.interfaces.regression import CiftiDespike, Regress
 from xcp_d.utils.bids import collect_run_data
 from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.plot import plot_design_matrix
-from xcp_d.utils.utils import consolidate_confounds, get_customfile, stringforparams
+from xcp_d.utils.confounds import (
+    consolidate_confounds,
+    describe_regression,
+    get_customfile,
+)
 from xcp_d.workflow.connectivity import init_cifti_functional_connectivity_wf
 from xcp_d.workflow.execsummary import init_execsummary_wf
 from xcp_d.workflow.outputs import init_writederivatives_wf
@@ -130,7 +133,7 @@ def init_ciftipostprocess_wf(
     ------
     bold_file
         CIFTI file
-    custom_confounds_folder
+    custom_confounds_file
         custom regressors
     t1w
     t1seg
@@ -144,6 +147,15 @@ def init_ciftipostprocess_wf(
     run_data = collect_run_data(layout, bold_file)
 
     TR = run_data["bold_metadata"]["RepetitionTime"]
+
+    # Load custom confounds
+    # We need to run this function directly to access information in the confounds that is
+    # used for the boilerplate.
+    custom_confounds_file = get_customfile(
+        custom_confounds_folder,
+        run_data["confounds"],
+    )
+    regression_description = describe_regression(params, custom_confounds_file)
 
     workflow = Workflow(name=name)
 
@@ -189,10 +201,20 @@ def init_ciftipostprocess_wf(
             "regressors were discarded, then "
         )
 
+    despike_str = ""
     if despike:
-        despike_str = "despiked, mean-centered, and linearly detrended"
-    else:
-        despike_str = "mean-centered and linearly detrended"
+        despike_str = (
+            "After censoring, but before nuisance regression, "
+            "the BOLD data were converted to NIfTI format, despiked with 3dDespike, "
+            "and converted back to CIFTI format."
+        )
+
+    bandpass_str = ""
+    if bandpass_filter:
+        bandpass_str = (
+            "The interpolated timeseries were then band-pass filtered to retain signals within "
+            f"the {lower_bpf}-{upper_bpf} Hz frequency band."
+        )
 
     workflow.__desc__ = f"""\
 For each of the {num2words(n_runs)} BOLD series found per subject (across all tasks and sessions),
@@ -202,21 +224,19 @@ In order to identify high-motion outlier volumes, {fd_str}.
 Volumes with {'filtered ' if motion_filter_type else ''}framewise displacement greater than
 {fd_thresh} mm were flagged as outliers and excluded from nuisance regression [@power_fd_dvars].
 {filter_post_str}
-Before nuisance regression, but after censoring, the BOLD data were {despike_str}.
-{stringforparams(params=params)} [@benchmarkp;@satterthwaite_2013].
-These nuisance regressors were regressed from the BOLD data using linear regression -
-as implemented in Scikit-Learn {sklearn.__version__} [@scikit-learn].
+{despike_str}
+Next, the BOLD data and confounds were mean-centered and linearly detrended.
+{regression_description}
 Any volumes censored earlier in the workflow were then interpolated in the residual time series
 produced by the regression.
-The interpolated timeseries were then band-pass filtered to retain signals within the
-{lower_bpf}-{upper_bpf} Hz frequency band.
+{bandpass_str}
 """
 
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
                 "bold_file",
-                "custom_confounds_folder",
+                "custom_confounds_file",
                 "t1w",
                 "t1seg",
                 "template_to_t1w",
@@ -228,7 +248,7 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     )
 
     inputnode.inputs.bold_file = bold_file
-    inputnode.inputs.custom_confounds_folder = custom_confounds_folder
+    inputnode.inputs.custom_confounds_file = custom_confounds_file
     inputnode.inputs.fmriprep_confounds_tsv = run_data["confounds"]
     inputnode.inputs.dummy_scans = dummy_scans
 
@@ -250,15 +270,6 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
         ]),
     ])
     # fmt:on
-
-    get_custom_confounds_file = pe.Node(
-        Function(
-            input_names=["custom_confounds_folder", "fmriprep_confounds_file"],
-            output_names=["custom_confounds_file"],
-            function=get_customfile,
-        ),
-        name="get_custom_confounds_file",
-    )
 
     fcon_ts_wf = init_cifti_functional_connectivity_wf(
         mem_gb=mem_gbx["timeseries"], name="cifti_ts_con_wf", omp_nthreads=omp_nthreads
@@ -351,14 +362,8 @@ The interpolated timeseries were then band-pass filtered to retain signals withi
     # Load and filter confounds
     # fmt:off
     workflow.connect([
-        (inputnode, get_custom_confounds_file, [
-            ("custom_confounds_folder", "custom_confounds_folder"),
-            ("fmriprep_confounds_tsv", "fmriprep_confounds_file"),
-        ]),
         (inputnode, consolidate_confounds_node, [
             ("bold_file", "img_file"),
-        ]),
-        (get_custom_confounds_file, consolidate_confounds_node, [
             ("custom_confounds_file", "custom_confounds_file"),
         ]),
     ])

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -21,13 +21,13 @@ from xcp_d.interfaces.prepostcleaning import (
 )
 from xcp_d.interfaces.regression import CiftiDespike, Regress
 from xcp_d.utils.bids import collect_run_data
-from xcp_d.utils.doc import fill_doc
-from xcp_d.utils.plot import plot_design_matrix
 from xcp_d.utils.confounds import (
     consolidate_confounds,
     describe_regression,
     get_customfile,
 )
+from xcp_d.utils.doc import fill_doc
+from xcp_d.utils.plot import plot_design_matrix
 from xcp_d.workflow.connectivity import init_cifti_functional_connectivity_wf
 from xcp_d.workflow.execsummary import init_execsummary_wf
 from xcp_d.workflow.outputs import init_writederivatives_wf


### PR DESCRIPTION
Closes #694.

## Changes proposed in this pull request
- Mean-center and detrend confounds to match the processing done to the BOLD data, prior to regression.
- Adopt non-aggressive denoising strategy by (1) loading signal AROMA components into design matrix along with noise ones, (2) fitting GLM to all regressors (including signal components), and (3) removing the fitted _nuisance_ regressors from theta to denies it.
- Convert if/else statements in `load_confound_matrix` and `describe_regression` to dictionaries of keyword arguments.

## Documentation that should be reviewed
- https://xcp-d--697.org.readthedocs.build/en/697/usage.html#signal-confounds-for-non-aggressive-denoising