### PR TITLE
Remove unused BrainPlot interface

### DIFF
--- a/xcp_d/interfaces/resting_state.py
+++ b/xcp_d/interfaces/resting_state.py
@@ -8,7 +8,6 @@
 import os
 import shutil
 
-from nilearn.plotting import view_img
 from nipype import logging
 from nipype.interfaces.afni.preprocess import Despike, DespikeInputSpec
 from nipype.interfaces.afni.utils import ReHoInputSpec, ReHoOutputSpec
@@ -23,7 +22,6 @@ from nipype.interfaces.base import (
 
 from xcp_d.utils.fcon import compute_2d_reho, compute_alff, mesh_adjacency
 from xcp_d.utils.filemanip import fname_presuffix
-from xcp_d.utils.utils import zscore_nifti
 from xcp_d.utils.write_save import read_gii, read_ndata, write_gii, write_ndata
 
 LOGGER = logging.getLogger("nipype.interface")
@@ -147,56 +145,6 @@ class ComputeALFF(SimpleInterface):
             filename=self._results["alff_out"],
             mask=self.inputs.mask,
         )
-        return runtime
-
-
-class _BrainPlotInputSpec(BaseInterfaceInputSpec):
-    in_file = File(exists=True, mandatory=True, desc="alff or reho")
-    mask_file = File(exists=True, mandatory=True, desc="mask file ")
-
-
-class _BrainPlotOutputSpec(TraitedSpec):
-    nifti_html = File(exists=True, mandatory=True, desc="zscore html")
-
-
-class BrainPlot(SimpleInterface):
-    """Create a brainsprite figure from a NIFTI file.
-
-    The image will first be normalized (z-scored) before the figure is generated.
-
-    """
-
-    input_spec = _BrainPlotInputSpec
-    output_spec = _BrainPlotOutputSpec
-
-    def _run_interface(self, runtime):
-
-        # create a file name
-        z_score_nifti = os.path.split(os.path.abspath(self.inputs.in_file))[0] + "/zscore.nii.gz"
-
-        # create a nifti with z-scores
-        z_score_nifti = zscore_nifti(
-            img=self.inputs.in_file, mask=self.inputs.mask_file, outputname=z_score_nifti
-        )
-
-        html_view = view_img(
-            stat_map_img=z_score_nifti,
-            threshold=0,
-            opacity=0.5,
-            cut_coords=[0, 0, 0],
-            title="zscore",
-            bg_img=None,
-        )
-
-        # write the html out
-        self._results["nifti_html"] = fname_presuffix(
-            "zscore_nifti_",
-            suffix="stat.html",
-            newpath=runtime.cwd,
-            use_ext=False,
-        )
-
-        html_view.save_as_html(self._results["nifti_html"])
         return runtime
 
 

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -245,3 +245,14 @@ def cast_cifti_to_int16(in_file):
     img.to_filename(out_file)
 
     return out_file
+
+
+def scale_to_min_max(X, x_min, x_max):
+    """Scale data to between minimum and maximum values."""
+    nom = (X - X.min()) * (x_max - x_min)
+    denom = X.max() - X.min()
+
+    if denom == 0:
+        denom = 1
+
+    return x_min + (nom / denom)

--- a/xcp_d/utils/plot.py
+++ b/xcp_d/utils/plot.py
@@ -18,6 +18,7 @@ from nilearn.signal import clean
 
 from xcp_d.utils.bids import _get_tr
 from xcp_d.utils.doc import fill_doc
+from xcp_d.utils.modified_data import scale_to_min_max
 from xcp_d.utils.qcmetrics import compute_dvars
 from xcp_d.utils.write_save import read_ndata, write_ndata
 
