### PR TITLE
Allow users to disable censoring, and only generate ALFF if censoring is disabled

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -195,7 +195,9 @@ Resting-state metric derivatives (Regional Homogeneity and ALFF)
 
 .. important::
       ALFF images will not be generated if bandpass filtering is disabled
-      (i.e., with the ``--disable-bandpass-filtering`` parameter).
+      (i.e., with the ``--disable-bandpass-filtering`` parameter),
+      or if high-motion outlier censoring is enabled
+      (i.e., ``--fd-thresh`` is greater than zero).
 
 
 Other outputs include quality control, framewise displacement, and confounds files

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -351,7 +351,9 @@ ALFF
 :func:`~xcp_d.workflows.restingstate.init_alff_wf`
 
 ALFF will only be calculated if the bandpass filter is enabled
-(i.e., if the ``--disable-bandpass-filter`` flag is not used).
+(i.e., if the ``--disable-bandpass-filter`` flag is not used)
+and censoring is disabled
+(i.e., if ``--fd-thresh`` is set to a value less than or equal to zero).
 
 Smoothed ALFF derivatives will also be generated if the ``--smoothing`` flag is used.
 

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -386,7 +386,8 @@ This parameter is used in conjunction with ``motion-filter-order`` and ``band-st
         help=(
             "Framewise displacement threshold for censoring. "
             "Any volumes with an FD value greater than the threshold will be removed from the "
-            "denoised BOLD data."
+            "denoised BOLD data. "
+            "A threshold of <=0 will disable censoring completely."
         ),
     )
 

--- a/xcp_d/interfaces/prepostcleaning.py
+++ b/xcp_d/interfaces/prepostcleaning.py
@@ -334,7 +334,10 @@ class FlagMotionOutliers(SimpleInterface):
         # Generate temporal mask with all timepoints have FD over threshold
         # set to 1 and then dropped.
         outlier_mask = np.zeros(len(fd_timeseries), dtype=int)
