### PR TITLE
Replace MultiLabel interpolation with GenericLabel

### DIFF
--- a/xcp_d/interfaces/ants.py
+++ b/xcp_d/interfaces/ants.py
@@ -17,6 +17,8 @@ from niworkflows.interfaces.fixes import (
     _FixTraitApplyTransformsInputSpec,
 )
 
+from xcp_d.utils.filemanip import fname_presuffix
+
 LOGGER = logging.getLogger("nipype.interface")
 
 
@@ -182,3 +184,14 @@ class ApplyTransforms(FixHeaderApplyTransforms):
     """
 
     input_spec = _ApplyTransformsInputSpec
+
+    def _run_interface(self, runtime):
+        # Run normally
+        self.inputs.output_image = fname_presuffix(
+            self.inputs.input_image,
+            suffix="_trans.nii.gz",
+            newpath=runtime.cwd,
+            use_ext=False,
+        )
+        runtime = super(ApplyTransforms, self)._run_interface(runtime)
+        return runtime

--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -7,7 +7,6 @@ import numpy as np
 from nilearn.input_data import NiftiLabelsMasker
 from nilearn.plotting import plot_matrix
 from nipype import logging
-from nipype.interfaces.ants.resampling import ApplyTransforms, ApplyTransformsInputSpec
 from nipype.interfaces.base import (
     BaseInterfaceInputSpec,
     File,
@@ -137,33 +136,6 @@ class NiftiConnect(SimpleInterface):
         np.savetxt(self._results["fcon_matrix_tsv"], correlation_matrices, delimiter="\t")
         np.savetxt(self._results["parcel_coverage_file"], parcel_coverage, delimiter="\t")
 
-        return runtime
-
-
-class _ApplyTransformsInputSpec(ApplyTransformsInputSpec):
-    transforms = InputMultiObject(
-        traits.Either(File(exists=True), "identity"),
-        argstr="%s",
-        mandatory=True,
-        desc="transform files",
-    )
-
-
-class ApplyTransformsx(ApplyTransforms):
-    """ApplyTransforms from nipype as workflow.
-
-    This is a modification of the ApplyTransforms interface,
-    with an updated set of inputs and a different default output image name.
-    """
-
-    input_spec = _ApplyTransformsInputSpec
-
-    def _run_interface(self, runtime):
-        # Run normally
-        self.inputs.output_image = fname_presuffix(
-            self.inputs.input_image, suffix="_trans.nii.gz", newpath=runtime.cwd, use_ext=False
-        )
-        runtime = super(ApplyTransformsx, self)._run_interface(runtime)
         return runtime
 
 

--- a/xcp_d/tests/test_workflows_connectivity.py
+++ b/xcp_d/tests/test_workflows_connectivity.py
@@ -98,8 +98,8 @@ def test_nifti_conn(fmriprep_with_freesurfer_data, tmp_path_factory):
     assert ground_truth.shape == (400, 400)
 
     # Parcels with <50% coverage should have NaNs
-    # We know that 10 of the parcels in the 400-parcel Schaefer are flagged
-    assert np.sum(np.isnan(np.diag(xcp_array))) == 10
+    # We know that 14 of the parcels in the 400-parcel Schaefer are flagged
+    assert np.sum(np.isnan(np.diag(xcp_array))) == 14
 
     # If we replace the bad parcels' results in the "ground truth" matrix with NaNs,
     # the resulting matrix should match the workflow-generated one.

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -10,8 +10,6 @@ import numpy as np
 from scipy.signal import butter, filtfilt
 from templateflow.api import get as get_template
 
-from xcp_d.interfaces.ants import ApplyTransforms
-
 
 def _t12native(fname):
     """Select T1w-to-scanner transform associated with a given BOLD file.
