### PR TITLE
Show workflow test logs live

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,8 @@ jobs:
           root: /src/coverage
           paths:
               - .coverage.pytests
+      - store_artifacts:
+          path: /src/xcp_d/.circleci/out/
 
   merge_coverage:
     <<: *dockersetup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
           name: Run full xcp_d on nifti without freesurfer
           no_output_timeout: 1h
           command: |
-            pytest -m "fmriprep_without_freesurfer" --cov-append --cov-report term-missing --cov=xcp_d --data_dir=/src/xcp_d/.circleci/data --output_dir=/src/xcp_d/.circleci/out --working_dir=/src/xcp_d/.circleci/work xcp_d
+            pytest -rP -o log_cli=true -m "fmriprep_without_freesurfer" --cov-append --cov-report term-missing --cov=xcp_d --data_dir=/src/xcp_d/.circleci/data --output_dir=/src/xcp_d/.circleci/out --working_dir=/src/xcp_d/.circleci/work xcp_d
             mkdir /src/coverage
             mv /src/xcp_d/.coverage /src/coverage/.coverage.fmriprep_without_freesurfer
       - persist_to_workspace:
@@ -132,7 +132,7 @@ jobs:
           name: Run full xcp_d on nifti with freesurfer
           no_output_timeout: 1h
           command: |
-            pytest -m "ds001419_nifti" --cov-append --cov-report term-missing --cov=xcp_d --data_dir=/src/xcp_d/.circleci/data --output_dir=/src/xcp_d/.circleci/out --working_dir=/src/xcp_d/.circleci/work xcp_d
+            pytest -rP -o log_cli=true -m "ds001419_nifti" --cov-append --cov-report term-missing --cov=xcp_d --data_dir=/src/xcp_d/.circleci/data --output_dir=/src/xcp_d/.circleci/out --working_dir=/src/xcp_d/.circleci/work xcp_d
             mkdir /src/coverage
             mv /src/xcp_d/.coverage /src/coverage/.coverage.ds001419_nifti
       - persist_to_workspace:
@@ -161,7 +161,7 @@ jobs:
           name: Run full xcp_d on nibabies
           no_output_timeout: 1h
           command: |
-            pytest -m "nibabies" --cov-append --cov-report term-missing --cov=xcp_d --data_dir=/src/xcp_d/.circleci/data --output_dir=/src/xcp_d/.circleci/out --working_dir=/src/xcp_d/.circleci/work xcp_d
+            pytest -rP -o log_cli=true -m "nibabies" --cov-append --cov-report term-missing --cov=xcp_d --data_dir=/src/xcp_d/.circleci/data --output_dir=/src/xcp_d/.circleci/out --working_dir=/src/xcp_d/.circleci/work xcp_d
             mkdir /src/coverage
             mv /src/xcp_d/.coverage /src/coverage/.coverage.nibabies
       - persist_to_workspace:
@@ -190,7 +190,7 @@ jobs:
           name: Run full xcp_d on cifti with freesurfer
           no_output_timeout: 5h
           command: |
-            pytest -m "ds001419_cifti" --cov-append --cov-report term-missing --cov=xcp_d --data_dir=/src/xcp_d/.circleci/data --output_dir=/src/xcp_d/.circleci/out --working_dir=/src/xcp_d/.circleci/work xcp_d
+            pytest -rP -o log_cli=true -m "ds001419_cifti" --cov-append --cov-report term-missing --cov=xcp_d --data_dir=/src/xcp_d/.circleci/data --output_dir=/src/xcp_d/.circleci/out --working_dir=/src/xcp_d/.circleci/work xcp_d
             mkdir /src/coverage
             mv /src/xcp_d/.coverage /src/coverage/.coverage.ds001419_cifti
       - persist_to_workspace:

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -84,9 +84,16 @@ The  ``xcp_d`` outputs are written out in BIDS format and consist of three main 
               "nuisance parameters": "27P",
           }
 
-   b. Functional timeseries and connectivity matrices::
+   b. Functional timeseries and connectivity matrices.
+      This includes the atlases used to extract the timeseries.::
 
           xcp_d/
+               # Nifti
+               space-<label>_atlas-<label>_dseg.nii.gz
+
+               # Cifti
+               space-<label>_atlas-<label>_dseg.dlabel.nii
+
                sub-<label>/[ses-<label>/]
                     func/
                          # Nifti

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -104,7 +104,7 @@ The  ``xcp_d`` outputs are written out in BIDS format and consist of three main 
                          <source_entities>_space-fsLR_atlas-<label>_den-91k_timeseries.ptseries.nii
                          <source_entities>_space-fsLR_atlas-<label>_den-91k_measure-pearsoncorrelation_conmat.pconn.nii
 
-   c. Resting-state derivatives (Regional Homogeneity and ALFF)::
+   c. Resting-state metric derivatives (Regional Homogeneity and ALFF)::
 
           xcp_d/
                sub-<label>/[ses-<label>/]

--- a/xcp_d/interfaces/qc_plot.py
+++ b/xcp_d/interfaces/qc_plot.py
@@ -331,7 +331,7 @@ class QCPlot(SimpleInterface):
 
         preproc_fig.savefig(
             self._results["raw_qcplot"],
-            bold_file_name_componentsox_inches="tight",
+            bbox_inches="tight",
         )
 
         # If censoring occurs, censor the cleaned BOLD data and FD time series
@@ -387,7 +387,7 @@ class QCPlot(SimpleInterface):
 
         postproc_fig.savefig(
             self._results["clean_qcplot"],
-            bold_file_name_componentsox_inches="tight",
+            bbox_inches="tight",
         )
 
         # Calculate QC measures


### PR DESCRIPTION
Closes None.

## Changes proposed in this pull request
- Show the test logs for the workflow tests live. This way we can see what's happening like we could before #740.
- Add the atlas filename patterns to the outputs file. I forgot to do this in #647.
- Store unit test artifacts in `/src/xcp_d/.circleci/out/`. We can use this to debug tests in the future.

## Documentation that should be reviewed
Outputs file.
