### PR TITLE
Set FreeSurfer license as pytest fixture

### DIFF
--- a/.circleci/RunPyTests.sh
+++ b/.circleci/RunPyTests.sh
@@ -55,7 +55,6 @@ get_bids_data ${TESTDIR} sub01
 get_bids_data ${TESTDIR} ds001419-fmriprep
 
 CFG=${TESTDIR}/data/nipype.cfg
-export FS_LICENSE=${TESTDIR}/data/license.txt
 
 TESTNAME=run_pytest
 setup_dir ${TESTDIR}/${TESTNAME}

--- a/.circleci/get_data.sh
+++ b/.circleci/get_data.sh
@@ -73,13 +73,6 @@ run_xcpd_cmd () {
       cfg_arg="-v ${CFG}:/nipype/nipype.cfg --env NIPYPE_CONFIG_DIR=/nipype"
     fi
 
-    # Is there a Freesurfer license?
-    fslicense_arg=""
-    FS_LICENSE=$(printenv FS_LICENSE)
-    if [[ -n "${FS_LICENSE}" ]]; then
-      fslicense_arg="-v ${FS_LICENSE}:/license.txt --env FS_LICENSE=/license.txt"
-    fi
-
     # Is there a BIDS filter file?
     bids_filter_file_arg=""
     BIDS_FILTER_FILE=$(printenv BIDS_FILTER_FILE)
@@ -94,7 +87,7 @@ run_xcpd_cmd () {
     output_mount="-v ${output_dir}:/out:rw"
     workdir_mount="-v ${workdir}:/work:rw"
 
-    XCPD_RUN="docker run --rm -u $(id -u) ${workdir_mount} ${patch_mount} ${cfg_arg} ${fslicense_arg} ${bids_filter_file_arg} ${bids_mount} ${output_mount} ${IMAGE} /bids-input/${bids_folder_name} /out participant -w /work"
+    XCPD_RUN="docker run --rm -u $(id -u) ${workdir_mount} ${patch_mount} ${cfg_arg} ${bids_filter_file_arg} ${bids_mount} ${output_mount} ${IMAGE} /bids-input/${bids_folder_name} /out participant -w /work"
 
   fi
   echo "${XCPD_RUN} --nthreads ${NTHREADS} --omp-nthreads ${OMP_NTHREADS}"
@@ -112,8 +105,6 @@ Default data:
 
 data/nipype.cfg
   Instructs nipype to stop on the first crash
-data/license.txt
-  A freesurfer license file
 
 DOC
 

--- a/xcp_d/tests/conftest.py
+++ b/xcp_d/tests/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the CircleCI tests."""
+import base64
 import os
 
 import pytest
@@ -116,3 +117,15 @@ def fmriprep_without_freesurfer_data(datasets):
     )
 
     return files
+
+
+@pytest.fixture
+def fslicense(working_dir):
+    """Set the FreeSurfer license as an environment variable."""
+    FS_LICENSE = os.path.join(working_dir, "license.txt")
+    os.environ["FS_LICENSE"] = FS_LICENSE
+    LICENSE_CODE = (
+        "bWF0dGhldy5jaWVzbGFrQHBzeWNoLnVjc2IuZWR1CjIwNzA2CipDZmVWZEg1VVQ4clkKRlNCWVouVWtlVElDdwo="
+    )
+    with open(FS_LICENSE, "w") as f:
+        f.write(base64.b64decode(LICENSE_CODE).decode())

--- a/xcp_d/tests/conftest.py
+++ b/xcp_d/tests/conftest.py
@@ -119,7 +119,7 @@ def fmriprep_without_freesurfer_data(datasets):
     return files
 
 
-@pytest.fixture
+@pytest.fixture(scope="session", autouse=True)
 def fslicense(working_dir):
     """Set the FreeSurfer license as an environment variable."""
     FS_LICENSE = os.path.join(working_dir, "license.txt")

--- a/xcp_d/tests/conftest.py
+++ b/xcp_d/tests/conftest.py
@@ -13,25 +13,25 @@ def pytest_addoption(parser):
 
 
 # Set up the commandline options as fixtures
-@pytest.fixture
+@pytest.fixture(scope="session")
 def data_dir(request):
     """Grab data directory."""
     return request.config.getoption("--data_dir")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def working_dir(request):
     """Grab working directory."""
     return request.config.getoption("--working_dir")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def output_dir(request):
     """Grab output directory."""
     return request.config.getoption("--output_dir")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def datasets(data_dir):
     """Locate downloaded datasets."""
     dsets = {}
@@ -44,7 +44,7 @@ def datasets(data_dir):
     return dsets
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fmriprep_with_freesurfer_data(datasets):
     """Collect a list of files from ds001419 that will be used by misc. tests."""
     subj_dir = os.path.join(datasets["ds001419"], "sub-01")
@@ -92,7 +92,7 @@ def fmriprep_with_freesurfer_data(datasets):
     return files
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fmriprep_without_freesurfer_data(datasets):
     """Collect a list of fmriprepwithoutfreesurfer files that will be used by misc. tests."""
     subj_dir = os.path.join(datasets["fmriprep_without_freesurfer"], "sub-01")

--- a/xcp_d/tests/conftest.py
+++ b/xcp_d/tests/conftest.py
@@ -22,13 +22,17 @@ def data_dir(request):
 @pytest.fixture(scope="session")
 def working_dir(request):
     """Grab working directory."""
-    return request.config.getoption("--working_dir")
+    workdir = request.config.getoption("--working_dir")
+    os.makedirs(workdir, exist_ok=True)
+    return workdir
 
 
 @pytest.fixture(scope="session")
 def output_dir(request):
     """Grab output directory."""
-    return request.config.getoption("--output_dir")
+    outdir = request.config.getoption("--output_dir")
+    os.makedirs(outdir, exist_ok=True)
+    return outdir
 
 
 @pytest.fixture(scope="session")

--- a/xcp_d/tests/data/license.txt
+++ b/xcp_d/tests/data/license.txt
@@ -1,4 +1,0 @@
-stauffer@upenn.edu
-20217
- *CNJKge/MKN62
- FShMG3atCAhWE

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -18,7 +18,7 @@ from xcp_d.utils.concatenation import concatenate_derivatives
 
 
 @pytest.mark.ds001419_nifti
-def test_ds001419_nifti(datasets, output_dir, working_dir, fslicense):
+def test_ds001419_nifti(datasets, output_dir, working_dir):
     """Run xcp_d on ds001419 fMRIPrep derivatives, with nifti options."""
     test_name = "test_ds001419_nifti"
 
@@ -75,7 +75,7 @@ def test_ds001419_nifti(datasets, output_dir, working_dir, fslicense):
 
 
 @pytest.mark.ds001419_cifti
-def test_ds001419_cifti(datasets, output_dir, working_dir, fslicense):
+def test_ds001419_cifti(datasets, output_dir, working_dir):
     """Run xcp_d on ds001419 fMRIPrep derivatives, with cifti options."""
     test_name = "test_ds001419_cifti"
 
@@ -145,7 +145,7 @@ def test_ds001419_cifti(datasets, output_dir, working_dir, fslicense):
 
 
 @pytest.mark.fmriprep_without_freesurfer
-def test_fmriprep_without_freesurfer(datasets, output_dir, working_dir, fslicense):
+def test_fmriprep_without_freesurfer(datasets, output_dir, working_dir):
     """Run xcp_d on fMRIPrep derivatives without FreeSurfer, with nifti options.
 
     Notes
@@ -202,7 +202,7 @@ def test_fmriprep_without_freesurfer(datasets, output_dir, working_dir, fslicens
 
 
 @pytest.mark.nibabies
-def test_nibabies(datasets, output_dir, working_dir, fslicense):
+def test_nibabies(datasets, output_dir, working_dir):
     """Run xcp_d on Nibabies derivatives, with nifti options."""
     test_name = "test_nibabies"
 

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -18,7 +18,7 @@ from xcp_d.utils.concatenation import concatenate_derivatives
 
 
 @pytest.mark.ds001419_nifti
-def test_ds001419_nifti(datasets, output_dir, working_dir):
+def test_ds001419_nifti(datasets, output_dir, working_dir, fslicense):
     """Run xcp_d on ds001419 fMRIPrep derivatives, with nifti options."""
     test_name = "test_ds001419_nifti"
 
@@ -27,7 +27,6 @@ def test_ds001419_nifti(datasets, output_dir, working_dir):
     work_dir = os.path.join(working_dir, test_name)
 
     test_data_dir = get_test_data_path()
-    os.environ["FS_LICENSE"] = os.path.join(test_data_dir, "license.txt")
     filter_file = os.path.join(test_data_dir, "ds001419-fmriprep_nifti_filter.json")
 
     parameters = [
@@ -76,7 +75,7 @@ def test_ds001419_nifti(datasets, output_dir, working_dir):
 
 
 @pytest.mark.ds001419_cifti
-def test_ds001419_cifti(datasets, output_dir, working_dir):
+def test_ds001419_cifti(datasets, output_dir, working_dir, fslicense):
     """Run xcp_d on ds001419 fMRIPrep derivatives, with cifti options."""
     test_name = "test_ds001419_cifti"
 
@@ -85,7 +84,6 @@ def test_ds001419_cifti(datasets, output_dir, working_dir):
     work_dir = os.path.join(working_dir, test_name)
 
     test_data_dir = get_test_data_path()
-    os.environ["FS_LICENSE"] = os.path.join(test_data_dir, "license.txt")
     filter_file = os.path.join(test_data_dir, "ds001419-fmriprep_cifti_filter.json")
 
     parameters = [
@@ -147,7 +145,7 @@ def test_ds001419_cifti(datasets, output_dir, working_dir):
 
 
 @pytest.mark.fmriprep_without_freesurfer
-def test_fmriprep_without_freesurfer(datasets, output_dir, working_dir):
+def test_fmriprep_without_freesurfer(datasets, output_dir, working_dir, fslicense):
     """Run xcp_d on fMRIPrep derivatives without FreeSurfer, with nifti options.
 
     Notes
@@ -163,7 +161,6 @@ def test_fmriprep_without_freesurfer(datasets, output_dir, working_dir):
     os.makedirs(custom_confounds_dir, exist_ok=True)
 
     test_data_dir = get_test_data_path()
-    os.environ["FS_LICENSE"] = os.path.join(test_data_dir, "license.txt")
 
     # Create custom confounds folder
     for run in [1, 2]:
@@ -205,7 +202,7 @@ def test_fmriprep_without_freesurfer(datasets, output_dir, working_dir):
 
 
 @pytest.mark.nibabies
-def test_nibabies(datasets, output_dir, working_dir):
+def test_nibabies(datasets, output_dir, working_dir, fslicense):
     """Run xcp_d on Nibabies derivatives, with nifti options."""
     test_name = "test_nibabies"
 
@@ -214,7 +211,6 @@ def test_nibabies(datasets, output_dir, working_dir):
     work_dir = os.path.join(working_dir, test_name)
 
     test_data_dir = get_test_data_path()
-    os.environ["FS_LICENSE"] = os.path.join(test_data_dir, "license.txt")
 
     parameters = [
         data_dir,


### PR DESCRIPTION
Closes None.

## Changes proposed in this pull request
- Remove FreeSurfer license file. We shouldn't have it in the repo.
- Set license environment variable as pytest fixture.