### PR TITLE
Use brain mask in NIFTI connectivity workflow

### DIFF
--- a/.circleci/tests/test_conn.py
+++ b/.circleci/tests/test_conn.py
@@ -53,6 +53,7 @@ def test_nifti_conn(fmriprep_with_freesurfer_data, tmp_path_factory):
     fcon_ts_wf.inputs.inputnode.t1w_to_native = t1w_to_native_xform
     fcon_ts_wf.inputs.inputnode.clean_bold = fake_bold_file
     fcon_ts_wf.inputs.inputnode.bold_file = bold_file
+    fcon_ts_wf.inputs.inputnode.bold_mask = bold_mask
     fcon_ts_wf.inputs.inputnode.ref_file = boldref
     fcon_ts_wf.base_dir = tmp_path_factory.mktemp("fcon_nifti_test_2")
     fcon_ts_wf.run()
@@ -86,7 +87,7 @@ def test_nifti_conn(fmriprep_with_freesurfer_data, tmp_path_factory):
     atlas = nb.load(atlas)
 
     # Masking img
-    masker = NiftiLabelsMasker(atlas, smoothing_fwhm=None, standardize=False)
+    masker = NiftiLabelsMasker(atlas, mask_img=bold_mask, smoothing_fwhm=None, standardize=False)
     # Fitting mask
     masker.fit(fake_bold_file)
     signals = masker.transform(fake_bold_file)

--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -29,6 +29,7 @@ LOGGER = logging.getLogger("nipype.interface")
 
 class _NiftiConnectInputSpec(BaseInterfaceInputSpec):
     filtered_file = File(exists=True, mandatory=True, desc="filtered file")
+    mask = File(exists=True, mandator=True, desc="brain mask file")
     atlas = File(exists=True, mandatory=True, desc="atlas file")
 
 
@@ -48,10 +49,16 @@ class NiftiConnect(SimpleInterface):
         # Then write out functional correlation matrix of
         # timeseries using numpy.
         self._results["time_series_tsv"] = fname_presuffix(
-            self.inputs.filtered_file, suffix="time_series.tsv", newpath=runtime.cwd, use_ext=False
+            self.inputs.filtered_file,
+            suffix="time_series.tsv",
+            newpath=runtime.cwd,
+            use_ext=False,
         )
         self._results["fcon_matrix_tsv"] = fname_presuffix(
-            self.inputs.filtered_file, suffix="fcon_matrix.tsv", newpath=runtime.cwd, use_ext=False
+            self.inputs.filtered_file,
+            suffix="fcon_matrix.tsv",
+            newpath=runtime.cwd,
+            use_ext=False,
         )
 
         (
@@ -60,6 +67,7 @@ class NiftiConnect(SimpleInterface):
         ) = extract_timeseries_funct(
             in_file=self.inputs.filtered_file,
             atlas=self.inputs.atlas,
+            mask=self.inputs.mask,
             timeseries=self._results["time_series_tsv"],
             fconmatrix=self._results["fcon_matrix_tsv"],
         )

--- a/xcp_d/utils/fcon.py
+++ b/xcp_d/utils/fcon.py
@@ -9,13 +9,15 @@ from scipy.stats import rankdata
 from templateflow.api import get as get_template
 
 
-def extract_timeseries_funct(in_file, atlas, timeseries, fconmatrix):
+def extract_timeseries_funct(in_file, mask, atlas, timeseries, fconmatrix):
     """Use Nilearn NiftiLabelsMasker to extract timeseries.
 
     Parameters
     ----------
     in_file : str
         bold file timeseries
+    mask : str
+        BOLD file's associated brain mask file.
     atlas : str
         atlas in the same space with bold
     timeseries : str
@@ -30,9 +32,16 @@ def extract_timeseries_funct(in_file, atlas, timeseries, fconmatrix):
     fconmatrix : str
         functional connectivity matrix filename
     """
-    masker = NiftiLabelsMasker(labels_img=atlas, smoothing_fwhm=None, standardize=False)
+    masker = NiftiLabelsMasker(
+        labels_img=atlas,
+        mask_img=mask,
+        smoothing_fwhm=None,
+        standardize=False,
+    )
+
     # Use nilearn for time_series
     time_series = masker.fit_transform(in_file)
+
     # Use numpy for correlation matrix
     correlation_matrices = np.corrcoef(time_series.T)
 

--- a/xcp_d/workflow/bold.py
+++ b/xcp_d/workflow/bold.py
@@ -577,8 +577,11 @@ produced by the regression.
 
     # functional connect workflow
     workflow.connect([
-        (downcast_data, fcon_ts_wf, [('bold_file', 'inputnode.bold_file'),
-                                     ('ref_file', 'inputnode.ref_file')]),
+        (downcast_data, fcon_ts_wf, [
+            ('bold_file', 'inputnode.bold_file'),
+            ("bold_mask", "inputnode.bold_mask"),
+            ('ref_file', 'inputnode.ref_file'),
+        ]),
         (inputnode, fcon_ts_wf, [('template_to_t1w', 'inputnode.template_to_t1w'),
                                  ('t1w_to_native', 'inputnode.t1w_to_native')]),
         (filtering_wf, fcon_ts_wf, [('filtered_file', 'inputnode.clean_bold')])

--- a/xcp_d/workflow/connectivity.py
+++ b/xcp_d/workflow/connectivity.py
@@ -77,7 +77,14 @@ which was operationalized as the Pearson's correlation of each parcel's unsmooth
 
     inputnode = pe.Node(
         niu.IdentityInterface(
-            fields=["bold_file", "ref_file", "clean_bold", "template_to_t1w", "t1w_to_native"],
+            fields=[
+                "bold_file",
+                "bold_mask",
+                "ref_file",
+                "clean_bold",
+                "template_to_t1w",
+                "t1w_to_native",
+            ],
         ),
         name="inputnode",
     )
@@ -145,7 +152,10 @@ which was operationalized as the Pearson's correlation of each parcel's unsmooth
                                                    ("template_to_t1w", "template_to_t1w"),
                                                    ("t1w_to_native", "t1w_to_native")]),
         (inputnode, warp_atlases_to_bold_space, [("ref_file", "reference_image")]),
-        (inputnode, nifti_connect, [("clean_bold", "filtered_file")]),
+        (inputnode, nifti_connect, [
+            ("clean_bold", "filtered_file"),
+            ("bold_mask", "mask"),
+        ]),
         (inputnode, matrix_plot, [("clean_bold", "in_file")]),
         (atlas_name_grabber, outputnode, [("atlas_names", "atlas_names")]),
         (atlas_name_grabber, atlas_file_grabber, [("atlas_names", "atlas_name")]),


### PR DESCRIPTION
Closes None, but is related to #700.

I tested out using the mask vs. not, and using the mask means that any voxels outside the mask will be excluded before the mean time series is calculated for each region. If we don't use the mask, then those voxels (in the atlas, but outside the mask) are replaced with zeros.

## Changes proposed in this pull request

- Use the downsampled brain mask in the NiftiLabelsMasker.

## Documentation that should be reviewed
None.
