### PR TITLE
Remove deprecated `--dummytime` parameter

### DIFF
--- a/.circleci/NiftiWithFreeSurferTest.sh
+++ b/.circleci/NiftiWithFreeSurferTest.sh
@@ -35,7 +35,6 @@ XCPD_CMD="$BASE_XCPD_CMD \
     --bids-filter-file /bids_filter_file.json \
     --nuisance-regressors aroma_gsr \
     --despike \
-    --dummytime 8 \
     --fd-thresh 0.04 \
     --head_radius 40 \
     --smoothing 6 \

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -18,7 +18,6 @@ from time import strftime
 from niworkflows import NIWORKFLOWS_LOG
 
 from xcp_d.cli.parser_utils import (
-    _DeprecatedStoreAction040,
     _float_or_auto,
     _int_or_auto,
     _restricted_float,
@@ -260,22 +259,7 @@ def get_parser():
             "This parameter can be disabled by providing a zero or a negative value."
         ),
     )
-
-    dummyvols = g_param.add_mutually_exclusive_group()
-    dummyvols.add_argument(
-        "-d",
-        "--dummytime",
-        default=0,
-        type=float,
-        action=_DeprecatedStoreAction040,
-        help=(
-            "Number of seconds to remove from the beginning of each run. "
-            "This value will be rounded up to the nearest TR. "
-            "This parameter is deprecated and will be removed in version 0.4.0. "
-            "Please use ``--dummy-scans``."
-        ),
-    )
-    dummyvols.add_argument(
+    g_param.add_argument(
         "--dummy-scans",
         dest="dummy_scans",
         default=0,
@@ -946,7 +930,6 @@ Running xcp_d version {__version__}:
         output_dir=str(output_dir),
         head_radius=opts.head_radius,
         custom_confounds_folder=opts.custom_confounds,
-        dummytime=opts.dummytime,
         dummy_scans=opts.dummy_scans,
         fd_thresh=opts.fd_thresh,
         process_surfaces=opts.process_surfaces,

--- a/xcp_d/interfaces/censoring.py
+++ b/xcp_d/interfaces/censoring.py
@@ -28,8 +28,7 @@ class _RemoveDummyVolumesInputSpec(BaseInterfaceInputSpec):
         mandatory=True,
         desc=(
             "Number of volumes to drop from the beginning, "
-            "calculated in an earlier workflow from dummytime/dummy_scans "
-            "and repetition time."
+            "calculated in an earlier workflow from dummy_scans."
         ),
     )
     confounds_file = File(

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -39,7 +39,7 @@ def test_ds001419_nifti(datasets, output_dir, working_dir):
         f"--bids-filter-file={filter_file}",
         "--nuisance-regressors=aroma_gsr",
         "--despike",
-        "--dummytime=8",
+        "--dummy-scans=4",
         "--fd-thresh=0.2",
         "--head_radius=40",
         "--smoothing=6",

--- a/xcp_d/utils/doc.py
+++ b/xcp_d/utils/doc.py
@@ -355,16 +355,6 @@ layout : :obj:`bids.layout.BIDSLayout`
 """
 
 docdict[
-    "dummytime"
-] = """
-dummytime : :obj:`float`, optional
-    Number of seconds to remove from the beginning of each run.
-    This parameter is deprecated. Please use ``dummy_scans`` instead.
-    This parameter will only take effect if ``dummy_scans`` is 0 and ``dummytime`` is not.
-    Default is 0.
-"""
-
-docdict[
     "dummy_scans"
 ] = """
 dummy_scans : :obj:`int` or "auto"

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -65,7 +65,6 @@ def init_xcpd_wf(
     params,
     smoothing,
     custom_confounds_folder,
-    dummytime,
     dummy_scans,
     cifti,
     omp_nthreads,
@@ -121,7 +120,6 @@ def init_xcpd_wf(
                 params="36P",
                 smoothing=6,
                 custom_confounds_folder=None,
-                dummytime=0,
                 dummy_scans=0,
                 cifti=False,
                 omp_nthreads=1,
@@ -164,7 +162,6 @@ def init_xcpd_wf(
     %(params)s
     %(smoothing)s
     %(custom_confounds_folder)s
-    %(dummytime)s
     %(dummy_scans)s
     %(process_surfaces)s
     %(dcan_qc)s
@@ -206,7 +203,6 @@ def init_xcpd_wf(
             bids_filters=bids_filters,
             smoothing=smoothing,
             output_dir=output_dir,
-            dummytime=dummytime,
             dummy_scans=dummy_scans,
             custom_confounds_folder=custom_confounds_folder,
             fd_thresh=fd_thresh,
@@ -253,7 +249,6 @@ def init_subject_wf(
     params,
     output_dir,
     custom_confounds_folder,
-    dummytime,
     dummy_scans,
     fd_thresh,
     despike,
@@ -298,7 +293,6 @@ def init_subject_wf(
                 params="36P",
                 output_dir=".",
                 custom_confounds_folder=None,
-                dummytime=0,
                 dummy_scans=0,
                 fd_thresh=0.2,
                 despike=True,
@@ -334,7 +328,6 @@ def init_subject_wf(
     %(params)s
     %(output_dir)s
     %(custom_confounds_folder)s
-    %(dummytime)s
     %(dummy_scans)s
     %(fd_thresh)s
     %(despike)s
@@ -602,7 +595,6 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
                 params=params,
                 output_dir=output_dir,
                 custom_confounds_folder=custom_confounds_folder,
-                dummytime=dummytime,
                 dummy_scans=dummy_scans,
                 fd_thresh=fd_thresh,
                 despike=despike,

--- a/xcp_d/workflows/bold.py
+++ b/xcp_d/workflows/bold.py
@@ -4,7 +4,6 @@
 import os
 
 import nibabel as nb
-import numpy as np
 from nipype import logging
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
@@ -45,7 +44,6 @@ def init_postprocess_nifti_wf(
     params,
     output_dir,
     custom_confounds_folder,
-    dummytime,
     dummy_scans,
     fd_thresh,
     despike,
@@ -107,7 +105,6 @@ def init_postprocess_nifti_wf(
                 params="27P",
                 output_dir=".",
                 custom_confounds_folder=custom_confounds_folder,
-                dummytime=0,
                 dummy_scans=2,
                 fd_thresh=0.2,
                 despike=True,
@@ -140,7 +137,6 @@ def init_postprocess_nifti_wf(
     %(params)s
     %(output_dir)s
     %(custom_confounds_folder)s
-    %(dummytime)s
     %(dummy_scans)s
     %(fd_thresh)s
     %(despike)s
@@ -249,9 +245,6 @@ def init_postprocess_nifti_wf(
         custom_confounds_folder,
         run_data["confounds"],
     )
-
-    if dummy_scans == 0 and dummytime != 0:
-        dummy_scans = int(np.ceil(dummytime / TR))
 
     workflow.__desc__ = (
         f"For each of the {num2words(n_runs)} BOLD runs found per subject "

--- a/xcp_d/workflows/cifti.py
+++ b/xcp_d/workflows/cifti.py
@@ -4,7 +4,6 @@
 import os
 
 import nibabel as nb
-import numpy as np
 from nipype import logging
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
@@ -44,7 +43,6 @@ def init_postprocess_cifti_wf(
     params,
     output_dir,
     custom_confounds_folder,
-    dummytime,
     dummy_scans,
     fd_thresh,
     despike,
@@ -104,7 +102,6 @@ def init_postprocess_cifti_wf(
                 params="27P",
                 output_dir=".",
                 custom_confounds_folder=custom_confounds_folder,
-                dummytime=0,
                 dummy_scans=2,
                 fd_thresh=0.2,
                 despike=True,
@@ -135,7 +132,6 @@ def init_postprocess_cifti_wf(
     %(params)s
     %(output_dir)s
     %(custom_confounds_folder)s
-    %(dummytime)s
     %(dummy_scans)s
     %(fd_thresh)s
     %(despike)s
@@ -224,9 +220,6 @@ def init_postprocess_cifti_wf(
     )
 
     workflow = Workflow(name=name)
-
-    if dummy_scans == 0 and dummytime != 0:
-        dummy_scans = int(np.ceil(dummytime / TR))
 
     workflow.__desc__ = (
         f"For each of the {num2words(n_runs)} BOLD runs found per subject "


### PR DESCRIPTION
Closes None, but removes a parameter that was deprecated and due to be removed in 0.4.0.

## Changes proposed in this pull request
- Remove dummytime.