@@ -65,6 +63,8 @@ def get_segfile(bold_file):
     -----
     Only used in concatenation code and should be dropped in favor of BIDSLayout methods ASAP.
     """
+    from xcp_d.interfaces.ants import ApplyTransforms
+
     # get transform files
     dd = Path(os.path.dirname(bold_file))
     anatdir = str(dd.parent) + "/anat"

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -7,9 +7,10 @@ import tempfile
 from pathlib import Path
 
 import numpy as np
-from nipype.interfaces.ants import ApplyTransforms
 from scipy.signal import butter, filtfilt
 from templateflow.api import get as get_template
+
+from xcp_d.interfaces.ants import ApplyTransforms
 
 
 def _t12native(fname):

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -159,7 +159,7 @@ def init_warp_anats_to_template_wf(
             ApplyTransformsx(
                 num_threads=2,
                 reference_image=template_file,
-                interpolation="MultiLabel",
+                interpolation="GenericLabel",
                 input_image_type=3,
                 dimension=3,
             ),

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -10,10 +10,9 @@ from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from pkg_resources import resource_filename as pkgrf
 from templateflow.api import get as get_template
 
-from xcp_d.interfaces.ants import CompositeInvTransformUtil, ConvertTransformFile
+from xcp_d.interfaces.ants import ApplyTransforms, CompositeInvTransformUtil, ConvertTransformFile
 from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.c3 import C3d  # TM
-from xcp_d.interfaces.connectivity import ApplyTransformsx
 from xcp_d.interfaces.nilearn import BinaryMath, Merge
 from xcp_d.interfaces.utils import FilterUndefined
 from xcp_d.interfaces.workbench import (  # MB,TM
@@ -134,7 +133,7 @@ def init_warp_anats_to_template_wf(
     else:
         # Warp the native T1w-space T1w and T1w segmentation files to the selected standard space.
         warp_t1w_to_template = pe.Node(
-            ApplyTransformsx(
+            ApplyTransforms(
                 num_threads=2,
                 reference_image=template_file,
                 interpolation="LanczosWindowedSinc",
@@ -156,7 +155,7 @@ def init_warp_anats_to_template_wf(
         # fmt:on
 
         warp_t1seg_to_template = pe.Node(
-            ApplyTransformsx(
+            ApplyTransforms(
                 num_threads=2,
                 reference_image=template_file,
                 interpolation="GenericLabel",

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -10,7 +10,11 @@ from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from pkg_resources import resource_filename as pkgrf
 from templateflow.api import get as get_template
 
-from xcp_d.interfaces.ants import ApplyTransforms, CompositeInvTransformUtil, ConvertTransformFile
+from xcp_d.interfaces.ants import (
+    ApplyTransforms,
+    CompositeInvTransformUtil,
+    ConvertTransformFile,
+)
 from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.c3 import C3d  # TM
 from xcp_d.interfaces.nilearn import BinaryMath, Merge

--- a/xcp_d/workflows/connectivity.py
+++ b/xcp_d/workflows/connectivity.py
@@ -148,7 +148,7 @@ when the parcel had >50% coverage, or were set to zero, when the parcel had <50%
     # Using the generated transforms, apply them to get everything in the correct MNI form
     warp_atlases_to_bold_space = pe.MapNode(
         ApplyTransformsx(
-            interpolation="MultiLabel",
+            interpolation="GenericLabel",
             input_image_type=3,
             dimension=3,
         ),

--- a/xcp_d/workflows/connectivity.py
+++ b/xcp_d/workflows/connectivity.py
@@ -8,8 +8,9 @@ from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
+from xcp_d.interfaces.ants import ApplyTransforms
 from xcp_d.interfaces.bids import DerivativesDataSink
-from xcp_d.interfaces.connectivity import ApplyTransformsx, ConnectPlot, NiftiConnect
+from xcp_d.interfaces.connectivity import ConnectPlot, NiftiConnect
 from xcp_d.interfaces.prepostcleaning import CiftiPrepareForParcellation
 from xcp_d.interfaces.workbench import (
     CiftiCorrelation,
@@ -147,7 +148,7 @@ when the parcel had >50% coverage, or were set to zero, when the parcel had <50%
 
     # Using the generated transforms, apply them to get everything in the correct MNI form
     warp_atlases_to_bold_space = pe.MapNode(
-        ApplyTransformsx(
+        ApplyTransforms(
             interpolation="GenericLabel",
             input_image_type=3,
             dimension=3,

--- a/xcp_d/workflows/plotting.py
+++ b/xcp_d/workflows/plotting.py
@@ -302,7 +302,7 @@ def init_qc_report_wf(
             ApplyTransforms(
                 dimension=3,
                 input_image=dseg_file,
-                interpolation="MultiLabel",
+                interpolation="GenericLabel",
             ),
             name="warp_dseg_to_bold",
             n_procs=omp_nthreads,

--- a/xcp_d/workflows/plotting.py
+++ b/xcp_d/workflows/plotting.py
@@ -1,9 +1,9 @@
 """Plotting workflows."""
 from nipype import Function
 from nipype.interfaces import utility as niu
+from nipype.interfaces.ants.resampling import ApplyTransforms
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 from templateflow.api import get as get_template
 
 from xcp_d.interfaces.bids import DerivativesDataSink

--- a/xcp_d/workflows/plotting.py
+++ b/xcp_d/workflows/plotting.py
@@ -1,11 +1,11 @@
 """Plotting workflows."""
 from nipype import Function
 from nipype.interfaces import utility as niu
-from nipype.interfaces.ants.resampling import ApplyTransforms
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from templateflow.api import get as get_template
 
+from xcp_d.interfaces.ants import ApplyTransforms
 from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.qc_plot import CensoringPlot, QCPlot
 from xcp_d.interfaces.report import FunctionalSummary


### PR DESCRIPTION
I'm not sure how I missed this. Last year, in October, we had conversations on Slack about using GenericLabel over MultiLabel, but somehow this wasn't translated to a PR in xcp_d.

## Changes proposed in this pull request
- Use GenericLabel instead of MultiLabel when applying transforms to atlas files.
- Replace miscellaneous uses of `niworkflows.interfaces.fixes.FixHeaderApplyTransforms`, `nipype.interfaces.ants.ApplyTransforms`, and `xcp_d.interfaces.connectivity.ApplyTransformsx` with a new interface inheriting from `niworkflows.interfaces.fixes.FixHeaderApplyTransforms`. The only change to the interface is that I've overridden the allowed interpolation options to allow GenericLabel.

## Documentation that should be reviewed
None.
