### PR TITLE
Fix CIFTI downcasting test

### DIFF
--- a/.circleci/tests/test_prepostcleaning.py
+++ b/.circleci/tests/test_prepostcleaning.py
@@ -66,8 +66,8 @@ def test_conversion_to_32bit_cifti(fmriprep_with_freesurfer_data, tmp_path_facto
 
     float_file = fmriprep_with_freesurfer_data["cifti_file"]
 
-    float64_file = os.path.join(tmpdir, "float64.nii.gz")
-    int64_file = os.path.join(tmpdir, "int64.nii.gz")
+    float64_file = os.path.join(tmpdir, "float64.dtseries.nii")
+    int64_file = os.path.join(tmpdir, "int64.dtseries.nii")
 
     # Create a float64 image to downcast
     float_img = nb.load(float_file)

--- a/.circleci/tests/test_prepostcleaning.py
+++ b/.circleci/tests/test_prepostcleaning.py
@@ -60,7 +60,6 @@ def test_conversion_to_32bit_nifti(fmriprep_with_freesurfer_data, tmp_path_facto
     assert int32_img.dataobj.dtype == np.int32
 
 
-@pytest.mark.skip(reason="Cannot make a cifti with float64 data.")
 def test_conversion_to_32bit_cifti(fmriprep_with_freesurfer_data, tmp_path_factory):
     """Convert nifti files to 32-bit."""
     tmpdir = tmp_path_factory.mktemp("test_conversion_to_32bit")


### PR DESCRIPTION
Closes #696. As it turns out, the reason the test was failing wasn't due to any issue with storing float64s or int64s in CIFTI files- it was just that I was using the wrong extensions in the test files!

## Changes proposed in this pull request
- Change "CIFTI" test files from `.nii.gz` extension (nifti) to `.dtseries.nii` (cifti).
- Stop skipping the CIFTI downcasting test.