### PR TITLE
Mention cosine regressors in aCompCor boilerplate

### DIFF
--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -284,6 +284,8 @@ def describe_regression(params, custom_confounds_file):
             "were selected as nuisance regressors [@behzadi2007component], "
             "along with the six motion parameters and their temporal derivatives "
             "[@benchmarkp;@satterthwaite_2013]. "
+            "As the aCompCor regressors were generated on high-pass filtered data, "
+            "the associated cosine basis regressors were included as well."
         ),
         "acompcor_gsr": (
             "The top 5 aCompCor principal components from the WM and CSF compartments "
@@ -291,6 +293,8 @@ def describe_regression(params, custom_confounds_file):
             "along with the six motion parameters and their temporal derivatives, "
             "mean white matter signal, mean CSF signal, and mean global signal "
             "[@benchmarkp;@satterthwaite_2013]. "
+            "As the aCompCor regressors were generated on high-pass filtered data, "
+            "the associated cosine basis regressors were included as well."
         ),
         "aroma": (
             "AROMA motion-labeled components [@pruim2015ica], mean white matter signal, "

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -285,7 +285,8 @@ def describe_regression(params, custom_confounds_file):
             "along with the six motion parameters and their temporal derivatives "
             "[@benchmarkp;@satterthwaite_2013]. "
             "As the aCompCor regressors were generated on high-pass filtered data, "
-            "the associated cosine basis regressors were included as well."
+            "the associated cosine basis regressors were included. "
+            "This has the effect of high-pass filtering the data as well."
         ),
         "acompcor_gsr": (
             "The top 5 aCompCor principal components from the WM and CSF compartments "
@@ -294,7 +295,8 @@ def describe_regression(params, custom_confounds_file):
             "mean white matter signal, mean CSF signal, and mean global signal "
             "[@benchmarkp;@satterthwaite_2013]. "
             "As the aCompCor regressors were generated on high-pass filtered data, "
-            "the associated cosine basis regressors were included as well."
+            "the associated cosine basis regressors were included. "
+            "This has the effect of high-pass filtering the data as well."
         ),
         "aroma": (
             "AROMA motion-labeled components [@pruim2015ica], mean white matter signal, "


### PR DESCRIPTION
Closes #787.

## Changes proposed in this pull request
- Document the use of cosine basis regressors in the boilerplate when aCompCor regressors are included.

## Documentation that should be reviewed
None
