### PR TITLE
Move dataset desc check to after conversion

### DIFF
--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -649,14 +649,6 @@ def build_workflow(opts, retval):
         )
         retval["return_code"] = 1
 
-    if not (fmri_dir / "dataset_description.json").is_file():
-        build_log.error(
-            "No dataset_description.json file found in input directory. "
-            "Make sure to point to the specific pipeline's derivatives folder. "
-            "For example, use '/dset/derivatives/fmriprep', not /dset/derivatives'."
-        )
-        retval["return_code"] = 1
-
     if opts.analysis_level != "participant":
         build_log.error('Please select analysis level "participant"')
         retval["return_code"] = 1
@@ -778,6 +770,14 @@ def build_workflow(opts, retval):
             convert_to_fmriprep(fmri_dir, outdir=converted_fmri_dir)
 
         fmri_dir = converted_fmri_dir
+
+    if not (fmri_dir / "dataset_description.json").is_file():
+        build_log.error(
+            "No dataset_description.json file found in input directory. "
+            "Make sure to point to the specific pipeline's derivatives folder. "
+            "For example, use '/dset/derivatives/fmriprep', not /dset/derivatives'."
+        )
+        retval["return_code"] = 1
 
     # Set up some instrumental utilities
     run_uuid = f"{strftime('%Y%m%d-%H%M%S')}_{uuid.uuid4()}"


### PR DESCRIPTION
Closes None, but is related to #714. For HCP/DCAN inputs, a dataset description file won't be available until after the preprocessed data are converted to BIDS format, but the check was occurring _before_ the conversion.

## Changes proposed in this pull request
- Move dataset_description check to after HCP/DCAN conversion.
