### PR TITLE
Refactor executive summary workflow

### DIFF
--- a/xcp_d/interfaces/surfplotting.py
+++ b/xcp_d/interfaces/surfplotting.py
@@ -8,6 +8,7 @@ from nipype.interfaces.base import (
     File,
     SimpleInterface,
     TraitedSpec,
+    isdefined,
     traits,
 )
 
@@ -130,6 +131,12 @@ class PlotSVGData(SimpleInterface):
             use_ext=False,
         )
 
+        mask_file = self.inputs.mask
+        mask_file = mask_file if isdefined(mask_file) else None
+
+        segmentation_file = self.inputs.seg_data
+        segmentation_file = segmentation_file if isdefined(segmentation_file) else None
+
         self._results["before_process"], self._results["after_process"] = plot_svgx(
             preprocessed_file=self.inputs.rawdata,
             residuals_file=self.inputs.regressed_data,
@@ -137,9 +144,9 @@ class PlotSVGData(SimpleInterface):
             tmask=self.inputs.tmask,
             dummy_scans=self.inputs.dummy_scans,
             TR=self.inputs.TR,
-            mask=self.inputs.mask,
+            mask=mask_file,
             filtered_motion=self.inputs.filtered_motion,
-            seg_data=self.inputs.seg_data,
+            seg_data=segmentation_file,
             processed_filename=after_process_fn,
             unprocessed_filename=before_process_fn,
         )

--- a/xcp_d/interfaces/surfplotting.py
+++ b/xcp_d/interfaces/surfplotting.py
@@ -84,10 +84,12 @@ class _PlotSVGDataInputSpec(BaseInterfaceInputSpec):
         mandatory=True,
         desc="TSV file with filtered motion parameters.",
     )
+    TR = traits.Float(default_value=1, desc="Repetition time")
+
+    # Optional inputs
     mask = File(exists=True, mandatory=False, desc="Bold mask")
     tmask = File(exists=True, mandatory=False, desc="Temporal mask")
     seg_data = File(exists=True, mandatory=False, desc="Segmentation file")
-    TR = traits.Float(default_value=1, desc="Repetition time")
     dummy_scans = traits.Int(
         0,
         usedefault=True,

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -589,7 +589,11 @@ def plot_svgx(
     unprocessed_figure = plt.figure(constrained_layout=True, figsize=(22.5, 30))
     grid = mgs.GridSpec(5, 1, wspace=0.0, hspace=0.05, height_ratios=[1, 1, 0.2, 2.5, 1])
     confoundplotx(
-        time_series=DVARS_timeseries, grid_spec_ts=grid[0], TR=TR, ylabel="DVARS", hide_x=True
+        time_series=DVARS_timeseries,
+        grid_spec_ts=grid[0],
+        TR=TR,
+        ylabel="DVARS",
+        hide_x=True,
     )
     confoundplotx(
         time_series=unprocessed_data_timeseries,
@@ -794,6 +798,7 @@ def plot_carpet(
     atlaslabels : numpy.ndarray, optional
         A 3D array of integer labels from an atlas, resampled into ``img`` space.
         Required if ``func`` is a NIfTI image.
+        Unused if ``func`` is a CIFTI.
     detrend : bool, optional
         Detrend and standardize the data prior to plotting.
     size : tuple, optional
@@ -807,8 +812,7 @@ def plot_carpet(
         are .png, .pdf, .svg. If output_file is not None, the plot
         is saved to a file, and the display is closed.
     legend : bool
-        Whether to render the average functional series with ``atlaslabels`` as
-        overlay.
+        Whether to render the average functional series with ``atlaslabels`` as overlay.
     TR : float, optional
         Specify the TR, if specified it uses this value. If left as None,
         # of frames is plotted instead of time.

--- a/xcp_d/workflow/base.py
+++ b/xcp_d/workflow/base.py
@@ -344,7 +344,7 @@ def init_subject_wf(
                 "t1w",
                 "t1w_mask",  # not used by cifti workflow
                 "t1w_seg",
-                "template_to_t1w_xform",
+                "template_to_t1w_xform",  # not used by cifti workflow
                 "t1w_to_template_xform",
             ],
         ),
@@ -507,14 +507,15 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
             (inputnode, bold_postproc_wf, [
                 ('t1w', 'inputnode.t1w'),
                 ('t1w_seg', 'inputnode.t1seg'),
-                ('template_to_t1w_xform', 'inputnode.template_to_t1w'),
             ]),
         ])
         if not cifti:
             workflow.connect([
-                (inputnode, bold_postproc_wf, [('t1w_mask', 'inputnode.t1w_mask')]),
+                (inputnode, bold_postproc_wf, [
+                    ('t1w_mask', 'inputnode.t1w_mask'),
+                    ('template_to_t1w_xform', 'inputnode.template_to_t1w'),
+                ]),
             ])
-
         # fmt:on
 
     # fmt:off

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -706,8 +706,9 @@ produced by the regression.
             TR=TR,
             bold_file=bold_file,
             layout=layout,
-            mem_gb=mem_gbx["timeseries"],
             output_dir=output_dir,
+            cifti=False,
+            mem_gb=mem_gbx["timeseries"],
             omp_nthreads=omp_nthreads,
         )
 

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -712,8 +712,6 @@ produced by the regression.
             bold_file=bold_file,
             layout=layout,
             output_dir=output_dir,
-            mem_gb=mem_gbx["timeseries"],
-            omp_nthreads=omp_nthreads,
             name="execsummary_wf",
         )
 

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -439,6 +439,7 @@ produced by the regression.
         head_radius=head_radius,
         mem_gb=mem_gbx["timeseries"],
         omp_nthreads=omp_nthreads,
