### PR TITLE
Track start of workflow with sentry

### DIFF
--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -589,6 +589,12 @@ def main():
     # Clean up master process before running workflow, which may create forks
     gc.collect()
 
+    # Track start of workflow with sentry
+    if not opts.notrack:
+        from xcp_d.utils.sentry import start_ping
+
+        start_ping(run_uuid, len(subject_list))
+
     errno = 1  # Default is error exit unless otherwise set
     try:
         xcpd_wf.run(**plugin_settings)


### PR DESCRIPTION
Closes #674.

## Changes proposed in this pull request
- Copy sentry logging from qsiprep, in order to log the start of the workflow.

## Documentation that should be reviewed
None.
