### PR TITLE
Do not use downcasted files as name sources

### DIFF
--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -713,13 +713,13 @@ produced by the regression.
 
         # fmt:off
         workflow.connect([
-            (downcast_data, executivesummary_wf, [
+            # Use inputnode for executive summary instead of downcast_data
+            # because T1w is used as name source.
+            (inputnode, executivesummary_wf, [
                 ("t1w", "inputnode.t1w"),
                 ("t1seg", "inputnode.t1seg"),
                 ("bold_file", "inputnode.bold_file"),
                 ("bold_mask", "inputnode.mask"),
-            ]),
-            (inputnode, executivesummary_wf, [
                 ("template_to_t1w", "inputnode.template_to_t1w"),
             ]),
             (regression_wf, executivesummary_wf, [

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -412,7 +412,7 @@ produced by the regression.
 
     # fmt:off
     workflow.connect([
-        (downcast_data, qc_report_wf, [
+        (inputnode, qc_report_wf, [
             ("bold_file", "inputnode.preprocessed_bold_file"),
         ]),
     ])
@@ -656,10 +656,10 @@ produced by the regression.
 
         # fmt:off
         workflow.connect([
+            # Use inputnode for executive summary instead of downcast_data
+            # because T1w is used as name source.
             (inputnode, executivesummary_wf, [
                 ('template_to_t1w', 'inputnode.template_to_t1w'),
-            ]),
-            (downcast_data, executivesummary_wf, [
                 ('t1w', 'inputnode.t1w'),
                 ('t1seg', 'inputnode.t1seg'),
                 ('bold_file', 'inputnode.bold_file'),

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -70,6 +70,7 @@ def init_qc_report_wf(
     Inputs
     ------
     preprocessed_bold_file
+        Used for naming outputs and finding related files.
     boldref
     bold_mask
     t1w_mask


### PR DESCRIPTION
Fixes a bug detected in #698.

## Changes proposed in this pull request
- Use files from the inputnode, instead of downcast_data, when those files are used as name sources.

## Documentation that should be reviewed
None