-        outlier_mask[fd_timeseries > self.inputs.fd_thresh] = 1
+        if self.inputs.fd_thresh > 0:
+            outlier_mask[fd_timeseries > self.inputs.fd_thresh] = 1
+        else:
+            LOGGER.info(f"FD threshold set to {self.inputs.fd_thresh}. Censoring is disabled.")
 
         # get the output
         self._results["temporal_mask"] = fname_presuffix(

--- a/xcp_d/tests/data/ds001419-fmriprep_cifti_outputs.txt
+++ b/xcp_d/tests/data/ds001419-fmriprep_cifti_outputs.txt
@@ -118,10 +118,7 @@ xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-fsLR_atlas-subcortical_den-91
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-fsLR_atlas-subcortical_coverage.tsv
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-fsLR_atlas-subcortical_den-91k_timeseries.ptseries.nii
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-fsLR_atlas-subcortical_timeseries.tsv
-xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-fsLR_den-91k_alff.dscalar.nii
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-fsLR_den-91k_reho.dscalar.nii
-xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-fsLR_den-91k_desc-smooth_alff.dscalar.nii
-xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-fsLR_den-91k_desc-smooth_alff.json
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-fsLR_den-91k_desc-denoised_bold.json
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-fsLR_den-91k_desc-denoisedSmoothed_bold.dtseries.nii
@@ -213,10 +210,7 @@ xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-fsLR_atlas-subcortical_den-91
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-fsLR_atlas-subcortical_coverage.tsv
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-fsLR_atlas-subcortical_den-91k_timeseries.ptseries.nii
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-fsLR_atlas-subcortical_timeseries.tsv
-xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-fsLR_den-91k_alff.dscalar.nii
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-fsLR_den-91k_reho.dscalar.nii
-xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-fsLR_den-91k_desc-smooth_alff.dscalar.nii
-xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-fsLR_den-91k_desc-smooth_alff.json
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-fsLR_den-91k_desc-denoised_bold.json
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-fsLR_den-91k_desc-denoisedSmoothed_bold.dtseries.nii

--- a/xcp_d/tests/data/ds001419-fmriprep_nifti_outputs.txt
+++ b/xcp_d/tests/data/ds001419-fmriprep_nifti_outputs.txt
@@ -64,10 +64,6 @@ xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-MNI152NLin2009cAsym_atlas-Sch
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-MNI152NLin2009cAsym_atlas-subcortical_measure-pearsoncorrelation_conmat.tsv
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-MNI152NLin2009cAsym_atlas-subcortical_coverage.tsv
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-MNI152NLin2009cAsym_atlas-subcortical_timeseries.tsv
-xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-MNI152NLin2009cAsym_res-2_alff.json
-xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-MNI152NLin2009cAsym_res-2_alff.nii.gz
-xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-MNI152NLin2009cAsym_res-2_desc-smooth_alff.json
-xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-MNI152NLin2009cAsym_res-2_desc-smooth_alff.nii.gz
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-MNI152NLin2009cAsym_res-2_reho.json
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-MNI152NLin2009cAsym_res-2_reho.nii.gz
 xcp_d/sub-01/func/sub-01_task-imagery_run-01_space-MNI152NLin2009cAsym_res-2_desc-denoised_bold.json
@@ -119,10 +115,6 @@ xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-MNI152NLin2009cAsym_atlas-Sch
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-MNI152NLin2009cAsym_atlas-subcortical_measure-pearsoncorrelation_conmat.tsv
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-MNI152NLin2009cAsym_atlas-subcortical_coverage.tsv
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-MNI152NLin2009cAsym_atlas-subcortical_timeseries.tsv
-xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-MNI152NLin2009cAsym_res-2_alff.json
-xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-MNI152NLin2009cAsym_res-2_alff.nii.gz
-xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-MNI152NLin2009cAsym_res-2_desc-smooth_alff.json
-xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-MNI152NLin2009cAsym_res-2_desc-smooth_alff.nii.gz
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-MNI152NLin2009cAsym_res-2_reho.json
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-MNI152NLin2009cAsym_res-2_reho.nii.gz
 xcp_d/sub-01/func/sub-01_task-imagery_run-02_space-MNI152NLin2009cAsym_res-2_desc-denoised_bold.json
@@ -174,10 +166,6 @@ xcp_d/sub-01/func/sub-01_task-rest_space-MNI152NLin2009cAsym_atlas-Schaefer917_t
 xcp_d/sub-01/func/sub-01_task-rest_space-MNI152NLin2009cAsym_atlas-subcortical_measure-pearsoncorrelation_conmat.tsv
 xcp_d/sub-01/func/sub-01_task-rest_space-MNI152NLin2009cAsym_atlas-subcortical_coverage.tsv
 xcp_d/sub-01/func/sub-01_task-rest_space-MNI152NLin2009cAsym_atlas-subcortical_timeseries.tsv
-xcp_d/sub-01/func/sub-01_task-rest_space-MNI152NLin2009cAsym_res-2_alff.json
-xcp_d/sub-01/func/sub-01_task-rest_space-MNI152NLin2009cAsym_res-2_alff.nii.gz
-xcp_d/sub-01/func/sub-01_task-rest_space-MNI152NLin2009cAsym_res-2_desc-smooth_alff.json
-xcp_d/sub-01/func/sub-01_task-rest_space-MNI152NLin2009cAsym_res-2_desc-smooth_alff.nii.gz
 xcp_d/sub-01/func/sub-01_task-rest_space-MNI152NLin2009cAsym_res-2_reho.json
 xcp_d/sub-01/func/sub-01_task-rest_space-MNI152NLin2009cAsym_res-2_reho.nii.gz
 xcp_d/sub-01/func/sub-01_task-rest_space-MNI152NLin2009cAsym_res-2_desc-denoised_bold.json

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -208,7 +208,7 @@ def test_nibabies(datasets, output_dir, working_dir):
         "--despike",
         "--head_radius=auto",
         "--smoothing=6",
-        "--fd-thresh=100",
+        "--fd-thresh=0",
     ]
     opts = get_parser().parse_args(parameters)
     retval = {}

