### PR TITLE
Add design matrix to report

### DIFF
--- a/docs/generalworkflow.rst
+++ b/docs/generalworkflow.rst
@@ -183,8 +183,8 @@ Processing Steps
 
     a.  Motion parameters summary: mean FD, mean and maximum RMS
     b.  Mean DVARs before and after regression and its relationship to FD
-    c.  BOLD-T1w coregistration quality - Dice, Jaccard, Coverage and Cross-correlation indices
-    d.  BOLD-Template normalization quality - Dice, Jaccard, Coverage and Cross-correlation indices
+    c.  BOLD-T1w coregistration quality - Dice, Coverage and Cross-correlation indices
+    d.  BOLD-Template normalization quality - Dice, Coverage and Cross-correlation indices
 
 Outputs
 -------

--- a/xcp_d/data/boilerplate.bib
+++ b/xcp_d/data/boilerplate.bib
@@ -563,3 +563,25 @@ Publisher: Nature Publishing Group},
   year={2007},
   publisher={Elsevier}
 }
+
+@article{dice1945measures,
+  title={Measures of the amount of ecologic association between species},
+  author={Dice, Lee R},
+  journal={Ecology},
+  volume={26},
+  number={3},
+  pages={297--302},
+  year={1945},
+  publisher={JSTOR},
+  url={https://doi.org/10.2307/1932409},
+  doi={10.2307/1932409}
+}
+
+@article{sorensen1948method,
+  title={A method of establishing groups of equal amplitude in plant sociology based on similarity of species content and its application to analyses of the vegetation on Danish commons},
+  author={Sorensen, Th A},
+  journal={Biol. Skar.},
+  volume={5},
+  pages={1--34},
+  year={1948}
+}

--- a/xcp_d/data/reports.yml
+++ b/xcp_d/data/reports.yml
@@ -13,8 +13,8 @@ sections:
     static: false
   - bids: {datatype: figures, desc: preprocessing, suffix: bold}
     caption:  FD and DVARS are two measures of in-scanner motion.
-              This plot shows standardized FD, DVARS,
-              and then a carpet plot for the time series of each voxel/vertex's time series of activity.
+              This plot shows standardized FD, DVARS, and then a carpet plot for the
+              time series of each voxel/vertex's time series of activity.
     subtitle: Carpet Plot Before Postprocessing
   - bids: {datatype: figures, desc: censoring, suffix: motion}
     caption:  Framewise displacement (FD) is used to flag high-motion volumes,
@@ -27,8 +27,9 @@ sections:
     caption:  The "design matrix" represents the confounds that are used to denoise the BOLD data.
     subtitle: Design Matrix for Confound Regression
   - bids: {datatype: figures, desc: postprocessing, suffix: bold}
-    caption:  FD and DVARS are two measures of in-scanner motion. This plot shows standardized FD, DVARS,
-              and then a carpet plot for the time series of each voxel/vertex's time series of activity.
+    caption:  FD and DVARS are two measures of in-scanner motion.
+              This plot shows standardized FD, DVARS, and then a carpet plot for the
+              time series of each voxel/vertex's time series of activity.
     subtitle: Carpet Plot After Postprocessing
   - bids: {datatype: figures, desc: connectivityplot, suffix: bold}
     caption:  This plot shows heatmaps from ROI-to-ROI correlations from four atlases.
@@ -44,7 +45,8 @@ sections:
       datatype: figures
       desc: rehoVolumetricPlot
       suffix: bold
-    caption:  ReHo, or regional homogeneity. Overlaid on T1W image with same entities as the original image.
+    caption:  ReHo, or regional homogeneity.
+              Overlaid on T1W image with same entities as the original image.
     subtitle: ReHo
 - name: About
   reportlets:

--- a/xcp_d/data/reports.yml
+++ b/xcp_d/data/reports.yml
@@ -8,12 +8,13 @@ sections:
   reportlets:
   - bids: {datatype: figures, desc: qualitycontrol, suffix: bold}
   - bids: {datatype: figures, desc: bbregister, suffix: bold}
-    caption: bbregister was used to coregister functional and anatomical MRI data.
+    caption:  bbregister was used to coregister functional and anatomical MRI data.
     subtitle: Alignment of functional and anatomical MRI data (surface driven)
     static: false
   - bids: {datatype: figures, desc: preprocessing, suffix: bold}
-    caption: FD and DVARS are two measures of in-scanner motion. This plot shows standardized FD, DVARS,
-             and then a carpet plot for the time series of each voxel/vertex's time series of activity.
+    caption:  FD and DVARS are two measures of in-scanner motion.
+              This plot shows standardized FD, DVARS,
+              and then a carpet plot for the time series of each voxel/vertex's time series of activity.
     subtitle: Carpet Plot Before Postprocessing
   - bids: {datatype: figures, desc: censoring, suffix: motion}
     caption:  Framewise displacement (FD) is used to flag high-motion volumes,
@@ -26,35 +27,24 @@ sections:
     caption:  The "design matrix" represents the confounds that are used to denoise the BOLD data.
     subtitle: Design Matrix for Confound Regression
   - bids: {datatype: figures, desc: postprocessing, suffix: bold}
-    caption: FD and DVARS are two measures of in-scanner motion. This plot shows standardized FD, DVARS,
-            and then a carpet plot for the time series of each voxel/vertex's time series of activity..
+    caption:  FD and DVARS are two measures of in-scanner motion. This plot shows standardized FD, DVARS,
+              and then a carpet plot for the time series of each voxel/vertex's time series of activity.
     subtitle: Carpet Plot After Postprocessing
   - bids: {datatype: figures, desc: connectivityplot, suffix: bold}
-    caption: This plot shows heatmaps from ROI-to-ROI correlations from four atlases.
+    caption:  This plot shows heatmaps from ROI-to-ROI correlations from four atlases.
     subtitle: Correlation Heatmaps from Four Atlases
   - bids:
       datatype: figures
       desc: alffVolumetricPlot
       suffix: bold
-    caption: ALFF, or amplitude of low frequency fluctuations. Overlaid on T1W image with same entities as the original image.
+    caption:  ALFF, or amplitude of low frequency fluctuations.
+              Overlaid on T1W image with same entities as the original image.
     subtitle: ALFF
   - bids:
       datatype: figures
       desc: rehoVolumetricPlot
       suffix: bold
-    caption: ReHo, or regional homogeneity. Overlaid on T1W image with same entities as the original image.
-    subtitle: ReHo
-  - bids:
-      datatype: figures
-      desc: alffSurfacePlot
-      suffix: bold
-    caption: ALFF, or amplitude of low frequency fluctuations. This plot is overlaid on midthickness surfaces and doesn't show subcortical voxels from the data.
-    subtitle: ALFF
-  - bids:
-      datatype: figures
-      desc: rehoSurfacePlot
-      suffix: bold
-    caption: ReHo, or regional homogeneity. This plot is overlaid on midthickness surfaces and doesn't show subcortical voxels from the data.s
+    caption:  ReHo, or regional homogeneity. Overlaid on T1W image with same entities as the original image.
     subtitle: ReHo
 - name: About
   reportlets:

--- a/xcp_d/data/reports.yml
+++ b/xcp_d/data/reports.yml
@@ -22,6 +22,9 @@ sections:
               parameters are filtered to remove respiratory effects before FD is calculated
               and outlier volumes are identified.
     subtitle: Framewise Displacement and Censored Volumes
+  - bids: {datatype: figures, suffix: design}
+    caption:  The "design matrix" represents the confounds that are used to denoise the BOLD data.
+    subtitle: Design Matrix for Confound Regression
   - bids: {datatype: figures, desc: postprocessing, suffix: bold}
     caption: FD and DVARS are two measures of in-scanner motion. This plot shows standardized FD, DVARS,
             and then a carpet plot for the time series of each voxel/vertex's time series of activity..

--- a/xcp_d/utils/atlas.py
+++ b/xcp_d/utils/atlas.py
@@ -6,6 +6,8 @@ def get_atlas_names():
 
     The actual list of files for the atlases is loaded from a different function.
 
+    NOTE: This is a Node function.
+
     Returns
     -------
     :obj:`list` of :obj:`str`
@@ -32,6 +34,8 @@ def get_atlas_nifti(atlas_name):
     """Select atlas by name from xcp_d/data using pkgrf.
 
     All atlases are in MNI space.
+
+    NOTE: This is a Node function.
 
     Parameters
     ----------
@@ -86,6 +90,8 @@ def get_atlas_cifti(atlas_name):
     """Select atlas by name from xcp_d/data.
 
     All atlases are in 91K space.
+
+    NOTE: This is a Node function.
 
     Parameters
     ----------

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -739,6 +739,8 @@ def _get_tr(img):
 def get_freesurfer_dir(fmri_dir):
     """Find FreeSurfer derivatives associated with preprocessing pipeline.
 
+    NOTE: This is a Node function.
+
     Parameters
     ----------
     fmri_dir : str
@@ -787,6 +789,8 @@ def get_freesurfer_dir(fmri_dir):
 
 def get_freesurfer_sphere(freesurfer_path, subject_id, hemisphere):
     """Find FreeSurfer sphere file.
+
+    NOTE: This is a Node function.
 
     Parameters
     ----------

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -199,6 +199,8 @@ def consolidate_confounds(
 ):
     """Combine confounds files into a single tsv.
 
+    NOTE: This is a Node function.
+
     Parameters
     ----------
     img_file : str

--- a/xcp_d/utils/execsummary.py
+++ b/xcp_d/utils/execsummary.py
@@ -10,6 +10,8 @@ def make_mosaic(png_files):
     """Take path to .png anatomical slices, create a mosaic, and save to file.
 
     The mosaic will be usable in a BrainSprite viewer.
+
+    NOTE: This is a Node function.
     """
     import os
 
@@ -49,7 +51,10 @@ def modify_brainsprite_scene_template(
     lh_wm_surf,
     scene_template,
 ):
-    """Create modified .scene text file to be used for creating brainsprite PNGs later."""
+    """Create modified .scene text file to be used for creating brainsprite PNGs later.
+
+    NOTE: This is a Node function.
+    """
     import gzip
     import os
 
@@ -93,7 +98,10 @@ def modify_pngs_scene_template(
     lh_wm_surf,
     scene_template,
 ):
-    """Create modified .scene text file to be used for creating PNGs later."""
+    """Create modified .scene text file to be used for creating PNGs later.
+
+    NOTE: This is a Node function.
+    """
     import gzip
     import os
 
@@ -128,7 +136,18 @@ def modify_pngs_scene_template(
 
 
 def get_n_frames(anat_file):
-    """Infer the number of frames from an image."""
+    """Infer the number of slices in x axis from an image.
+
+    NOTE: This is a Node function.
+
+    Parameters
+    ----------
+    anat_file
+
+    Returns
+    -------
+    frame_numbers
+    """
     import nibabel as nb
     import numpy as np
 
@@ -148,7 +167,10 @@ def get_n_frames(anat_file):
 
 
 def get_png_image_names():
-    """Get a list of scene names for which to produce PNGs."""
+    """Get a list of scene names for which to produce PNGs.
+
+    NOTE: This is a Node function.
+    """
     image_descriptions = [
         "AxialInferiorTemporalCerebellum",
         "AxialBasalGangliaPutamen",

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -162,6 +162,8 @@ def cast_cifti_to_int16(in_file):
     DerivativesDataSink class from niworkflows version 1.7.1.
     For more information, see https://github.com/nipreps/niworkflows/issues/778.
 
+    NOTE: This is a Node function.
+
     Parameters
     ----------
     in_file : str

--- a/xcp_d/utils/plotting.py
+++ b/xcp_d/utils/plotting.py
@@ -1009,8 +1009,9 @@ def _carpet(
 
 
 def plot_alff_reho_volumetric(output_path, filename, bold_file):
-    """
-    Plot ReHo and ALFF mosaics for niftis.
+    """Plot ReHo and ALFF mosaics for niftis.
+
+    NOTE: This is a Node function.
 
     Parameters
     ----------
@@ -1076,8 +1077,9 @@ def surf_data_from_cifti(data, axis, surf_name):
 
 
 def plot_alff_reho_surface(output_path, filename, bold_file):
-    """
-    Plot ReHo and ALFF for ciftis on surface.
+    """Plot ReHo and ALFF for ciftis on surface.
+
+    NOTE: This is a Node function.
 
     Parameters
     ----------
@@ -1196,6 +1198,8 @@ def plot_alff_reho_surface(output_path, filename, bold_file):
 
 def plot_design_matrix(design_matrix, censoring_file=None):
     """Plot design matrix TSV with Nilearn.
+
+    NOTE: This is a Node function.
 
     Parameters
     ----------

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -155,13 +155,13 @@ def compute_dvars(datat):
 
     Parameters
     ----------
-    datat : numpy.ndarray
+    datat : :obj:`numpy.ndarray`
         The data matrix from which to calculate DVARS.
         Ordered as vertices by timepoints.
 
     Returns
     -------
-    numpy.ndarray
+    :obj:`numpy.ndarray`
         The calculated DVARS array.
         A (timepoints,) array.
     """
@@ -172,7 +172,22 @@ def compute_dvars(datat):
 
 
 def _make_dcan_qc_file(filtered_motion, TR):
-    """Make DCAN HDF5 file from single motion file."""
+    """Make DCAN HDF5 file from single motion file.
+
+    NOTE: This is a Node function.
+
+    Parameters
+    ----------
+    filtered_motion_file : :obj:`str`
+        File from which to extract information.
+    TR : :obj:`float`
+        Repetition time.
+
+    Returns
+    -------
+    dcan_df_file : :obj:`str`
+        Name of the HDF5-format file that is created.
+    """
     import os
 
     from xcp_d.utils.qcmetrics import make_dcan_df
@@ -188,30 +203,31 @@ def make_dcan_df(filtered_motion_file, name, TR):
 
     Parameters
     ----------
-    filtered_motion_file : str
+    filtered_motion_file : :obj:`str`
         File from which to extract information.
-    name : str
+    name : :obj:`str`
         Name of the HDF5-format file to be created.
-    TR : float
+    TR : :obj:`float`
         Repetition time.
 
     Notes
     -----
-    FD_threshold: a number >= 0 that represents the FD threshold used to calculate
-    the metrics in this list.
-    frame_removal: a binary vector/array the same length as the number of frames
-    in the concatenated time series, indicates whether a frame is removed (1) or
-    not (0)
-    format_string (legacy): a string that denotes how the frames were excluded
-    -- uses a notation devised by Avi Snyder
-    total_frame_count: a whole number that represents the total number of frames
-    in the concatenated series
-    remaining_frame_count: a whole number that represents the number of remaining
-    frames in the concatenated series
-    remaining_seconds: a whole number that represents the amount of time remaining
-    after thresholding
-    remaining_frame_mean_FD: a number >= 0 that represents the mean FD of the
-    remaining frames
+    The metrics in the file are:
+
+    -   ``FD_threshold``: a number >= 0 that represents the FD threshold used to calculate
+        the metrics in this list.
+    -   ``frame_removal``: a binary vector/array the same length as the number of frames
+        in the concatenated time series, indicates whether a frame is removed (1) or not (0)
+    -   ``format_string`` (legacy): a string that denotes how the frames were excluded.
+        This uses a notation devised by Avi Snyder.
+    -   ``total_frame_count``: a whole number that represents the total number of frames
+        in the concatenated series
+    -   ``remaining_frame_count``: a whole number that represents the number of remaining
+        frames in the concatenated series
+    -   ``remaining_seconds``: a whole number that represents the amount of time remaining
+        after thresholding
+    -   ``remaining_frame_mean_FD``: a number >= 0 that represents the mean FD of the
+        remaining frames
     """
     LOGGER.debug(f"Generating DCAN file: {name}")
 

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -114,6 +114,8 @@ def get_bold2std_and_t1w_xforms(bold_file, template_to_t1w, t1w_to_native):
     Since ANTSApplyTransforms takes in the transform files as a stack,
     these are applied in the reverse order of which they are specified.
 
+    NOTE: This is a Node function.
+
     Parameters
     ----------
     bold_file : str
@@ -242,6 +244,8 @@ def get_std2bold_xforms(bold_file, template_to_t1w, t1w_to_native):
 
     Since ANTSApplyTransforms takes in the transform files as a stack,
     these are applied in the reverse order of which they are specified.
+
+    NOTE: This is a Node function.
 
     Parameters
     ----------
@@ -431,6 +435,8 @@ def butter_bandpass(
 
 def estimate_brain_radius(mask_file, head_radius="auto"):
     """Estimate brain radius from binary brain mask file.
+
+    NOTE: This is a Node function.
 
     Parameters
     ----------


### PR DESCRIPTION
Closes #818, closes #817, and closes #791.

## Changes proposed in this pull request

- Add design matrix plot to the nipreps report (#818).
- Remove Jaccard from QC metrics (#817).
- Rename cross-correlation in QC metrics to Pearson correlation.
- Remove surface ALFF and ReHo plots from nipreps report, but keep the volumetric versions (#791).
