### PR TITLE
Select MNI152NLin6Asym target space for T1w from CIFTI derivatives

### DIFF
--- a/xcp_d/data/nipreps.json
+++ b/xcp_d/data/nipreps.json
@@ -131,12 +131,12 @@
     },
     {
       "name": "cohort",
-      "pattern": "[_/\\\\]+cohort-0*(\\d+)",
+      "pattern": "(?:^|_)cohort-([0-9]+)",
       "dtype": "int"
     },
     {
       "name": "measure",
-      "pattern": "[_/\\\\]measure-([a-zA-Z0-9]+)"
+      "pattern": "(?:^|_)measure-([a-zA-Z0-9]+)"
     }
   ],
   "default_path_patterns": [

--- a/xcp_d/tests/data/ds001419-fmriprep_nifti_outputs.txt
+++ b/xcp_d/tests/data/ds001419-fmriprep_nifti_outputs.txt
@@ -4,8 +4,8 @@ xcp_d/logs
 xcp_d/logs/CITATION.md
 xcp_d/sub-01
 xcp_d/sub-01/anat
-xcp_d/sub-01/anat/sub-01_space-MNI152NLin6Asym_desc-preproc_T1w.nii.gz
-xcp_d/sub-01/anat/sub-01_space-MNI152NLin6Asym_dseg.nii.gz
+xcp_d/sub-01/anat/sub-01_space-MNI152NLin2009cAsym_desc-preproc_T1w.nii.gz
+xcp_d/sub-01/anat/sub-01_space-MNI152NLin2009cAsym_dseg.nii.gz
 xcp_d/sub-01/anat/sub-01_space-fsLR_den-32k_hemi-L_desc-hcp_inflated.surf.gii
 xcp_d/sub-01/anat/sub-01_space-fsLR_den-32k_hemi-L_desc-hcp_midthickness.surf.gii
 xcp_d/sub-01/anat/sub-01_space-fsLR_den-32k_hemi-L_desc-hcp_vinflated.surf.gii

--- a/xcp_d/tests/data/nibabies_outputs.txt
+++ b/xcp_d/tests/data/nibabies_outputs.txt
@@ -5,8 +5,8 @@ xcp_d/logs/CITATION.md
 xcp_d/sub-01
 xcp_d/sub-01/ses-1mo
 xcp_d/sub-01/ses-1mo/anat
-xcp_d/sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_space-MNI152NLin6Asym_desc-preproc_T1w.nii.gz
-xcp_d/sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_space-MNI152NLin6Asym_dseg.nii.gz
+xcp_d/sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_space-MNIInfant_desc-preproc_T1w.nii.gz
+xcp_d/sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_space-MNIInfant_dseg.nii.gz
 xcp_d/sub-01/ses-1mo/func
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_desc-preproc_design.tsv
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_motion.tsv

--- a/xcp_d/tests/data/nibabies_outputs.txt
+++ b/xcp_d/tests/data/nibabies_outputs.txt
@@ -5,8 +5,8 @@ xcp_d/logs/CITATION.md
 xcp_d/sub-01
 xcp_d/sub-01/ses-1mo
 xcp_d/sub-01/ses-1mo/anat
-xcp_d/sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_space-MNIInfant_desc-preproc_T1w.nii.gz
-xcp_d/sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_space-MNIInfant_dseg.nii.gz
+xcp_d/sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_space-MNIInfant_cohort-1_desc-preproc_T1w.nii.gz
+xcp_d/sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_space-MNIInfant_cohort-1_dseg.nii.gz
 xcp_d/sub-01/ses-1mo/func
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_desc-preproc_design.tsv
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_motion.tsv

--- a/xcp_d/tests/data/nifti_without_freesurfer_outputs.txt
+++ b/xcp_d/tests/data/nifti_without_freesurfer_outputs.txt
@@ -8,8 +8,8 @@ xcp_d/logs/CITATION.md
 xcp_d/logs/CITATION.tex
 xcp_d/sub-01
 xcp_d/sub-01/anat
-xcp_d/sub-01/anat/sub-01_space-MNI152NLin6Asym_desc-preproc_T1w.nii.gz
-xcp_d/sub-01/anat/sub-01_space-MNI152NLin6Asym_dseg.nii.gz
+xcp_d/sub-01/anat/sub-01_space-MNI152NLin2009cAsym_desc-preproc_T1w.nii.gz
+xcp_d/sub-01/anat/sub-01_space-MNI152NLin2009cAsym_dseg.nii.gz
 xcp_d/sub-01/func
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-1_desc-preproc_design.tsv
 xcp_d/sub-01/func/sub-01_task-mixedgamblestask_run-2_desc-preproc_design.tsv

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -1,0 +1,45 @@
+"""Tests for the xcp_d.utils.bids module."""
+from bids.layout import BIDSLayout
+
+import xcp_d.utils.bids as xbids
+
+
+def test_collect_data(datasets):
+    """Test the collect_data function."""
+    bids_dir = datasets["ds001419"]
+    ds001419_layout = BIDSLayout(
+        bids_dir,
+        validate=False,
+        derivatives=True,
+        config=["bids", "derivatives"],
+    )
+
+    _, subj_data = xbids.collect_data(
+        bids_dir=bids_dir,
+        input_type="fmriprep",
+        participant_label="01",
+        task=None,
+        bids_validate=False,
+        bids_filters=None,
+        cifti=False,
+        layout=ds001419_layout,
+    )
+
+    assert len(subj_data["bold"]) == 5
+    assert "space-MNI152NLin2009cAsym" in subj_data["bold"][0]
+    assert "space-" not in subj_data["t1w"]
+
+    _, subj_data = xbids.collect_data(
+        bids_dir=bids_dir,
+        input_type="fmriprep",
+        participant_label="01",
+        task=None,
+        bids_validate=False,
+        bids_filters=None,
+        cifti=True,
+        layout=ds001419_layout,
+    )
+
+    assert len(subj_data["bold"]) == 5
+    assert "space-fsLR" in subj_data["bold"][0]
+    assert "space-" not in subj_data["t1w"]

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -1,19 +1,23 @@
 """Tests for the xcp_d.utils.bids module."""
+import os
+
+import pytest
 from bids.layout import BIDSLayout
 
 import xcp_d.utils.bids as xbids
 
 
-def test_collect_data(datasets):
+def test_collect_data_ds001419(datasets):
     """Test the collect_data function."""
     bids_dir = datasets["ds001419"]
-    ds001419_layout = BIDSLayout(
+    layout = BIDSLayout(
         bids_dir,
         validate=False,
         derivatives=True,
         config=["bids", "derivatives"],
     )
 
+    # NIFTI workflow
     _, subj_data = xbids.collect_data(
         bids_dir=bids_dir,
         input_type="fmriprep",
@@ -22,13 +26,17 @@ def test_collect_data(datasets):
         bids_validate=False,
         bids_filters=None,
         cifti=False,
-        layout=ds001419_layout,
+        layout=layout,
     )
 
     assert len(subj_data["bold"]) == 5
     assert "space-MNI152NLin2009cAsym" in subj_data["bold"][0]
+    assert os.path.basename(subj_data["t1w"]) == "sub-01_desc-preproc_T1w.nii.gz"
     assert "space-" not in subj_data["t1w"]
+    assert "to-MNI152NLin2009cAsym" in subj_data["t1w_to_template_xform"]
+    assert "from-MNI152NLin2009cAsym" in subj_data["template_to_t1w_xform"]
 
+    # CIFTI workflow
     _, subj_data = xbids.collect_data(
         bids_dir=bids_dir,
         input_type="fmriprep",
@@ -37,9 +45,56 @@ def test_collect_data(datasets):
         bids_validate=False,
         bids_filters=None,
         cifti=True,
-        layout=ds001419_layout,
+        layout=layout,
     )
 
     assert len(subj_data["bold"]) == 5
     assert "space-fsLR" in subj_data["bold"][0]
     assert "space-" not in subj_data["t1w"]
+    assert os.path.basename(subj_data["t1w"]) == "sub-01_desc-preproc_T1w.nii.gz"
+    assert "to-MNI152NLin6Asym" in subj_data["t1w_to_template_xform"]
+    assert "from-MNI152NLin6Asym" in subj_data["template_to_t1w_xform"]
+
+
+def test_collect_data_nibabies(datasets):
+    """Test the collect_data function."""
+    bids_dir = datasets["nibabies"]
+    layout = BIDSLayout(
+        bids_dir,
+        validate=False,
+        derivatives=True,
+        config=["bids", "derivatives"],
+    )
+
+    # NIFTI workflow
+    _, subj_data = xbids.collect_data(
+        bids_dir=bids_dir,
+        input_type="fmriprep",
+        participant_label="01",
+        task=None,
+        bids_validate=False,
+        bids_filters=None,
+        cifti=False,
+        layout=layout,
+    )
+
+    assert len(subj_data["bold"]) == 1
+    assert "space-MNIInfant" in subj_data["bold"][0]
+    assert "cohort-1" in subj_data["bold"][0]
+    assert os.path.basename(subj_data["t1w"]) == "sub-01_ses-1mo_run-001_desc-preproc_T1w.nii.gz"
+    assert "space-" not in subj_data["t1w"]
+    assert "to-MNIInfant" in subj_data["t1w_to_template_xform"]
+    assert "from-MNIInfant" in subj_data["template_to_t1w_xform"]
+
+    # CIFTI workflow
+    with pytest.raises(FileNotFoundError):
+        _, subj_data = xbids.collect_data(
+            bids_dir=bids_dir,
+            input_type="fmriprep",
+            participant_label="01",
+            task=None,
+            bids_validate=False,
+            bids_filters=None,
+            cifti=True,
+            layout=layout,
+        )

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -770,7 +770,7 @@ def get_entity(filename, entity):
 
     folder, file_base = os.path.split(filename)
 
-    entity_values = re.findall(f"{entity}-([a-zA-Z0-9]+)", file_base)
+    entity_values = re.findall(f"{entity}-([a-zA-Z0-9+]+)", file_base)
     if len(entity_values) < 1:
         entity_value = None
     else:

--- a/xcp_d/workflow/anatomical.py
+++ b/xcp_d/workflow/anatomical.py
@@ -37,13 +37,13 @@ LOGGER = logging.getLogger("nipype.workflow")
 
 
 @fill_doc
-def init_t1w_wf(
+def init_warp_anats_to_template_wf(
     output_dir,
     input_type,
     target_space,
     omp_nthreads,
     mem_gb,
-    name="t1w_wf",
+    name="warp_anats_to_template_wf",
 ):
     """Copy T1w and segmentation to the derivative directory.
 
@@ -54,14 +54,14 @@ def init_t1w_wf(
             :graph2use: orig
             :simple_form: yes
 
-            from xcp_d.workflow.anatomical import init_t1w_wf
-            wf = init_t1w_wf(
+            from xcp_d.workflow.anatomical import init_warp_anats_to_template_wf
+            wf = init_warp_anats_to_template_wf(
                 output_dir=".",
                 input_type="fmriprep",
                 target_space="MNI152Nlin6Asym",
                 omp_nthreads=1,
                 mem_gb=0.1,
-                name="t1w_wf",
+                name="warp_anats_to_template_wf",
             )
 
     Parameters
@@ -73,7 +73,7 @@ def init_t1w_wf(
     %(omp_nthreads)s
     %(mem_gb)s
     %(name)s
-        Default is "t1w_wf".
+        Default is "warp_anats_to_template_wf".
 
     Inputs
     ------
@@ -95,6 +95,7 @@ def init_t1w_wf(
         name="outputnode",
     )
 
+    # Split cohort out of the space for MNIInfant templates.
     cohort = None
     if "+" in target_space:
         target_space, cohort = target_space.split("+")
@@ -104,37 +105,38 @@ def init_t1w_wf(
     )
 
     if input_type in ("dcan", "hcp"):
-        ds_t1wmni = pe.Node(
+        # Assume that the T1w and T1w segmentation files are in standard space,
+        # but don't have the "space" entity, for the "dcan" and "hcp" derivatives.
+        # This is a bug, and the converted filenames are inaccurate, so we have this
+        # workaround in place.
+        ds_t1w = pe.Node(
             DerivativesDataSink(
                 base_directory=output_dir,
                 extension=".nii.gz",
             ),
-            name="ds_t1wmni",
+            name="ds_t1w",
             run_without_submitting=False,
         )
 
-        ds_t1wseg = pe.Node(
+        ds_t1seg = pe.Node(
             DerivativesDataSink(
                 base_directory=output_dir,
                 extension=".nii.gz",
             ),
-            name="ds_t1wseg",
+            name="ds_t1seg",
             run_without_submitting=False,
         )
 
         # fmt:off
         workflow.connect([
-            (inputnode, ds_t1wmni, [("t1w", "in_file")]),
-            (inputnode, ds_t1wseg, [("t1seg", "in_file")]),
+            (inputnode, ds_t1w, [("t1w", "in_file")]),
+            (inputnode, ds_t1seg, [("t1seg", "in_file")]),
         ])
         # fmt:on
 
     else:
-        # TM: need to replace MNI92FSL xfm with the correct
-        # xfm from the MNI output space of fMRIPrep/NiBabies
-        # (MNI2009, MNIInfant, or for cifti output MNI152NLin6Asym)
-        # to MNI152NLin6Asym.
-        t1w_transform = pe.Node(
+        # Warp the native T1w-space T1w and T1w segmentation files to the selected standard space.
+        warp_t1w_to_template = pe.Node(
             ApplyTransformsx(
                 num_threads=2,
                 reference_image=template_file,
@@ -142,12 +144,21 @@ def init_t1w_wf(
                 input_image_type=3,
                 dimension=3,
             ),
-            name="t1w_transform",
+            name="warp_t1w_to_template",
             mem_gb=mem_gb,
             n_procs=omp_nthreads,
         )
 
-        seg_transform = pe.Node(
+        # fmt:off
+        workflow.connect([
+            (inputnode, warp_t1w_to_template, [
+                ("t1w", "input_image"),
+                ("t1w_to_template", "transforms"),
+            ]),
+        ])
+        # fmt:on
+
+        warp_t1seg_to_template = pe.Node(
             ApplyTransformsx(
                 num_threads=2,
                 reference_image=template_file,
@@ -155,50 +166,56 @@ def init_t1w_wf(
                 input_image_type=3,
                 dimension=3,
             ),
-            name="seg_transform",
+            name="warp_t1seg_to_template",
             mem_gb=mem_gb,
             n_procs=omp_nthreads,
         )
 
-        ds_t1wmni = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                space="MNI152NLin6Asym",
-                extension=".nii.gz",
-            ),
-            name="ds_t1wmni",
-            run_without_submitting=False,
-        )
+        # fmt:off
+        workflow.connect([
+            (inputnode, warp_t1seg_to_template, [
+                ("t1seg", "input_image"),
+                ("t1w_to_template", "transforms"),
+            ]),
+        ])
+        # fmt:on
 
-        ds_t1wseg = pe.Node(
+        ds_t1w = pe.Node(
             DerivativesDataSink(
                 base_directory=output_dir,
-                space="MNI152NLin6Asym",
+                space=target_space,
+                cohort=cohort,
                 extension=".nii.gz",
             ),
-            name="ds_t1wseg",
+            name="ds_t1w",
             run_without_submitting=False,
         )
 
         # fmt:off
-        workflow.connect(
-            [
-                (inputnode, t1w_transform, [("t1w", "input_image"),
-                                            ("t1w_to_template", "transforms")]),
-                (inputnode, seg_transform, [("t1seg", "input_image"),
-                                            ("t1w_to_template", "transforms")]),
-                (t1w_transform, ds_t1wmni, [("output_image", "in_file")]),
-                (seg_transform, ds_t1wseg, [("output_image", "in_file")]),
-            ]
+        workflow.connect([(warp_t1w_to_template, ds_t1w, [("output_image", "in_file")])])
+        # fmt:on
+
+        ds_t1seg = pe.Node(
+            DerivativesDataSink(
+                base_directory=output_dir,
+                space=target_space,
+                cohort=cohort,
+                extension=".nii.gz",
+            ),
+            name="ds_t1seg",
+            run_without_submitting=False,
         )
+
+        # fmt:off
+        workflow.connect([(warp_t1seg_to_template, ds_t1seg, [("output_image", "in_file")])])
         # fmt:on
 
     # fmt:off
     workflow.connect([
-        (inputnode, ds_t1wmni, [("t1w", "source_file")]),
-        (inputnode, ds_t1wseg, [("t1seg", "source_file")]),
-        (ds_t1wmni, outputnode, [("out_file", "t1w")]),
-        (ds_t1wseg, outputnode, [("out_file", "t1seg")]),
+        (inputnode, ds_t1w, [("t1w", "source_file")]),
+        (inputnode, ds_t1seg, [("t1seg", "source_file")]),
+        (ds_t1w, outputnode, [("out_file", "t1w")]),
+        (ds_t1seg, outputnode, [("out_file", "t1seg")]),
     ])
     # fmt:on
 

--- a/xcp_d/workflow/anatomical.py
+++ b/xcp_d/workflow/anatomical.py
@@ -95,7 +95,7 @@ def init_t1w_wf(
     )
 
     template_file = str(
-        get_template(template=target_space, resolution=2, desc=None, suffix="T1w")
+        get_template(template=target_space, resolution=1, desc=None, suffix="T1w")
     )
 
     if input_type in ("dcan", "hcp"):

--- a/xcp_d/workflow/anatomical.py
+++ b/xcp_d/workflow/anatomical.py
@@ -95,7 +95,13 @@ def init_t1w_wf(
         name="outputnode",
     )
 
-    template_file = str(get_template(template=target_space, resolution=1, desc=None, suffix="T1w"))
+    cohort = None
+    if "+" in target_space:
+        target_space, cohort = target_space.split("+")
+
+    template_file = str(
+        get_template(template=target_space, cohort=cohort, resolution=1, desc=None, suffix="T1w")
+    )
 
     if input_type in ("dcan", "hcp"):
         ds_t1wmni = pe.Node(

--- a/xcp_d/workflow/anatomical.py
+++ b/xcp_d/workflow/anatomical.py
@@ -58,6 +58,7 @@ def init_t1w_wf(
             wf = init_t1w_wf(
                 output_dir=".",
                 input_type="fmriprep",
+                target_space="MNI152Nlin6Asym",
                 omp_nthreads=1,
                 mem_gb=0.1,
                 name="t1w_wf",
@@ -94,9 +95,7 @@ def init_t1w_wf(
         name="outputnode",
     )
 
-    template_file = str(
-        get_template(template=target_space, resolution=1, desc=None, suffix="T1w")
-    )
+    template_file = str(get_template(template=target_space, resolution=1, desc=None, suffix="T1w"))
 
     if input_type in ("dcan", "hcp"):
         ds_t1wmni = pe.Node(

--- a/xcp_d/workflow/base.py
+++ b/xcp_d/workflow/base.py
@@ -26,7 +26,7 @@ from xcp_d.utils.bids import (
     write_dataset_description,
 )
 from xcp_d.utils.doc import fill_doc
-from xcp_d.workflow.anatomical import init_anatomical_wf, init_t1w_wf
+from xcp_d.workflow.anatomical import init_anatomical_wf, init_warp_anats_to_template_wf
 from xcp_d.workflow.bold import init_boldpostprocess_wf
 from xcp_d.workflow.cifti import init_ciftipostprocess_wf
 from xcp_d.workflow.execsummary import init_brainsprite_figures_wf
@@ -471,7 +471,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
     # Extract target volumetric space for T1w image
     target_space = get_entity(subj_data["t1w_to_template_xform"], "to")
 
-    t1w_wf = init_t1w_wf(
+    warp_anats_to_template_wf = init_warp_anats_to_template_wf(
         output_dir=output_dir,
         input_type=input_type,
         target_space=target_space,
@@ -481,9 +481,11 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
 
     # fmt:off
     workflow.connect([
-        (inputnode, t1w_wf, [('t1w', 'inputnode.t1w'),
-                             ('t1w_seg', 'inputnode.t1seg'),
-                             ('t1w_to_template_xform', 'inputnode.t1w_to_template')]),
+        (inputnode, warp_anats_to_template_wf, [
+            ("t1w", "inputnode.t1w"),
+            ("t1w_seg", "inputnode.t1seg"),
+            ("t1w_to_template_xform", "inputnode.t1w_to_template"),
+        ]),
     ])
     # fmt:on
 
@@ -514,7 +516,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
                 ("t1w", "inputnode.t1w"),
                 ("t1w_seg", "inputnode.t1seg"),
             ]),
-            (t1w_wf, brainsprite_wf, [
+            (warp_anats_to_template_wf, brainsprite_wf, [
                 ("outputnode.t1w", "inputnode.t1w"),
             ]),
             (anatomical_wf, brainsprite_wf, [

--- a/xcp_d/workflow/base.py
+++ b/xcp_d/workflow/base.py
@@ -26,7 +26,10 @@ from xcp_d.utils.bids import (
     write_dataset_description,
 )
 from xcp_d.utils.doc import fill_doc
-from xcp_d.workflow.anatomical import init_warp_anats_to_template_wf, init_warp_surfaces_to_template_wf
+from xcp_d.workflow.anatomical import (
+    init_warp_anats_to_template_wf,
+    init_warp_surfaces_to_template_wf,
+)
 from xcp_d.workflow.bold import init_boldpostprocess_wf
 from xcp_d.workflow.cifti import init_ciftipostprocess_wf
 from xcp_d.workflow.execsummary import init_brainsprite_figures_wf

--- a/xcp_d/workflow/base.py
+++ b/xcp_d/workflow/base.py
@@ -21,6 +21,7 @@ from xcp_d.interfaces.report import AboutSummary, SubjectSummary
 from xcp_d.utils.bids import (
     collect_data,
     collect_surface_data,
+    get_entity,
     get_preproc_pipeline_info,
     write_dataset_description,
 )
@@ -467,9 +468,13 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
         run_without_submitting=True,
     )
 
+    # Extract target volumetric space for T1w image
+    target_space = get_entity(subj_data["t1w_to_template_xform"], "to")
+
     t1w_wf = init_t1w_wf(
         output_dir=output_dir,
         input_type=input_type,
+        target_space=target_space,
         omp_nthreads=omp_nthreads,
         mem_gb=5,  # RF: need to change memory size
     )


### PR DESCRIPTION
Maybe, hopefully, addresses #701.

## Changes proposed in this pull request
- Rename `init_t1w_wf` to `init_warp_anats_to_template_wf`.
- Add tests for `xcp_d.utils.bids.collect_data`.
- Only search for to-MNI152Nlin6Asym transform when the inputs are CIFTIs, since this is the associated volumetric space for the fsLR CIFTI template.
- Extract the appropriate template to warp to in the T1w workflow from the transforms that are provided.
- Change the template's resolution from 2mm to 1mm in the T1w workflow.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
