### PR TITLE
Update base Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 
 .dockersetup: &dockersetup
   docker:
-    - image: pennbbl/xcpd_build:0.0.6rc1
+    - image: pennlinc/xcp_d_build:0.0.6rc4
   working_directory: /src/xcp_d
 
 runinstall: &runinstall

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 
 .dockersetup: &dockersetup
   docker:
-    - image: pennlinc/xcp_d_build:0.0.6rc4
+    - image: pennlinc/xcp_d_build:0.0.6rc5
   working_directory: /src/xcp_d
 
 runinstall: &runinstall

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM pennbbl/xcpd_build:0.0.6rc1
+FROM pennlinc/xcp_d_build:0.0.6rc4
 
 # Installing xcp_d
 COPY . /src/xcp_d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM pennlinc/xcp_d_build:0.0.6rc4
+FROM pennlinc/xcp_d_build:0.0.6rc5
 
 # Installing xcp_d
 COPY . /src/xcp_d


### PR DESCRIPTION
Closes None.

## Changes proposed in this pull request
- Change base Docker image to new `pennlinc/xcp_d_build`.