+        dcan_qc=dcan_qc,
         cifti=False,
         name="qc_report_wf",
     )

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -719,6 +719,7 @@ produced by the regression.
             (inputnode, executivesummary_wf, [
                 ("t1w", "inputnode.t1w"),
                 ("bold_file", "inputnode.bold_file"),
+                ("ref_file", "inputnode.boldref_file"),
                 ("bold_mask", "inputnode.mask"),
                 ("template_to_t1w", "inputnode.template_to_t1w"),
             ]),

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -717,7 +717,6 @@ produced by the regression.
             # Use inputnode for executive summary instead of downcast_data
             # because T1w is used as name source.
             (inputnode, executivesummary_wf, [
-                ("t1w", "inputnode.t1w"),
                 ("bold_file", "inputnode.bold_file"),
                 ("ref_file", "inputnode.boldref_file"),
                 ("bold_mask", "inputnode.mask"),

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -709,18 +709,18 @@ produced by the regression.
 
     # executive summary workflow
     if dcan_qc:
-        executivesummary_wf = init_execsummary_wf(
+        executive_summary_wf = init_execsummary_wf(
             bold_file=bold_file,
             layout=layout,
             output_dir=output_dir,
-            name="execsummary_wf",
+            name="executive_summary_wf",
         )
 
         # fmt:off
         workflow.connect([
             # Use inputnode for executive summary instead of downcast_data
             # because T1w is used as name source.
-            (inputnode, executivesummary_wf, [
+            (inputnode, executive_summary_wf, [
                 ("bold_file", "inputnode.bold_file"),
                 ("ref_file", "inputnode.boldref_file"),
             ]),

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -717,7 +717,6 @@ produced by the regression.
             # because T1w is used as name source.
             (inputnode, executivesummary_wf, [
                 ("t1w", "inputnode.t1w"),
-                ("t1seg", "inputnode.t1seg"),
                 ("bold_file", "inputnode.bold_file"),
                 ("bold_mask", "inputnode.mask"),
                 ("template_to_t1w", "inputnode.template_to_t1w"),

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -721,6 +721,7 @@ produced by the regression.
                 ("ref_file", "inputnode.boldref_file"),
                 ("bold_mask", "inputnode.mask"),
                 ("template_to_t1w", "inputnode.template_to_t1w"),
+                ("t1w_to_native", "inputnode.t1w_to_native_xform"),
             ]),
             (regression_wf, executivesummary_wf, [
                 ("res_file", "inputnode.regressed_data"),

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -663,7 +663,6 @@ produced by the regression.
             (inputnode, executivesummary_wf, [
                 ('template_to_t1w', 'inputnode.template_to_t1w'),
                 ('t1w', 'inputnode.t1w'),
-                ('t1seg', 'inputnode.t1seg'),
                 ('bold_file', 'inputnode.bold_file'),
             ]),
             (regression_wf, executivesummary_wf, [

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -654,8 +654,7 @@ produced by the regression.
             bold_file=bold_file,
             layout=layout,
             output_dir=output_dir,
-            mem_gb=mem_gbx["timeseries"],
-            omp_nthreads=omp_nthreads,
+            name="execsummary_wf",
         )
 
         # fmt:off

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -663,7 +663,6 @@ produced by the regression.
             # because T1w is used as name source.
             (inputnode, executivesummary_wf, [
                 ('template_to_t1w', 'inputnode.template_to_t1w'),
-                ('t1w', 'inputnode.t1w'),
                 ('bold_file', 'inputnode.bold_file'),
             ]),
             (regression_wf, executivesummary_wf, [

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -650,8 +650,9 @@ produced by the regression.
             bold_file=bold_file,
             layout=layout,
             output_dir=output_dir,
-            omp_nthreads=omp_nthreads,
+            cifti=True,
             mem_gb=mem_gbx["timeseries"],
+            omp_nthreads=omp_nthreads,
         )
 
         # fmt:off

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -651,11 +651,11 @@ produced by the regression.
 
     # executive summary workflow
     if dcan_qc:
-        executivesummary_wf = init_execsummary_wf(
+        executive_summary_wf = init_execsummary_wf(
             bold_file=bold_file,
             layout=layout,
             output_dir=output_dir,
-            name="execsummary_wf",
+            name="executive_summary_wf",
         )
 
         # fmt:off
@@ -664,29 +664,12 @@ produced by the regression.
         workflow.connect([
             # Use inputnode for executive summary instead of downcast_data
             # because T1w is used as name source.
-            (inputnode, executivesummary_wf, [
+            (inputnode, executive_summary_wf, [
                 ('bold_file', 'inputnode.bold_file'),
                 ("ref_file", "inputnode.boldref_file"),
             ]),
         ])
         # fmt:on
-
-        if dummy_scans:
-            # fmt:off
-            workflow.connect([
-                (remove_dummy_scans, executivesummary_wf, [
-                    ("dummy_scans", "inputnode.dummy_scans"),
-                ])
-            ])
-            # fmt:on
-        else:
-            # fmt:off
-            workflow.connect([
-                (inputnode, executivesummary_wf, [
-                    ("dummy_scans", "inputnode.dummy_scans"),
-                ]),
-            ])
-            # fmt:on
 
     return workflow
 

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -405,6 +405,7 @@ produced by the regression.
         head_radius=head_radius,
         mem_gb=mem_gbx["timeseries"],
         omp_nthreads=omp_nthreads,
+        dcan_qc=dcan_qc,
         cifti=True,
         name="qc_report_wf",
     )

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -140,7 +140,6 @@ def init_ciftipostprocess_wf(
         custom regressors
     t1w
     t1seg
-    %(template_to_t1w)s
     fmriprep_confounds_tsv
 
     References
@@ -242,7 +241,6 @@ produced by the regression.
                 "custom_confounds_file",
                 "t1w",
                 "t1seg",
-                "template_to_t1w",
                 "fmriprep_confounds_tsv",
                 "dummy_scans",
             ],
@@ -662,7 +660,6 @@ produced by the regression.
             # Use inputnode for executive summary instead of downcast_data
             # because T1w is used as name source.
             (inputnode, executivesummary_wf, [
-                ('template_to_t1w', 'inputnode.template_to_t1w'),
                 ('bold_file', 'inputnode.bold_file'),
             ]),
             (regression_wf, executivesummary_wf, [

--- a/xcp_d/workflow/cifti.py
+++ b/xcp_d/workflow/cifti.py
@@ -666,7 +666,7 @@ produced by the regression.
             # because T1w is used as name source.
             (inputnode, executivesummary_wf, [
                 ('bold_file', 'inputnode.bold_file'),
-                ("ref_file", "inputnode.boldref"),
+                ("ref_file", "inputnode.boldref_file"),
             ]),
         ])
         # fmt:on

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -152,8 +152,6 @@ def init_execsummary_wf(
     bold_file,
     output_dir,
     layout,
-    mem_gb,
-    omp_nthreads,
     name="execsummary_wf",
 ):
     """Generate the figures for an executive summary.
@@ -164,8 +162,6 @@ def init_execsummary_wf(
         BOLD data before post-processing.
     %(output_dir)s
     layout
-    %(mem_gb)s
-    %(omp_nthreads)s
     %(name)s
 
     Inputs

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -339,7 +339,7 @@ def init_execsummary_wf(
 
         # fmt:off
         workflow.connect([
-            (inputnode, warp_dseg_to_bold, [("bold_file", "reference_image")]),
+            (inputnode, warp_dseg_to_bold, [("boldref_file", "reference_image")]),
             (add_xform_to_nlin6asym, warp_dseg_to_bold, [("out", "transforms")]),
             (inputnode, plot_boldref, [("boldref_file", "in_file")]),
         ])

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -203,14 +203,12 @@ def init_execsummary_wf(
     boldref_file
         The boldref file associated with the BOLD file.
         This should only be defined (and used) for NIFTI inputs.
-    t1w
     regressed_data
         BOLD data after regression, but before filtering.
     residual_data
         BOLD data after regression and filtering.
     filtered_motion
     tmask
-    rawdata
     mask
     %(template_to_t1w)s
     %(dummy_scans)s
@@ -221,12 +219,10 @@ def init_execsummary_wf(
         niu.IdentityInterface(
             fields=[
                 "bold_file",
-                "t1w",
                 "regressed_data",
                 "residual_data",
                 "filtered_motion",
                 "tmask",
-                "rawdata",
                 "template_to_t1w",
                 "dummy_scans",
                 # nifti-only inputs

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -171,24 +171,24 @@ def init_brainsprite_wf(
 
 @fill_doc
 def init_execsummary_wf(
-    omp_nthreads,
     bold_file,
     output_dir,
     TR,
-    mem_gb,
     layout,
+    mem_gb,
+    omp_nthreads,
     name="execsummary_wf",
 ):
-    """Generate an executive summary.
+    """Generate the figures for an executive summary.
 
     Parameters
     ----------
-    %(omp_nthreads)s
     bold_file
     %(output_dir)s
     TR
-    %(mem_gb)s
     layout
+    %(mem_gb)s
+    %(omp_nthreads)s
     %(name)s
 
     Inputs
@@ -327,7 +327,7 @@ def init_execsummary_wf(
     ])
     # fmt:on
 
-    # Plot the SVG files
+    # Generate preprocessing and postprocessing carpet plots.
     plot_carpets = pe.Node(
         PlotSVGData(TR=TR),
         name="plot_carpets",
@@ -350,8 +350,7 @@ def init_execsummary_wf(
     ])
     # fmt:on
 
-    # Write out the necessary files:
-    # Reference file
+    # Write out the figures.
     ds_boldref_figure = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
@@ -370,7 +369,6 @@ def init_execsummary_wf(
     ])
     # fmt:on
 
-    # Plot SVG before
     ds_preproc_carpet = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
@@ -381,7 +379,7 @@ def init_execsummary_wf(
         name="ds_preproc_carpet",
         run_without_submitting=True,
     )
-    # Plot SVG after
+
     ds_postproc_carpet = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
@@ -402,7 +400,6 @@ def init_execsummary_wf(
     ])
     # fmt:on
 
-    # Bold T1 registration file
     ds_registration_figure = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -208,9 +208,16 @@ def init_execsummary_wf(
     residual_data
         BOLD data after regression and filtering.
     filtered_motion
+        File containing the filtered motion parameters used for censoring.
     tmask
+        File containing the temporal mask used for censoring.
     mask
+        This should only be defined (and used) for NIFTI inputs.
     %(template_to_t1w)s
+        For NIFTI data, this is used to warp the MNI152NLin6-space tissue-type segmentation
+        file to T1w or native space, which should never happen.
+
+        For CIFTI data, this is used to identify the appropriate boldref file to plot.
     %(dummy_scans)s
     """
     workflow = Workflow(name=name)

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -277,9 +277,7 @@ def init_execsummary_wf(
 
     # fmt:off
     workflow.connect([
-        (find_nifti_files, find_t1_to_native, [
-            ("nifti_bold_file", "fname"),
-        ]),
+        (find_nifti_files, find_t1_to_native, [("nifti_bold_file", "fname")]),
     ])
     # fmt:on
 

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -306,7 +306,7 @@ def init_execsummary_wf(
     # fmt:on
 
     # Transform the file to native space
-    resample_parc = pe.Node(
+    warp_dseg_to_bold = pe.Node(
         ApplyTransformsx(
             dimension=3,
             input_image=str(
@@ -320,14 +320,14 @@ def init_execsummary_wf(
             ),
             interpolation="MultiLabel",
         ),
-        name="resample_parc",
+        name="warp_dseg_to_bold",
         n_procs=omp_nthreads,
         mem_gb=mem_gb * 3 * omp_nthreads,
     )
 
     # fmt:off
     workflow.connect([
-        (find_nifti_files, resample_parc, [
+        (find_nifti_files, warp_dseg_to_bold, [
             ("nifti_boldref_file", "reference_image"),
         ]),
     ])
@@ -400,8 +400,8 @@ def init_execsummary_wf(
             ('dummy_scans', 'dummy_scans'),
         ]),
         (inputnode, get_std2native_transform, [('template_to_t1w', 'template_to_t1w')]),
-        (get_std2native_transform, resample_parc, [('transform_list', 'transforms')]),
-        (resample_parc, plot_svgx_wf, [('output_image', 'seg_data')]),
+        (get_std2native_transform, warp_dseg_to_bold, [('transform_list', 'transforms')]),
+        (warp_dseg_to_bold, plot_svgx_wf, [('output_image', 'seg_data')]),
         (plot_svgx_wf, ds_plot_svg_before_wf, [('before_process', 'in_file')]),
         (plot_svgx_wf, ds_plot_svg_after_wf, [('after_process', 'in_file')]),
         (inputnode, ds_plot_svg_before_wf, [('bold_file', 'source_file')]),

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -194,7 +194,6 @@ def init_execsummary_wf(
     Inputs
     ------
     t1w
-    t1seg
     regressed_data
     residual_data
     filtered_motion
@@ -210,7 +209,6 @@ def init_execsummary_wf(
         niu.IdentityInterface(
             fields=[
                 "t1w",
-                "t1seg",
                 "regressed_data",
                 "residual_data",
                 "filtered_motion",

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -257,11 +257,11 @@ def init_execsummary_wf(
     # fmt:on
 
     # Plot the reference bold image
-    plotrefbold_wf = pe.Node(PlotImage(), name="plotrefbold_wf")
+    plot_boldref = pe.Node(PlotImage(), name="plot_boldref")
 
     # fmt:off
     workflow.connect([
-        (find_nifti_files, plotrefbold_wf, [
+        (find_nifti_files, plot_boldref, [
             ("nifti_boldref_file", "in_file"),
         ]),
     ])
@@ -337,9 +337,9 @@ def init_execsummary_wf(
     # fmt:on
 
     # Plot the SVG files
-    plot_svgx_wf = pe.Node(
+    plot_carpets = pe.Node(
         PlotSVGData(TR=TR),
-        name="plot_svgx_wf",
+        name="plot_carpets",
         mem_gb=mem_gb,
         n_procs=omp_nthreads,
     )
@@ -392,8 +392,8 @@ def init_execsummary_wf(
     # Connect all the workflows
     # fmt:off
     workflow.connect([
-        (plotrefbold_wf, ds_boldref_figure, [('out_file', 'in_file')]),
-        (inputnode, plot_svgx_wf, [
+        (plot_boldref, ds_boldref_figure, [('out_file', 'in_file')]),
+        (inputnode, plot_carpets, [
             ('filtered_motion', 'filtered_motion'),
             ('regressed_data', 'regressed_data'),
             ('residual_data', 'residual_data'),
@@ -404,9 +404,9 @@ def init_execsummary_wf(
         ]),
         (inputnode, get_mni_to_bold_xforms, [('template_to_t1w', 'template_to_t1w')]),
         (get_mni_to_bold_xforms, warp_dseg_to_bold, [('transform_list', 'transforms')]),
-        (warp_dseg_to_bold, plot_svgx_wf, [('output_image', 'seg_data')]),
-        (plot_svgx_wf, ds_preproc_carpet, [('before_process', 'in_file')]),
-        (plot_svgx_wf, ds_postproc_carpet, [('after_process', 'in_file')]),
+        (warp_dseg_to_bold, plot_carpets, [('output_image', 'seg_data')]),
+        (plot_carpets, ds_preproc_carpet, [('before_process', 'in_file')]),
+        (plot_carpets, ds_postproc_carpet, [('after_process', 'in_file')]),
         (inputnode, ds_preproc_carpet, [('bold_file', 'source_file')]),
         (inputnode, ds_postproc_carpet, [('bold_file', 'source_file')]),
         (inputnode, ds_boldref_figure, [('bold_file', 'source_file')]),

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -346,38 +346,38 @@ def init_execsummary_wf(
 
     # Write out the necessary files:
     # Reference file
-    ds_plot_bold_reference_file_wf = pe.Node(
+    ds_boldref_figure = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir, dismiss_entities=["den"], datatype="figures", desc="boldref"
         ),
-        name="ds_plot_bold_reference_file_wf",
+        name="ds_boldref_figure",
         run_without_submitting=True,
     )
 
     # Plot SVG before
-    ds_plot_svg_before_wf = pe.Node(
+    ds_preproc_carpet = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
             dismiss_entities=["den"],
             datatype="figures",
             desc="precarpetplot",
         ),
-        name="plot_svgxbe",
+        name="ds_preproc_carpet",
         run_without_submitting=True,
     )
     # Plot SVG after
-    ds_plot_svg_after_wf = pe.Node(
+    ds_postproc_carpet = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
             dismiss_entities=["den"],
             datatype="figures",
             desc="postcarpetplot",
         ),
-        name="plot_svgx_after",
+        name="ds_postproc_carpet",
         run_without_submitting=True,
     )
     # Bold T1 registration file
-    ds_registration_wf = pe.Node(
+    ds_registration_figure = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
             in_file=bold_t1w_registration_file,
@@ -385,14 +385,14 @@ def init_execsummary_wf(
             datatype="figures",
             desc="bbregister",
         ),
-        name="bb_registration_file",
+        name="ds_registration_figure",
         run_without_submitting=True,
     )
 
     # Connect all the workflows
     # fmt:off
     workflow.connect([
-        (plotrefbold_wf, ds_plot_bold_reference_file_wf, [('out_file', 'in_file')]),
+        (plotrefbold_wf, ds_boldref_figure, [('out_file', 'in_file')]),
         (inputnode, plot_svgx_wf, [
             ('filtered_motion', 'filtered_motion'),
             ('regressed_data', 'regressed_data'),
@@ -405,12 +405,12 @@ def init_execsummary_wf(
         (inputnode, get_mni_to_bold_xforms, [('template_to_t1w', 'template_to_t1w')]),
         (get_mni_to_bold_xforms, warp_dseg_to_bold, [('transform_list', 'transforms')]),
         (warp_dseg_to_bold, plot_svgx_wf, [('output_image', 'seg_data')]),
-        (plot_svgx_wf, ds_plot_svg_before_wf, [('before_process', 'in_file')]),
-        (plot_svgx_wf, ds_plot_svg_after_wf, [('after_process', 'in_file')]),
-        (inputnode, ds_plot_svg_before_wf, [('bold_file', 'source_file')]),
-        (inputnode, ds_plot_svg_after_wf, [('bold_file', 'source_file')]),
-        (inputnode, ds_plot_bold_reference_file_wf, [('bold_file', 'source_file')]),
-        (inputnode, ds_registration_wf, [('bold_file', 'source_file')]),
+        (plot_svgx_wf, ds_preproc_carpet, [('before_process', 'in_file')]),
+        (plot_svgx_wf, ds_postproc_carpet, [('after_process', 'in_file')]),
+        (inputnode, ds_preproc_carpet, [('bold_file', 'source_file')]),
+        (inputnode, ds_postproc_carpet, [('bold_file', 'source_file')]),
+        (inputnode, ds_boldref_figure, [('bold_file', 'source_file')]),
+        (inputnode, ds_registration_figure, [('bold_file', 'source_file')]),
     ])
     # fmt:on
 

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -286,7 +286,7 @@ def init_execsummary_wf(
     ])
     # fmt:on
 
-    # Get the set of transforms from MNI152NLin2009cAsym (the dseg) to the BOLD space.
+    # Get the set of transforms from MNI152NLin6Asym (the dseg) to the BOLD space.
     # Given that xcp-d doesn't process native-space data, this transform will never be used.
     get_mni_to_bold_xforms = pe.Node(
         Function(
@@ -314,7 +314,7 @@ def init_execsummary_wf(
             dimension=3,
             input_image=str(
                 get_template(
-                    "MNI152NLin2009cAsym",
+                    "MNI152NLin6Asym",
                     resolution=1,
                     desc="carpet",
                     suffix="dseg",

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -222,6 +222,7 @@ def init_execsummary_wf(
         name="inputnode",
     )
     inputnode.inputs.bold_file = bold_file
+
     # Get bb_registration_file prefix from fmriprep
     all_files = list(layout.get_files())
     current_bold_file = os.path.basename(bold_file)
@@ -260,11 +261,7 @@ def init_execsummary_wf(
     plot_boldref = pe.Node(PlotImage(), name="plot_boldref")
 
     # fmt:off
-    workflow.connect([
-        (find_nifti_files, plot_boldref, [
-            ("nifti_boldref_file", "in_file"),
-        ]),
-    ])
+    workflow.connect([(find_nifti_files, plot_boldref, [("nifti_boldref_file", "in_file")])])
     # fmt:on
 
     # Get the transform file to native space
@@ -299,13 +296,9 @@ def init_execsummary_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, get_mni_to_bold_xforms, [('template_to_t1w', 'template_to_t1w')]),
-        (find_nifti_files, get_mni_to_bold_xforms, [
-            ("nifti_bold_file", "bold_file"),
-        ]),
-        (find_t1_to_native, get_mni_to_bold_xforms, [
-            ("t1w_to_native_xform", "t1w_to_native"),
-        ]),
+        (inputnode, get_mni_to_bold_xforms, [("template_to_t1w", "template_to_t1w")]),
+        (find_nifti_files, get_mni_to_bold_xforms, [("nifti_bold_file", "bold_file")]),
+        (find_t1_to_native, get_mni_to_bold_xforms, [("t1w_to_native_xform", "t1w_to_native")]),
     ])
     # fmt:on
 
@@ -331,10 +324,8 @@ def init_execsummary_wf(
 
     # fmt:off
     workflow.connect([
-        (find_nifti_files, warp_dseg_to_bold, [
-            ("nifti_boldref_file", "reference_image"),
-        ]),
-        (get_mni_to_bold_xforms, warp_dseg_to_bold, [('transform_list', 'transforms')]),
+        (find_nifti_files, warp_dseg_to_bold, [("nifti_boldref_file", "reference_image")]),
+        (get_mni_to_bold_xforms, warp_dseg_to_bold, [("transform_list", "transforms")]),
     ])
     # fmt:on
 
@@ -349,15 +340,15 @@ def init_execsummary_wf(
     # fmt:off
     workflow.connect([
         (inputnode, plot_carpets, [
-            ('filtered_motion', 'filtered_motion'),
-            ('regressed_data', 'regressed_data'),
-            ('residual_data', 'residual_data'),
-            ('mask', 'mask'),
-            ('bold_file', 'rawdata'),
-            ('tmask', 'tmask'),
-            ('dummy_scans', 'dummy_scans'),
+            ("filtered_motion", "filtered_motion"),
+            ("regressed_data", "regressed_data"),
+            ("residual_data", "residual_data"),
+            ("mask", "mask"),
+            ("bold_file", "rawdata"),
+            ("tmask", "tmask"),
+            ("dummy_scans", "dummy_scans"),
         ]),
-        (warp_dseg_to_bold, plot_carpets, [('output_image', 'seg_data')]),
+        (warp_dseg_to_bold, plot_carpets, [("output_image", "seg_data")]),
     ])
     # fmt:on
 
@@ -365,7 +356,10 @@ def init_execsummary_wf(
     # Reference file
     ds_boldref_figure = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir, dismiss_entities=["den"], datatype="figures", desc="boldref"
+            base_directory=output_dir,
+            dismiss_entities=["den"],
+            datatype="figures",
+            desc="boldref",
         ),
         name="ds_boldref_figure",
         run_without_submitting=True,
@@ -373,8 +367,8 @@ def init_execsummary_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, ds_boldref_figure, [('bold_file', 'source_file')]),
-        (plot_boldref, ds_boldref_figure, [('out_file', 'in_file')]),
+        (inputnode, ds_boldref_figure, [("bold_file", "source_file")]),
+        (plot_boldref, ds_boldref_figure, [("out_file", "in_file")]),
     ])
     # fmt:on
 
@@ -403,10 +397,10 @@ def init_execsummary_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, ds_preproc_carpet, [('bold_file', 'source_file')]),
-        (inputnode, ds_postproc_carpet, [('bold_file', 'source_file')]),
-        (plot_carpets, ds_preproc_carpet, [('before_process', 'in_file')]),
-        (plot_carpets, ds_postproc_carpet, [('after_process', 'in_file')]),
+        (inputnode, ds_preproc_carpet, [("bold_file", "source_file")]),
+        (inputnode, ds_postproc_carpet, [("bold_file", "source_file")]),
+        (plot_carpets, ds_preproc_carpet, [("before_process", "in_file")]),
+        (plot_carpets, ds_postproc_carpet, [("after_process", "in_file")]),
     ])
     # fmt:on
 
@@ -425,7 +419,7 @@ def init_execsummary_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, ds_registration_figure, [('bold_file', 'source_file')]),
+        (inputnode, ds_registration_figure, [("bold_file", "source_file")]),
     ])
     # fmt:on
 

--- a/xcp_d/workflow/execsummary.py
+++ b/xcp_d/workflow/execsummary.py
@@ -185,6 +185,7 @@ def init_execsummary_wf(
     Parameters
     ----------
     bold_file
+        BOLD data before post-processing.
     %(output_dir)s
     TR
     layout
@@ -197,13 +198,16 @@ def init_execsummary_wf(
     Inputs
     ------
     bold_file
+        BOLD data before post-processing.
         Set from the parameter.
     boldref_file
         The boldref file associated with the BOLD file.
         This should only be defined (and used) for NIFTI inputs.
     t1w
     regressed_data
+        BOLD data after regression, but before filtering.
     residual_data
+        BOLD data after regression and filtering.
     filtered_motion
     tmask
     rawdata

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -345,7 +345,7 @@ def init_qc_report_wf(
         # Generate preprocessing and postprocessing carpet plots.
         plot_executive_summary_carpets = pe.Node(
             PlotSVGData(TR=TR),
-            name="plot_carpets",
+            name="plot_executive_summary_carpets",
             mem_gb=mem_gb,
             n_procs=omp_nthreads,
         )

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -156,17 +156,17 @@ def init_qc_report_wf(
     ])
     # fmt:on
 
-    if not cifti:
-        nlin2009casym_brain_mask = str(
-            get_template(
-                "MNI152NLin2009cAsym",
-                resolution=2,
-                desc="brain",
-                suffix="mask",
-                extension=[".nii", ".nii.gz"],
-            )
+    nlin2009casym_brain_mask = str(
+        get_template(
+            "MNI152NLin2009cAsym",
+            resolution=2,
+            desc="brain",
+            suffix="mask",
+            extension=[".nii", ".nii.gz"],
         )
+    )
 
+    if not cifti:
         # We need the BOLD mask in T1w and standard spaces for QC metric calculation.
         # This is only possible for nifti inputs.
         get_native2space_transforms = pe.Node(
@@ -256,7 +256,7 @@ def init_qc_report_wf(
             (inputnode, get_mni_to_bold_xforms, [
                 ("preprocessed_bold_file", "bold_file"),
                 ("template_to_t1w", "template_to_t1w"),
-                ("t1w_to_native_xform", "t1w_to_native"),
+                ("t1w_to_native", "t1w_to_native"),
             ]),
         ])
         # fmt:on

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -367,7 +367,7 @@ def init_qc_report_wf(
             # fmt:off
             workflow.connect([
                 (inputnode, plot_executive_summary_carpets, [
-                    ("mask", "mask"),
+                    ("bold_mask", "mask"),
                 ]),
                 (warp_dseg_to_bold, plot_executive_summary_carpets, [
                     ("output_image", "seg_data"),

--- a/xcp_d/workflow/plotting.py
+++ b/xcp_d/workflow/plotting.py
@@ -76,8 +76,12 @@ def init_qc_report_wf(
     ------
     preprocessed_bold_file
         Used for naming outputs and finding related files.
+        Also used for carpet plots.
     cleaned_unfiltered_file
+        Used for carpet plots.
+        Only used if dcan_qc is True.
     cleaned_file
+        Used for carpet plots.
     boldref
         Only used with non-CIFTI data.
     bold_mask
@@ -349,10 +353,10 @@ def init_qc_report_wf(
         # fmt:off
         workflow.connect([
             (inputnode, plot_executive_summary_carpets, [
-                ("preprocessed_bold_file", "rawdata")
-                ("cleaned_unfiltered_file", "regressed_data"),  # need to get
+                ("preprocessed_bold_file", "rawdata"),
+                ("cleaned_unfiltered_file", "regressed_data"),
                 ("cleaned_file", "residual_data"),
-                ("filtered_motion", "filtered_motion"),  # need to get
+                ("filtered_motion", "filtered_motion"),
                 ("tmask", "tmask"),
                 ("dummy_scans", "dummy_scans"),
             ]),


### PR DESCRIPTION
Closes None.

Open questions:
- When would we want to warp the T1w image to standard space? At the moment, we collect the native T1w-space image, but we should really collect the standard-space one as well and just save that to the output directory. When would there be BOLD data in standard space, but not a T1w image in the same space?
- We don't support native or T1w-space inputs/outputs, so do we need to support warps to T1w or native space?

Resolved questions:
- Should we just use the dseg in the preprocessing derivatives?
    - There should be a standard-space tissue-type dseg in the fMRIPrep derivatives, in the anat folder. **However, this dseg is just the three tissue types, I believe, while the carpet plot uses labels like subcortical GM and cerebellum.**
    - I assume that Nibabies derivatives would include the same thing.
    - I'm not sure about the DCAN and HCP derivatives. In #714, it became clear that what we called the regular dseg was actually the aparc+aseg file, so we may not have a tissue type dseg file from those pipelines. On the other hand, would we ever run DCAN/HCP with NIFTI processing (i.e., not CIFTI processing)? If the answer is "no", then we won't ever _need_ a tissue type dseg from those pipelines.
        - The answer _is_ "no", since processing HCP/DCAN data will automatically set cifti to True.

## Changes proposed in this pull request
- Move the carpet plot generation code from the executive summary workflow into the QC plotting workflow.
    - This streamlines things since the same segmentation file is used for both sets of carpet plots and the whole warp-to-BOLD-space string of Nodes are the same between the two.
- Use the T1w-to-native transform from `collect_run_data` instead of trying to find it with a custom function.
- Load a boldref file in `collect_run_data`, even if running the CIFTI workflow, which can then be plotted in the executive summary workflow. This replaces the function that tried to find a boldref file.
- Remove the HCP/DCAN hack in `collect_data`. Just search for the MNI/T1w transforms directly, instead of using NIFTI BOLD files as an intermediate.
- Remove unused arguments from the executive summary workflow, now that it only makes the boldref and registration plots.
- ~~Fix a bug in the NIFTI executive summary, where the segmentation file used for the carpet plots was in MNI152NLin2009cAsym space, but transforms from MNI152NLin6Asym were used. I've tacked on the MNI152NLin2009cAsym --> MNI152NLin6Asym transform, to get the dseg from MNI152NLin2009cAsym space to the BOLD space.~~ Moved to #727.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
