### PR TITLE
Pin networkx version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     indexed_gzip ~= 1.6.4  # for loading imgs in nibabel
     jinja2 ~= 3.0.0  # for executive summary
     matplotlib ~= 3.3.4
+    networkx ~= 2.8.8  # nipype needs networkx, but 3+ isn't compatible with nipype 1.8.5
     nibabel >= 3.2.1
     nilearn ~= 0.9.2
     nipype ~= 1.8.5


### PR DESCRIPTION
Closes None, but addresses issue with networkx >=3 that's breaking our tests.

## Changes proposed in this pull request
- Pin networkx version to 2.8.8. We can increase this when we increase the nipype version as well.