--- a/xcp_d/utils/doc.py
+++ b/xcp_d/utils/doc.py
@@ -188,6 +188,7 @@ docdict[
 fd_thresh : :obj:`float`
     Framewise displacement threshold for censoring, in millimeters.
     Any framewise displacement values higher than the threshold are flagged as "high motion".
+    If set to <=0, no censoring will be performed.
     Default is 0.2 mm.
 """
 

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -241,5 +241,9 @@ def flag_bad_run(
         band_stop_max=band_stop_max,
     )
     fd_arr = compute_fd(confound=motion_df, head_radius=head_radius)
+    if fd_thresh > 0:
+        n_good_volumes = int(np.sum(fd_arr <= fd_thresh))
+    else:
+        n_good_volumes = fd_arr.size
 
-    return int(np.sum(fd_arr <= fd_thresh))
+    return n_good_volumes

--- a/xcp_d/workflows/bold.py
+++ b/xcp_d/workflows/bold.py
@@ -431,7 +431,7 @@ def init_postprocess_nifti_wf(
     ])
     # fmt:on
 
-    if bandpass_filter:
+    if bandpass_filter and (fd_thresh <= 0):
         alff_wf = init_alff_wf(
             name_source=bold_file,
             output_dir=output_dir,
@@ -517,6 +517,7 @@ def init_postprocess_nifti_wf(
         output_dir=output_dir,
         low_pass=low_pass,
         high_pass=high_pass,
+        fd_thresh=fd_thresh,
         motion_filter_type=motion_filter_type,
         TR=TR,
         name="postproc_derivatives_wf",
@@ -547,7 +548,7 @@ def init_postprocess_nifti_wf(
     ])
     # fmt:on
 
-    if bandpass_filter:
+    if bandpass_filter and (fd_thresh <= 0):
         # fmt:off
         workflow.connect([
             (alff_wf, postproc_derivatives_wf, [

--- a/xcp_d/workflows/cifti.py
+++ b/xcp_d/workflows/cifti.py
@@ -473,6 +473,7 @@ def init_postprocess_cifti_wf(
         output_dir=output_dir,
         low_pass=low_pass,
         high_pass=high_pass,
+        fd_thresh=fd_thresh,
         motion_filter_type=motion_filter_type,
         TR=TR,
         name="postproc_derivatives_wf",

--- a/xcp_d/workflows/outputs.py
+++ b/xcp_d/workflows/outputs.py
@@ -16,6 +16,7 @@ def init_postproc_derivatives_wf(
     bandpass_filter,
     low_pass,
     high_pass,
+    fd_thresh,
     motion_filter_type,
     smoothing,
     params,
@@ -39,6 +40,7 @@ def init_postproc_derivatives_wf(
                 bandpass_filter=True,
                 low_pass=0.1,
                 high_pass=0.008,
+                fd_thresh=0.2,
                 motion_filter_type=None,
                 smoothing=6,
                 params="36P",
@@ -57,6 +59,7 @@ def init_postproc_derivatives_wf(
         low pass filter
     high_pass : float
         high pass filter
+    %(fd_thresh)s
     %(motion_filter_type)s
     %(smoothing)s
     %(params)s
@@ -322,7 +325,7 @@ def init_postproc_derivatives_wf(
             mem_gb=1,
         )
 
-        if bandpass_filter:
+        if bandpass_filter and (fd_thresh <= 0):
             ds_alff = pe.Node(
                 DerivativesDataSink(
                     base_directory=output_dir,
@@ -355,7 +358,7 @@ def init_postproc_derivatives_wf(
                 mem_gb=2,
             )
 
-            if bandpass_filter:
+            if bandpass_filter and (fd_thresh <= 0):
                 ds_smoothed_alff = pe.Node(
                     DerivativesDataSink(
                         base_directory=output_dir,
@@ -504,7 +507,7 @@ def init_postproc_derivatives_wf(
             mem_gb=1,
         )
 
-        if bandpass_filter:
+        if bandpass_filter and (fd_thresh <= 0):
             ds_alff = pe.Node(
                 DerivativesDataSink(
                     base_directory=output_dir,
@@ -540,7 +543,7 @@ def init_postproc_derivatives_wf(
                 mem_gb=2,
             )
 
-            if bandpass_filter:
+            if bandpass_filter and (fd_thresh <= 0):
                 ds_smoothed_alff = pe.Node(
                     DerivativesDataSink(
                         base_directory=output_dir,
@@ -576,13 +579,13 @@ def init_postproc_derivatives_wf(
         ])
         # fmt:on
 
-    if bandpass_filter:
+    if bandpass_filter and (fd_thresh <= 0):
         workflow.connect([(inputnode, ds_alff, [("alff", "in_file")])])
 
     if smoothing:
         workflow.connect([(inputnode, ds_smoothed_bold, [("smoothed_denoised_bold", "in_file")])])
 
-        if bandpass_filter:
+        if bandpass_filter and (fd_thresh <= 0):
             workflow.connect([(inputnode, ds_smoothed_alff, [("smoothed_alff", "in_file")])])
 
     return workflow

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -132,14 +132,18 @@ def init_prepare_confounds_wf(
             "regressors were discarded as non-steady-state volumes, or 'dummy scans'. "
         )
 
-    censoring_description = describe_censoring(
-        motion_filter_type=motion_filter_type,
-        motion_filter_order=motion_filter_order,
-        band_stop_min=band_stop_min,
-        band_stop_max=band_stop_max,
-        head_radius=head_radius,
-        fd_thresh=fd_thresh,
-    )
+    if fd_thresh > 0:
+        censoring_description = describe_censoring(
+            motion_filter_type=motion_filter_type,
+            motion_filter_order=motion_filter_order,
+            band_stop_min=band_stop_min,
+            band_stop_max=band_stop_max,
+            head_radius=head_radius,
+            fd_thresh=fd_thresh,
+        )
+    else:
+        censoring_description = ""
+
     confounds_description = describe_regression(params, custom_confounds_file)
 
     workflow.__desc__ = f" {dummy_scans_str}{censoring_description}{confounds_description}"


### PR DESCRIPTION
Closes #811 and closes #812.

## Changes proposed in this pull request
- Allow `--fd-thresh` to be <=0, in which case censoring will be disabled.
- Only generate ALFF outputs if censoring is disabled.