### PR TITLE
Apply bandpass filter to temporal mask

### DIFF
--- a/xcp_d/interfaces/filtering.py
+++ b/xcp_d/interfaces/filtering.py
@@ -67,7 +67,11 @@ class FilteringData(SimpleInterface):
             order=self.inputs.filter_order,
         ).T
         temporal_mask["filtered_outliers"] = butter_bandpass(
-            temporal_mask["framewise_displacement"].to_numpy()
+            temporal_mask["framewise_displacement"].to_numpy(),
+            fs=1 / self.inputs.TR,
+            lowpass=self.inputs.lowpass,
+            highpass=self.inputs.highpass,
+            order=self.inputs.filter_order,
         )
         outliers_metadata["filtered_outliers"] = {
             "Description": (

--- a/xcp_d/interfaces/filtering.py
+++ b/xcp_d/interfaces/filtering.py
@@ -75,7 +75,7 @@ class FilteringData(SimpleInterface):
             highpass=self.inputs.highpass,
             order=self.inputs.filter_order,
         )
-        temporal_mask["filtered_outliers"] = np.squeeze(filtered_temporal_mask)
+        temporal_mask_df["filtered_outliers"] = np.squeeze(filtered_temporal_mask)
         outliers_metadata["filtered_outliers"] = {
             "Description": (
                 "Outlier timeseries, bandpass filtered to identify volumes that have been "
@@ -110,6 +110,6 @@ class FilteringData(SimpleInterface):
             newpath=runtime.cwd,
             use_ext=True,
         )
-        temporal_mask.to_csv(self._results["filtered_mask"], sep="\t", index=False)
+        temporal_mask_df.to_csv(self._results["filtered_mask"], sep="\t", index=False)
 
         return runtime

--- a/xcp_d/interfaces/filtering.py
+++ b/xcp_d/interfaces/filtering.py
@@ -51,13 +51,13 @@ class FilteringData(SimpleInterface):
             LOGGER.debug("Not running bandpass filter.")
             self._results["filtered_file"] = self.inputs.in_file
             self._results["filtered_mask"] = self.inputs.temporal_mask
-            self._results["tmask_metadata"] = self.inputs.tmask_metadata
+            self._results["mask_metadata"] = self.inputs.mask_metadata
             return runtime
 
         # get the nifti/cifti into  matrix
         data_matrix = read_ndata(datafile=self.inputs.in_file, maskfile=self.inputs.mask)
         temporal_mask = pd.read_table(self.inputs.temporal_mask)
-        outliers_metadata = self.inputs.tmask_metadata
+        outliers_metadata = self.inputs.mask_metadata
 
         filt_data = butter_bandpass(
             data=data_matrix.T,
@@ -76,7 +76,7 @@ class FilteringData(SimpleInterface):
             ),
             "Threshold": outliers_metadata["framewise_displacement"]["Threshold"],
         }
-        self._results["tmask_metadata"] = outliers_metadata
+        self._results["mask_metadata"] = outliers_metadata
 
         # write out the data
         if self.inputs.in_file.endswith(".dtseries.nii"):

--- a/xcp_d/workflows/bold.py
+++ b/xcp_d/workflows/bold.py
@@ -597,9 +597,14 @@ produced by the regression.
     ])
 
     # add filtering workflow
