### PR TITLE
Simplify the anatomical workflow some more

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -24,7 +24,7 @@ See :ref:`usage_inputs` for information on input dataset structures.
 
 Anatomical processing
 =====================
-:func:`~xcp_d.workflows.anatomical.init_warp_anats_to_template_wf`
+:func:`~xcp_d.workflows.anatomical.init_postprocess_anat_wf`
 
 XCP-D performs minimal postprocessing on anatomical derivatives from the preprocessing pipeline.
 This includes applying existing transforms to preprocessed T1w and T2w volumes,

--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -32,47 +32,7 @@ def surface_files(datasets, tmp_path_factory):
     return final_files
 
 
-def test_init_warp_surfaces_to_template_wf_01(
-    datasets,
-    fmriprep_with_freesurfer_data,
-    surface_files,
-    tmp_path_factory,
-):
-    """Test surface-warping workflow with mesh surfaces are available in standard space."""
-    tmpdir = tmp_path_factory.mktemp("test_init_warp_surfaces_to_template_wf_01")
-
-    subject_id = "01"
-
-    wf = anatomical.init_warp_surfaces_to_template_wf(
-        fmri_dir=datasets["ds001419"],
-        subject_id=subject_id,
-        output_dir=tmpdir,
-        warp_to_standard=False,
-        omp_nthreads=1,
-        mem_gb=0.1,
-    )
-
-    wf.inputs.inputnode.lh_pial_surf = surface_files["fsLR_lh_pial"]
-    wf.inputs.inputnode.rh_pial_surf = surface_files["fsLR_rh_pial"]
-    wf.inputs.inputnode.lh_wm_surf = surface_files["fsLR_lh_wm"]
-    wf.inputs.inputnode.rh_wm_surf = surface_files["fsLR_rh_wm"]
-    # transforms (only used if warp_to_standard is True)
-    wf.inputs.inputnode.t1w_to_template_xfm = fmriprep_with_freesurfer_data["t1w_to_template_xfm"]
-    wf.inputs.inputnode.template_to_t1w_xfm = fmriprep_with_freesurfer_data["template_to_t1w_xfm"]
-
-    wf.base_dir = tmpdir
-    wf.run()
-
-    # All of the possible fsLR surfaces should be available.
-    out_anat_dir = os.path.join(tmpdir, "xcp_d", "sub-01", "anat")
-    for key, filename in surface_files.items():
-        if "fsLR" in key:
-            out_fname = os.path.basename(filename)
-            out_file = os.path.join(out_anat_dir, out_fname)
-            assert os.path.isfile(out_file)
-
-
-def test_init_warp_surfaces_to_template_wf_02(
+def test_warp_surfaces_to_template_wf_01(
     datasets,
     fmriprep_with_freesurfer_data,
     surface_files,
@@ -82,7 +42,7 @@ def test_init_warp_surfaces_to_template_wf_02(
 
     The transforms should be applied and all of the standard-space outputs should be generated.
     """
-    tmpdir = tmp_path_factory.mktemp("test_init_warp_surfaces_to_template_wf_02")
+    tmpdir = tmp_path_factory.mktemp("test_warp_surfaces_to_template_wf_01")
 
     subject_id = "01"
 
@@ -115,9 +75,9 @@ def test_init_warp_surfaces_to_template_wf_02(
             assert os.path.isfile(out_file), "\n".join(sorted(os.listdir(out_anat_dir)))
 
 
-def test_warp_anats_to_template_wf(fmriprep_with_freesurfer_data, tmp_path_factory):
-    """Test xcp_d.workflows.anatomical.init_warp_anats_to_template_wf."""
-    tmpdir = tmp_path_factory.mktemp("test_nifti_conn")
+def test_postprocess_anat_wf(fmriprep_with_freesurfer_data, tmp_path_factory):
+    """Test xcp_d.workflows.anatomical.init_postprocess_anat_wf."""
+    tmpdir = tmp_path_factory.mktemp("test_postprocess_anat_wf")
 
     t1w_to_template_xfm = fmriprep_with_freesurfer_data["t1w_to_template_xfm"]
     t1w = fmriprep_with_freesurfer_data["t1w"]
@@ -125,14 +85,14 @@ def test_warp_anats_to_template_wf(fmriprep_with_freesurfer_data, tmp_path_facto
     t2w = os.path.join(tmpdir, "sub-01_desc-preproc_T2w.nii.gz")  # pretend t1w is t2w
     shutil.copyfile(t1w, t2w)
 
-    wf = anatomical.init_warp_anats_to_template_wf(
+    wf = anatomical.init_postprocess_anat_wf(
         output_dir=tmpdir,
         input_type="fmriprep",
         t2w_available=True,
         target_space="MNI152NLin2009cAsym",
         omp_nthreads=1,
         mem_gb=0.1,
-        name="warp_anats_to_template_wf",
+        name="postprocess_anat_wf",
     )
     wf.inputs.inputnode.t1w_to_template_xfm = t1w_to_template_xfm
     wf.inputs.inputnode.t1w = t1w
@@ -143,11 +103,11 @@ def test_warp_anats_to_template_wf(fmriprep_with_freesurfer_data, tmp_path_facto
     wf_nodes = get_nodes(wf_res)
 
     out_anat_dir = os.path.join(tmpdir, "xcp_d", "sub-01", "anat")
-    out_t1w = wf_nodes["warp_anats_to_template_wf.ds_t1w_std"].get_output("out_file")
+    out_t1w = wf_nodes["postprocess_anat_wf.ds_t1w_std"].get_output("out_file")
     assert os.path.isfile(out_t1w), os.listdir(out_anat_dir)
 
-    out_t2w = wf_nodes["warp_anats_to_template_wf.ds_t2w_std"].get_output("out_file")
+    out_t2w = wf_nodes["postprocess_anat_wf.ds_t2w_std"].get_output("out_file")
     assert os.path.isfile(out_t2w), os.listdir(out_anat_dir)
 
-    out_t1w_seg = wf_nodes["warp_anats_to_template_wf.ds_t1w_seg_std"].get_output("out_file")
+    out_t1w_seg = wf_nodes["postprocess_anat_wf.ds_t1w_seg_std"].get_output("out_file")
     assert os.path.isfile(out_t1w_seg), os.listdir(out_anat_dir)

--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -32,7 +32,7 @@ def surface_files(datasets, tmp_path_factory):
     return final_files
 
 
-def test_warp_surfaces_to_template_wf_01(
+def test_warp_surfaces_to_template_wf(
     datasets,
     fmriprep_with_freesurfer_data,
     surface_files,
@@ -42,7 +42,7 @@ def test_warp_surfaces_to_template_wf_01(
 
     The transforms should be applied and all of the standard-space outputs should be generated.
     """
-    tmpdir = tmp_path_factory.mktemp("test_warp_surfaces_to_template_wf_01")
+    tmpdir = tmp_path_factory.mktemp("test_warp_surfaces_to_template_wf")
 
     subject_id = "01"
 
@@ -50,7 +50,6 @@ def test_warp_surfaces_to_template_wf_01(
         fmri_dir=datasets["ds001419"],
         subject_id=subject_id,
         output_dir=tmpdir,
-        warp_to_standard=True,
         omp_nthreads=1,
         mem_gb=0.1,
     )
@@ -91,6 +90,7 @@ def test_postprocess_anat_wf(fmriprep_with_freesurfer_data, tmp_path_factory):
         t1w_available=True,
         t2w_available=True,
         target_space="MNI152NLin2009cAsym",
+        dcan_qc=False,
         omp_nthreads=1,
         mem_gb=0.1,
         name="postprocess_anat_wf",

--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -88,6 +88,7 @@ def test_postprocess_anat_wf(fmriprep_with_freesurfer_data, tmp_path_factory):
     wf = anatomical.init_postprocess_anat_wf(
         output_dir=tmpdir,
         input_type="fmriprep",
+        t1w_available=True,
         t2w_available=True,
         target_space="MNI152NLin2009cAsym",
         omp_nthreads=1,

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -325,7 +325,7 @@ def init_postprocess_anat_wf(
                 # fmt:off
                 workflow.connect([
                     (warp_t2w_to_template, execsummary_anatomical_plots_wf, [
-                        ("outputnode.t2w", "inputnode.t2w"),
+                        ("output_image", "inputnode.t2w"),
                     ]),
                 ])
                 # fmt:on

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -314,9 +314,9 @@ def init_postprocess_anat_wf(
         if dcan_qc:
             # fmt:off
             workflow.connect([
+                (inputnode, execsummary_anatomical_plots_wf, [("template", "inputnode.template")]),
                 (warp_t1w_to_template, execsummary_anatomical_plots_wf, [
-                    ("outputnode.t1w", "inputnode.t1w"),
-                    ("outputnode.template", "inputnode.template"),
+                    ("output_image", "inputnode.t1w"),
                 ]),
             ])
             # fmt:on

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -458,6 +458,16 @@ def init_postprocess_surfaces_wf(
             )
             for hemi in ["lh", "rh"]
         }
+        # fmt:off
+        workflow.connect([
+            (inputnode, hcp_surface_wfs["lh"], [
+                ("lh_pial_surf", "inputnode.name_source"),
+            ]),
+            (inputnode, hcp_surface_wfs["rh"], [
+                ("rh_pial_surf", "inputnode.name_source"),
+            ]),
+        ])
+        # fmt:on
 
     if mesh_available and standard_space_mesh:
         # Mesh files are already in fsLR.

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -43,6 +43,7 @@ LOGGER = logging.getLogger("nipype.workflow")
 def init_postprocess_anat_wf(
     output_dir,
     input_type,
+    t1w_available,
     t2w_available,
     target_space,
     dcan_qc,
@@ -64,6 +65,7 @@ def init_postprocess_anat_wf(
             wf = init_postprocess_anat_wf(
                 output_dir=".",
                 input_type="fmriprep",
+                t1w_available=True,
                 t2w_available=True,
                 target_space="MNI152NLin6Asym",
                 dcan_qc=True,
@@ -76,6 +78,8 @@ def init_postprocess_anat_wf(
     ----------
     %(output_dir)s
     %(input_type)s
+    t1w_available : bool
+        True if a preprocessed T1w is available, False if not.
     t2w_available : bool
         True if a preprocessed T2w is available, False if not.
     target_space : :obj:`str`
@@ -274,7 +278,7 @@ def init_postprocess_anat_wf(
 
     if dcan_qc:
         execsummary_anatomical_plots_wf = init_execsummary_anatomical_plots_wf(
-            t1w_available=True,
+            t1w_available=t1w_available,
             t2w_available=t2w_available,
             output_dir=output_dir,
             name="execsummary_anatomical_plots_wf",

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -495,6 +495,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
         target_space=target_space,
         process_surfaces=process_surfaces,
         output_dir=output_dir,
+        mem_gb=1,
         omp_nthreads=omp_nthreads,
         name="postprocess_anat_wf",
     )

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -34,7 +34,10 @@ from xcp_d.utils.bids import (
 from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.modified_data import flag_bad_run
 from xcp_d.utils.utils import estimate_brain_radius
-from xcp_d.workflows.anatomical import init_postprocess_anat_wf, init_postprocess_surfaces_wf
+from xcp_d.workflows.anatomical import (
+    init_postprocess_anat_wf,
+    init_postprocess_surfaces_wf,
+)
 from xcp_d.workflows.bold import init_postprocess_nifti_wf
 from xcp_d.workflows.cifti import init_postprocess_cifti_wf
 from xcp_d.workflows.concatenation import init_concatenate_data_wf

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -633,7 +633,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
 
             # fmt:off
             workflow.connect([
-                (postprocess_surfaces_wf, postprocess_bold_wf, [
+                (postprocess_anat_wf, postprocess_bold_wf, [
                     ("outputnode.t1w", "inputnode.t1w"),
                     ("outputnode.t2w", "inputnode.t2w"),
                 ]),

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -490,8 +490,10 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
         input_type=input_type,
         t2w_available=subj_data["t2w"] is not None,
         target_space=target_space,
+        dcan_qc=dcan_qc,
         omp_nthreads=omp_nthreads,
         mem_gb=1,
+        name="postprocess_anat_wf",
     )
 
     # fmt:off

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -508,42 +508,45 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
     ])
     # fmt:on
 
-    postprocess_surfaces_wf = init_postprocess_surfaces_wf(
-        fmri_dir=fmri_dir,
-        subject_id=subject_id,
-        dcan_qc=dcan_qc,
-        mesh_available=mesh_available,
-        standard_space_mesh=standard_space_mesh,
-        shape_available=shape_available,
-        process_surfaces=process_surfaces,
-        output_dir=output_dir,
-        mem_gb=1,
-        omp_nthreads=omp_nthreads,
-        name="postprocess_surfaces_wf",
-    )
+    if process_surfaces or (dcan_qc and mesh_available):
+        # Run surface post-processing workflow if we want to warp meshes to standard space *or*
+        # generate brainsprite.
+        postprocess_surfaces_wf = init_postprocess_surfaces_wf(
+            fmri_dir=fmri_dir,
+            subject_id=subject_id,
+            dcan_qc=dcan_qc,
+            mesh_available=mesh_available,
+            standard_space_mesh=standard_space_mesh,
+            shape_available=shape_available,
+            process_surfaces=process_surfaces,
+            output_dir=output_dir,
+            mem_gb=1,
+            omp_nthreads=omp_nthreads,
+            name="postprocess_surfaces_wf",
+        )
 
-    # fmt:off
-    workflow.connect([
-        (inputnode, postprocess_surfaces_wf, [
-            ("lh_pial_surf", "inputnode.lh_pial_surf"),
-            ("rh_pial_surf", "inputnode.rh_pial_surf"),
-            ("lh_wm_surf", "inputnode.lh_wm_surf"),
-            ("rh_wm_surf", "inputnode.rh_wm_surf"),
-            ("t1w_to_template_xfm", "inputnode.t1w_to_template_xfm"),
-            ("template_to_t1w_xfm", "inputnode.template_to_t1w_xfm"),
-            ("lh_sulcal_depth", "inputnode.lh_sulcal_depth"),
-            ("rh_sulcal_depth", "inputnode.rh_sulcal_depth"),
-            ("lh_sulcal_curv", "inputnode.lh_sulcal_curv"),
-            ("rh_sulcal_curv", "inputnode.rh_sulcal_curv"),
-            ("lh_cortical_thickness", "inputnode.lh_cortical_thickness"),
-            ("rh_cortical_thickness", "inputnode.rh_cortical_thickness"),
-        ]),
-        (postprocess_anat_wf, postprocess_surfaces_wf, [
-            ("outputnode.t1w", "inputnode.t1w"),
-            ("outputnode.t2w", "inputnode.t2w"),
-        ]),
-    ])
-    # fmt:on
+        # fmt:off
+        workflow.connect([
+            (inputnode, postprocess_surfaces_wf, [
+                ("lh_pial_surf", "inputnode.lh_pial_surf"),
+                ("rh_pial_surf", "inputnode.rh_pial_surf"),
+                ("lh_wm_surf", "inputnode.lh_wm_surf"),
+                ("rh_wm_surf", "inputnode.rh_wm_surf"),
+                ("t1w_to_template_xfm", "inputnode.t1w_to_template_xfm"),
+                ("template_to_t1w_xfm", "inputnode.template_to_t1w_xfm"),
+                ("lh_sulcal_depth", "inputnode.lh_sulcal_depth"),
+                ("rh_sulcal_depth", "inputnode.rh_sulcal_depth"),
+                ("lh_sulcal_curv", "inputnode.lh_sulcal_curv"),
+                ("rh_sulcal_curv", "inputnode.rh_sulcal_curv"),
+                ("lh_cortical_thickness", "inputnode.lh_cortical_thickness"),
+                ("rh_cortical_thickness", "inputnode.rh_cortical_thickness"),
+            ]),
+            (postprocess_anat_wf, postprocess_surfaces_wf, [
+                ("outputnode.t1w", "inputnode.t1w"),
+                ("outputnode.t2w", "inputnode.t2w"),
+            ]),
+        ])
+        # fmt:on
 
     # Estimate head radius, if necessary
     head_radius = estimate_brain_radius(mask_file=subj_data["t1w_mask"], head_radius=head_radius)

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -488,6 +488,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
     postprocess_anat_wf = init_postprocess_anat_wf(
         output_dir=output_dir,
         input_type=input_type,
+        t1w_available=subj_data["t1w"] is not None,
         t2w_available=subj_data["t2w"] is not None,
         target_space=target_space,
         dcan_qc=dcan_qc,

--- a/xcp_d/workflows/outputs.py
+++ b/xcp_d/workflows/outputs.py
@@ -35,6 +35,10 @@ def init_copy_inputs_to_outputs_wf(output_dir, name="copy_inputs_to_outputs_wf")
 
     Inputs
     ------
+    lh_pial_surf
+    rh_pial_surf
+    lh_pial_wm
+    rh_pial_wm
     lh_sulcal_depth
     rh_sulcal_depth
     lh_sulcal_curv
@@ -47,7 +51,10 @@ def init_copy_inputs_to_outputs_wf(output_dir, name="copy_inputs_to_outputs_wf")
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                # required surfaces
+                "lh_pial_surf",
+                "rh_pial_surf",
+                "lh_pial_wm",
+                "rh_pial_wm",
                 "lh_sulcal_depth",
                 "rh_sulcal_depth",
                 "lh_sulcal_curv",
@@ -68,13 +75,18 @@ def init_copy_inputs_to_outputs_wf(output_dir, name="copy_inputs_to_outputs_wf")
     # fmt:off
     workflow.connect([
         (inputnode, collect_files, [
+            # fsLR-space surface mesh files
+            ("lh_pial_surf", "in1"),
+            ("rh_pial_surf", "in2"),
+            ("lh_pial_wm", "in3"),
+            ("rh_pial_wm", "in4"),
             # fsLR-space surface shape files
-            ("lh_sulcal_depth", "in1"),
-            ("rh_sulcal_depth", "in2"),
-            ("lh_sulcal_curv", "in3"),
-            ("rh_sulcal_curv", "in4"),
-            ("lh_cortical_thickness", "in5"),
-            ("rh_cortical_thickness", "in6"),
+            ("lh_sulcal_depth", "in5"),
+            ("rh_sulcal_depth", "in6"),
+            ("lh_sulcal_curv", "in7"),
+            ("rh_sulcal_curv", "in8"),
+            ("lh_cortical_thickness", "in9"),
+            ("rh_cortical_thickness", "in10"),
         ]),
     ])
     # fmt:on


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
- Move the HCP-style surface generation step from `init_warp_surfaces_to_template_wf` to `init_postprocess_surfaces_wf`.
- Only call `init_warp_surfaces_to_template_wf` if the surfaces need to be warped to fsLR. Otherwise, just pass them to `init_copy_inputs_to_outputs_wf`.
- Rename `init_postprocess_anat_wf` to `init_postprocess_surfaces_wf`. This workflow no longer handles the anatomical executive summary plots or the volumetric anatomical images.
- Rename `init_warp_anats_to_template_wf` to `init_postprocess_anat_wf`. This workflow handles the anatomical executive summary plots and the volumetric anatomical images.
