### PR TITLE
Use NaNs for low-coverage parcels

### DIFF
--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -128,7 +128,7 @@ class NiftiConnect(SimpleInterface):
         time_series = masker.fit_transform(filtered_file)
 
         # Apply the coverage mask
-        time_series[:, coverage_thresholded] = 0
+        time_series[:, coverage_thresholded] = np.nan
 
         # Use numpy for correlation matrix
         correlation_matrices = np.corrcoef(time_series.T)

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -750,11 +750,11 @@ class CiftiSanitizeParcellationResults(SimpleInterface):
 
         timeseries_arr = timeseries_img.get_fdata()
         correlation_arr = correlation_img.get_fdata()
-        assert timeseries_arr.shape[0] == correlation_arr.shape[0]
+        assert timeseries_arr.shape[1] == correlation_arr.shape[0]
         assert correlation_arr.shape[1] == correlation_arr.shape[0]
 
-        bad_parcels = np.where(np.all(timeseries_arr == 0, axis=0))
-        timeseries_arr[bad_parcels, :] = np.nan
+        bad_parcels = np.where(np.all(timeseries_arr == 0, axis=0))[0]
+        timeseries_arr[:, bad_parcels] = np.nan
         correlation_arr[bad_parcels, :] = np.nan
         correlation_arr[:, bad_parcels] = np.nan
 

--- a/xcp_d/tests/test_ALFF.py
+++ b/xcp_d/tests/test_ALFF.py
@@ -43,10 +43,6 @@ def test_nifti_alff(fmriprep_with_freesurfer_data, tmp_path_factory):
     alff_compute_wf.inputs.inputnode.clean_bold = bold_file
     alff_compute_wf.run()
 