-    workflow.connect([(downcast_data, filtering_wf, [('bold_mask', 'mask')]),
-                      (interpolate_wf, filtering_wf, [('bold_interpolated',
-                                                       'in_file')])])
+    workflow.connect([
+        (downcast_data, filtering_wf, [('bold_mask', 'mask')]),
+        (interpolate_wf, filtering_wf, [('bold_interpolated', 'in_file')]),
+        (censor_scrub, filtering_wf, [
+            ("tmask", "temporal_mask"),
+            ("tmask_metadata", "mask_metadata"),
+        ]),
+    ])
 
     # residual smoothing
     workflow.connect([(filtering_wf, resd_smoothing_wf,
@@ -631,9 +636,11 @@ produced by the regression.
 
     # qc report
     workflow.connect([
-        (filtering_wf, qc_report_wf, [('filtered_file', 'inputnode.cleaned_file')]),
+        (filtering_wf, qc_report_wf, [
+            ('filtered_file', 'inputnode.cleaned_file'),
+            ('filtered_mask', 'inputnode.tmask'),
+        ]),
         (censor_scrub, qc_report_wf, [
-            ('tmask', 'inputnode.tmask'),
             ("filtered_motion", "inputnode.filtered_motion"),
         ]),
     ])
@@ -657,8 +664,10 @@ produced by the regression.
         (censor_scrub, write_derivative_wf, [
             ('filtered_motion', 'inputnode.filtered_motion'),
             ('filtered_motion_metadata', 'inputnode.filtered_motion_metadata'),
-            ('tmask', 'inputnode.tmask'),
-            ('tmask_metadata', 'inputnode.tmask_metadata'),
+        ]),
+        (filtering_wf, write_derivative_wf, [
+            ('filtered_mask', 'inputnode.tmask'),
+            ('mask_metadata', 'inputnode.tmask_metadata'),
         ]),
         (reho_compute_wf, write_derivative_wf, [
             ('outputnode.reho_out', 'inputnode.reho_out'),

--- a/xcp_d/workflows/cifti.py
+++ b/xcp_d/workflows/cifti.py
@@ -575,8 +575,13 @@ produced by the regression.
     ])
 
     # add filtering workflow
-    workflow.connect([(interpolate_wf, filtering_wf, [('bold_interpolated',
-                                                       'in_file')])])
+    workflow.connect([
+        (interpolate_wf, filtering_wf, [('bold_interpolated', 'in_file')]),
+        (censor_scrub, filtering_wf, [
+            ("tmask", "temporal_mask"),
+            ("tmask_metadata", "mask_metadata"),
+        ])
+    ])
 
     # residual smoothing
     workflow.connect([(filtering_wf, resd_smoothing_wf,
@@ -600,9 +605,11 @@ produced by the regression.
 
     # qc report
     workflow.connect([
-        (filtering_wf, qc_report_wf, [("filtered_file", "inputnode.cleaned_file")]),
+        (filtering_wf, qc_report_wf, [
+            ("filtered_file", "inputnode.cleaned_file"),
+            ("filtered_mask", "inputnode.tmask"),
+        ]),
         (censor_scrub, qc_report_wf, [
-            ("tmask", "inputnode.tmask"),
             ("filtered_motion", "inputnode.filtered_motion"),
         ]),
     ])
@@ -614,6 +621,8 @@ produced by the regression.
         ]),
         (filtering_wf, write_derivative_wf, [
             ('filtered_file', 'inputnode.processed_bold'),
+            ('filtered_mask', 'inputnode.tmask'),
+            ('mask_metadata', 'inputnode.tmask_metadata'),
         ]),
         (qc_report_wf, write_derivative_wf, [
             ('outputnode.qc_file', 'inputnode.qc_file'),
@@ -624,8 +633,6 @@ produced by the regression.
         (censor_scrub, write_derivative_wf, [
             ('filtered_motion', 'inputnode.filtered_motion'),
             ('filtered_motion_metadata', 'inputnode.filtered_motion_metadata'),
-            ('tmask', 'inputnode.tmask'),
-            ('tmask_metadata', 'inputnode.tmask_metadata'),
         ]),
         (reho_compute_wf, write_derivative_wf, [
             ('outputnode.reho_out', 'inputnode.reho_out'),


### PR DESCRIPTION
Closes None, but is related to #813.

## Changes proposed in this pull request

- Feed temporal mask into filtering interface, to produce a bandpass-filtered version of the temporal mask. This filtered mask can be used to identify volumes in the filtered BOLD data that are contaminated by interpolated data, and the extent of the contamination.

## Documentation that should be reviewed
Outputs file.
