### PR TITLE
Only use associated vol space for ciftis

### DIFF
--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -269,9 +269,7 @@ def collect_data(
         nifti_bold_data = layout.get(**temp_bold_query)
 
         if not nifti_bold_data:
-            raise FileNotFoundError(
-                f"No nifti BOLD data found in allowed space ({volspace})"
-            )
+            raise FileNotFoundError(f"No nifti BOLD data found in allowed space ({volspace})")
 
     # Grab the first (and presumably best) density and resolution if there are multiple.
     # This probably works well for resolution (1 typically means 1x1x1,

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -269,7 +269,7 @@ def collect_data(
         nifti_bold_data = layout.get(**temp_bold_query)
 
         if not nifti_bold_data:
-            raise FileNotFoundError(f"No nifti BOLD data found in allowed space ({volspace})")
+            raise FileNotFoundError(f"No NIfTI BOLD data found in allowed space ({volspace})")
 
     # Grab the first (and presumably best) density and resolution if there are multiple.
     # This probably works well for resolution (1 typically means 1x1x1,

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -63,7 +63,8 @@ def get_segfile(bold_file):
 
     Notes
     -----
-    Only used in concatenation code and should be dropped in favor of BIDSLayout methods ASAP.
+    Only used in concatenation code for NIFTI inputs and should be dropped in favor of BIDSLayout
+    methods ASAP.
     """
     # get transform files
     dd = Path(os.path.dirname(bold_file))

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -287,6 +287,7 @@ def init_execsummary_wf(
     # fmt:on
 
     # Get the transform file to native space
+    # NOTE: Is this actually native space? It should the BOLD file's standard space.
     get_std2native_transform = pe.Node(
         Function(
             input_names=["bold_file", "template_to_t1w", "t1w_to_native"],
@@ -307,7 +308,8 @@ def init_execsummary_wf(
     ])
     # fmt:on
 
-    # Transform the file to native space
+    # Transform the standard-space carpet-specific dseg to native space
+    # NOTE: Is this actually going to be native space though?
     resample_parc = pe.Node(
         ApplyTransformsx(
             dimension=3,


### PR DESCRIPTION
Closes None, but stems from https://github.com/PennLINC/xcp_d/pull/706#discussion_r1047209856.

## Changes proposed in this pull request
- When processing CIFTI data and looking for a volumetric space, only look for the volumetric space associated with the CIFTI data's template. At the moment, this means fsLR --> MNI152NLin6Asym, but it could be expanded in the future.

## Documentation that should be reviewed
None.