### PR TITLE
Check for existence of dataset_description.json in fmri_dir

### DIFF
--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -649,6 +649,14 @@ def build_workflow(opts, retval):
         )
         retval["return_code"] = 1
 
+    if not (fmri_dir / "dataset_description.json").is_file():
+        build_log.error(
+            "No dataset_description.json file found in input directory. "
+            "Make sure to point to the specific pipeline's derivatives folder. "
+            "For example, use '/dset/derivatives/fmriprep', not /dset/derivatives'."
+        )
+        retval["return_code"] = 1
+
     if opts.analysis_level != "participant":
         build_log.error('Please select analysis level "participant"')
         retval["return_code"] = 1


### PR DESCRIPTION
Closes #804.

## Changes proposed in this pull request
- Check that a `dataset_description.json` file exists in `fmri_dir` within `build_workflow`. This should catch cases where a user provides the path to the general derivatives folder (e.g., `/dset/derivatives`), rather than the specific preprocessed derivatives (e.g., `/dset/derivatives/fmriprep`).

## Documentation that should be reviewed
None.