@@ -557,8 +558,10 @@ def plot_svgx(
         atlaslabels = None
 
     # The plot going to carpet plot will be rescaled to [-600,600]
-    scaled_raw_data = read_ndata(datafile=preprocessed_file, maskfile=mask, scale=600)
-    scaled_denoised_data = read_ndata(datafile=denoised_file, maskfile=mask, scale=600)
+    raw_data = read_ndata(datafile=preprocessed_file, maskfile=mask)
+    denoised_data = read_ndata(datafile=denoised_file, maskfile=mask)
+    scaled_raw_data = scale_to_min_max(raw_data, -600, 600)
+    scaled_denoised_data = scale_to_min_max(denoised_data, -600, 600)
 
     # Make a temporary file for niftis and ciftis
     if preprocessed_file.endswith(".nii.gz"):

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -6,7 +6,6 @@ import os
 import tempfile
 from pathlib import Path
 
-import nibabel as nb
 import numpy as np
 from nipype.interfaces.ants import ApplyTransforms
 from scipy.signal import butter, filtfilt
@@ -370,50 +369,6 @@ def fwhm2sigma(fwhm):
         Sigma.
     """
     return fwhm / np.sqrt(8 * np.log(2))
-
-
-def zscore_nifti(img, outputname, mask=None):
-    """Normalize (z-score) a NIFTI image.
-
-    Image and mask must be in the same space.
-    TODO: Use Nilearn for masking.
-
-    Parameters
-    ----------
-    img : str
-        Path to the NIFTI image to z-score.
-    outputname : str
-        Output filename.
-    mask : str or None, optional
-        Path to binary mask file. Default is None.
-
-    Returns
-    -------
-    outputname : str
-        Output filename. Same as the ``outputname`` parameter.
-    """
-    img = nb.load(img)
-
-    if mask:
-        # z-score the data
-        maskdata = nb.load(mask).get_fdata()
-        imgdata = img.get_fdata()
-        meandata = imgdata[maskdata > 0].mean()
-        stddata = imgdata[maskdata > 0].std()
-        zscore_fdata = (imgdata - meandata) / stddata
-        # values where the mask is less than 1 are set to 0
-        zscore_fdata[maskdata < 1] = 0
-    else:
-        # z-score the data
-        imgdata = img.get_fdata()
-        meandata = imgdata[np.abs(imgdata) > 0].mean()
-        stddata = imgdata[np.abs(imgdata) > 0].std()
-        zscore_fdata = (imgdata - meandata) / stddata
-
-    # turn image to nifti and write it out
-    dataout = nb.Nifti1Image(zscore_fdata, affine=img.affine, header=img.header)
-    dataout.to_filename(outputname)
-    return outputname
 
 
 def butter_bandpass(data, fs, lowpass, highpass, order=2):

--- a/xcp_d/utils/write_save.py
+++ b/xcp_d/utils/write_save.py
@@ -12,7 +12,7 @@ from templateflow.api import get as get_template
 from xcp_d.utils.filemanip import split_filename
 
 
-def read_ndata(datafile, maskfile=None, scale=0):
+def read_ndata(datafile, maskfile=None):
     """Read nifti or cifti file.
 
     Parameters
@@ -22,7 +22,6 @@ def read_ndata(datafile, maskfile=None, scale=0):
     maskfile : str
         Path to a binary mask.
         Unused for CIFTI data.
-    scale : ?
 
     Outputs
     -------
@@ -43,9 +42,6 @@ def read_ndata(datafile, maskfile=None, scale=0):
 
     # transpose from TxS to SxT
     data = data.T
-
-    if scale > 0:
-        data = scalex(data, -scale, scale)
 
     return data
 
@@ -74,7 +70,7 @@ def get_cifti_intents():
     return CIFTI_INTENTS
 
 
-def write_ndata(data_matrix, template, filename, mask=None, TR=1, scale=0):
+def write_ndata(data_matrix, template, filename, mask=None, TR=1):
     """Save numpy array to a nifti or cifti file.
 
     Parameters
@@ -90,7 +86,6 @@ def write_ndata(data_matrix, template, filename, mask=None, TR=1, scale=0):
         The mask is only used for nifti files- masking is not supported in ciftis.
         Default is None.
     TR : float, optional
-    scale : float, optional
 
     Returns
     -------
@@ -111,9 +106,6 @@ def write_ndata(data_matrix, template, filename, mask=None, TR=1, scale=0):
         assert os.path.isfile(mask), f"The mask file does not exist: {mask}"
     else:
         raise ValueError(f"Unknown extension for {template}")
-
-    if scale > 0:
-        data_matrix = scalex(data_matrix, -scale, scale)
 
     # transpose from SxT to TxS
     data_matrix = data_matrix.T
@@ -250,14 +242,3 @@ def read_gii(surf_gii):
         for arr in range(len(bold_data.darrays)):
             gifti_data[:, arr] = bold_data.darrays[arr].data
     return gifti_data
-
-
-def scalex(X, x_min, x_max):
-    """Scale data to between minimum and maximum values."""
-    nom = (X - X.min()) * (x_max - x_min)
-    denom = X.max() - X.min()
-
-    if denom == 0:
-        denom = 1
-
-    return x_min + (nom / denom)


### PR DESCRIPTION
Closes None. Just removing some unused code.

## Changes proposed in this pull request
- Remove BrainPlot.
- Remove `z_score_nifti`.
- Remove `scale` parameter from `read_ndata` and `write_ndata`. Move `scalex` to `modified_data` and rename it to `scale_data_min_max`.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