-    node = alff_compute_wf.get_node("alff_compt")
-    node_output_dir = node.output_dir()
-    raise Exception(f"Paths:\n\tbase_dir: {tempdir}\n\tnode output_dir: {node_output_dir}")
-
     # Let's get the mean of the ALFF for later comparison
     original_alff = os.path.join(
         tempdir,

--- a/xcp_d/tests/test_ALFF.py
+++ b/xcp_d/tests/test_ALFF.py
@@ -43,6 +43,10 @@ def test_nifti_alff(fmriprep_with_freesurfer_data, tmp_path_factory):
     alff_compute_wf.inputs.inputnode.clean_bold = bold_file
     alff_compute_wf.run()
 
+    node = alff_compute_wf.get_node("alff_compt")
+    node_output_dir = node.output_dir()
+    raise Exception(f"Paths:\n\tbase_dir: {tempdir}\n\tnode output_dir: {node_output_dir}")
+
     # Let's get the mean of the ALFF for later comparison
     original_alff = os.path.join(
         tempdir,

--- a/xcp_d/tests/test_workflows_connectivity.py
+++ b/xcp_d/tests/test_workflows_connectivity.py
@@ -166,21 +166,25 @@ def test_cifti_conn(fmriprep_with_freesurfer_data, tmp_path_factory):
     )
     timeseries_file = os.path.join(
         sanitize_dir,
-        "parcellated_prepared_timeseries.dtseries.ptseries.nii",
+        "parcellated_prepared_timeseries.dtseriessanitized.ptseries.nii",
     )
     assert os.path.isfile(timeseries_file), os.listdir(sanitize_dir)
 
     correlation_file = os.path.join(
         sanitize_dir,
-        "fake_signal_filefcon_matrix.pconn.nii",
+        "correlation_matrix_parcellated_prepared_timeseries.dtseries.ptseriessanitized.pconn.nii",
     )
     assert os.path.isfile(correlation_file), os.listdir(sanitize_dir)
 
-    coverage_file = os.path.join(
-        sanitize_dir,
-        "fake_signal_fileparcel_coverage_file.pscalar.nii",
+    coverage_dir = os.path.join(
+        connectivity_wf.base_dir,
+        "connectivity_wf/parcellate_coverage_file/mapflow/_parcellate_coverage_file9",
     )
-    assert os.path.isfile(coverage_file), os.listdir(sanitize_dir)
+    coverage_file = os.path.join(
+        coverage_dir,
+        "parcellated_parcel_coverage.dscalar.pscalar.nii",
+    )
+    assert os.path.isfile(coverage_file), os.listdir(coverage_dir)
 
     # Let's read out the parcellated time series and get its corr coeff
     timeseries_arr = nb.load(timeseries_file).get_fdata().T

--- a/xcp_d/tests/test_workflows_connectivity.py
+++ b/xcp_d/tests/test_workflows_connectivity.py
@@ -80,17 +80,17 @@ def test_nifti_conn(fmriprep_with_freesurfer_data, tmp_path_factory):
     # Read that into a df
     timeseries_df = pd.read_table(timeseries_file, header=None)
     timeseries_arr = timeseries_df.to_numpy()
-    assert timeseries_arr.shape == (60, 1000)  # :(
+    assert timeseries_arr.shape == (60, 998)  # :(
 
     # Read that into a df
     corr_df = pd.read_table(correlation_file, header=None)
     corr_arr = corr_df.to_numpy()
-    assert corr_arr.shape == (1000, 1000)  # :(
+    assert corr_arr.shape == (998, 998)  # :(
 
     # Read that into a df
     coverage_df = pd.read_table(coverage_file, header=None)
     coverage_arr = coverage_df.to_numpy()
-    assert coverage_arr.shape == (1000,)  # :(
+    assert coverage_arr.shape == (998,)  # :(
 
     # Now let's get the ground truth. First, we should locate the atlas
     atlas_file = os.path.join(

--- a/xcp_d/tests/test_workflows_connectivity.py
+++ b/xcp_d/tests/test_workflows_connectivity.py
@@ -90,7 +90,7 @@ def test_nifti_conn(fmriprep_with_freesurfer_data, tmp_path_factory):
     # Read that into a df
     coverage_df = pd.read_table(coverage_file, header=None)
     coverage_arr = coverage_df.to_numpy()
-    assert coverage_arr.shape == (998,)  # :(
+    assert coverage_arr.shape == (998, 1)  # :(
 
     # Now let's get the ground truth. First, we should locate the atlas
     atlas_file = os.path.join(
@@ -180,10 +180,7 @@ def test_cifti_conn(fmriprep_with_freesurfer_data, tmp_path_factory):
         connectivity_wf.base_dir,
         "connectivity_wf/parcellate_coverage_file/mapflow/_parcellate_coverage_file9",
     )
-    coverage_file = os.path.join(
-        coverage_dir,
-        "parcellated_parcel_coverage.dscalar.pscalar.nii",
-    )
+    coverage_file = os.path.join(coverage_dir, "parcel_coverage.pscalar.nii")
     assert os.path.isfile(coverage_file), os.listdir(coverage_dir)
 
     # Let's read out the parcellated time series and get its corr coeff

--- a/xcp_d/tests/test_workflows_connectivity.py
+++ b/xcp_d/tests/test_workflows_connectivity.py
@@ -80,17 +80,17 @@ def test_nifti_conn(fmriprep_with_freesurfer_data, tmp_path_factory):
     # Read that into a df
     timeseries_df = pd.read_table(timeseries_file, header=None)
     timeseries_arr = timeseries_df.to_numpy()
-    assert timeseries_arr.shape == (60, 1000)
+    assert timeseries_arr.shape == (60, 1000)  # :(
 
     # Read that into a df
     corr_df = pd.read_table(correlation_file, header=None)
     corr_arr = corr_df.to_numpy()
-    assert corr_arr.shape == (1000, 1000)
+    assert corr_arr.shape == (1000, 1000)  # :(
 
     # Read that into a df
     coverage_df = pd.read_table(coverage_file, header=None)
     coverage_arr = coverage_df.to_numpy()
-    assert coverage_arr.shape == (1000,)
+    assert coverage_arr.shape == (1000,)  # :(
 
     # Now let's get the ground truth. First, we should locate the atlas
     atlas_file = os.path.join(
@@ -112,7 +112,7 @@ def test_nifti_conn(fmriprep_with_freesurfer_data, tmp_path_factory):
 
     # The "ground truth" matrix
     ground_truth = np.corrcoef(signals.T)
-    assert ground_truth.shape == (1000, 1000)
+    assert ground_truth.shape == (998, 998)  # :(
 
     # Parcels with <50% coverage should have NaNs
     bad_parcel_idx = np.where(coverage_arr < 0.5)[0]

--- a/xcp_d/workflows/connectivity.py
+++ b/xcp_d/workflows/connectivity.py
@@ -10,12 +10,14 @@ from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
 from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.connectivity import ApplyTransformsx, ConnectPlot, NiftiConnect
-from xcp_d.interfaces.prepostcleaning import CiftiPrepareForParcellation
+from xcp_d.interfaces.prepostcleaning import (
+    CiftiPrepareForParcellation,
+    CiftiSanitizeParcellationResults,
+)
 from xcp_d.interfaces.workbench import (
     CiftiCorrelation,
     CiftiCreateDenseFromTemplate,
     CiftiParcellate,
-    CiftiSanitizeParcellationResults,
 )
 from xcp_d.utils.atlas import get_atlas_cifti, get_atlas_names, get_atlas_nifti
 from xcp_d.utils.doc import fill_doc


### PR DESCRIPTION
Closes #777.

## Changes proposed in this pull request
- Create interface to replace time series of zeros (i.e., parcels with bad coverage) in the parcellated CIFTI files with NaNs. It also replaces the correlation values for those parcels (assuming they're in the same order in the data array) with NaNs.
- Use a time series of NaNs for bad parcels in the parcellated NIFTI results as well.

## Documentation that should be reviewed
None.
