### PR TITLE
Work around load_confounds aCompCor bug

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,6 @@ doc =
     sphinxcontrib-bibtex
     svgutils
 tests =
-    codecov
     coverage
     pytest
     pytest-cov

--- a/xcp_d/tests/test_confounds.py
+++ b/xcp_d/tests/test_confounds.py
@@ -144,12 +144,12 @@ def test_load_confounds(fmriprep_with_freesurfer_data):
     confounds_df = load_confound_matrix(
         params="acompcor", img_file=bold_file, confounds_file=confounds_file
     )
-    assert confounds_df.shape == (N_VOLUMES, 18)
+    assert confounds_df.shape == (N_VOLUMES, 28)
 
     confounds_df = load_confound_matrix(
         params="acompcor_gsr", img_file=bold_file, confounds_file=confounds_file
     )
-    assert confounds_df.shape == (N_VOLUMES, 19)
+    assert confounds_df.shape == (N_VOLUMES, 29)
 
     confounds_df = load_confound_matrix(
         params="aroma", img_file=bold_file, confounds_file=confounds_file

--- a/xcp_d/tests/test_confounds.py
+++ b/xcp_d/tests/test_confounds.py
@@ -13,6 +13,7 @@ def test_custom_confounds(fmriprep_with_freesurfer_data, tmp_path_factory):
     """Ensure that custom confounds can be loaded without issue."""
     tempdir = tmp_path_factory.mktemp("test_custom_confounds")
     bold_file = fmriprep_with_freesurfer_data["nifti_file"]
+    confounds_file = fmriprep_with_freesurfer_data["confounds_file"]
 
     N_VOLUMES = 60
     TR = 2.5
@@ -45,6 +46,7 @@ def test_custom_confounds(fmriprep_with_freesurfer_data, tmp_path_factory):
     combined_confounds = load_confound_matrix(
         params="24P",
         img_file=bold_file,
+        confounds_file=confounds_file,
         custom_confounds=custom_confounds_file,
     )
     # We expect n params + 2 (one for each condition in custom confounds)
@@ -55,6 +57,7 @@ def test_custom_confounds(fmriprep_with_freesurfer_data, tmp_path_factory):
     custom_confounds = load_confound_matrix(
         params="custom",
         img_file=bold_file,
+        confounds_file=confounds_file,
         custom_confounds=custom_confounds_file,
     )
     # We expect 2 (one for each condition in custom confounds)
@@ -119,32 +122,47 @@ def test_describe_regression():
 def test_load_confounds(fmriprep_with_freesurfer_data):
     """Ensure that xcp_d loads the right confounds."""
     bold_file = fmriprep_with_freesurfer_data["nifti_file"]
+    confounds_file = fmriprep_with_freesurfer_data["confounds_file"]
 
     N_VOLUMES = 60
 
-    confounds_df = load_confound_matrix(params="24P", img_file=bold_file)
+    confounds_df = load_confound_matrix(
+        params="24P", img_file=bold_file, confounds_file=confounds_file
+    )
     assert confounds_df.shape == (N_VOLUMES, 24)
 
-    confounds_df = load_confound_matrix(params="27P", img_file=bold_file)
+    confounds_df = load_confound_matrix(
+        params="27P", img_file=bold_file, confounds_file=confounds_file
+    )
     assert confounds_df.shape == (N_VOLUMES, 27)
 
-    confounds_df = load_confound_matrix(params="36P", img_file=bold_file)
+    confounds_df = load_confound_matrix(
+        params="36P", img_file=bold_file, confounds_file=confounds_file
+    )
     assert confounds_df.shape == (N_VOLUMES, 36)
 
-    confounds_df = load_confound_matrix(params="acompcor", img_file=bold_file)
+    confounds_df = load_confound_matrix(
+        params="acompcor", img_file=bold_file, confounds_file=confounds_file
+    )
     assert confounds_df.shape == (N_VOLUMES, 18)
 
-    confounds_df = load_confound_matrix(params="acompcor_gsr", img_file=bold_file)
+    confounds_df = load_confound_matrix(
+        params="acompcor_gsr", img_file=bold_file, confounds_file=confounds_file
+    )
     assert confounds_df.shape == (N_VOLUMES, 19)
 
-    confounds_df = load_confound_matrix(params="aroma", img_file=bold_file)
+    confounds_df = load_confound_matrix(
+        params="aroma", img_file=bold_file, confounds_file=confounds_file
+    )
     assert confounds_df.shape == (N_VOLUMES, 48)
 
-    confounds_df = load_confound_matrix(params="aroma_gsr", img_file=bold_file)
+    confounds_df = load_confound_matrix(
+        params="aroma_gsr", img_file=bold_file, confounds_file=confounds_file
+    )
     assert confounds_df.shape == (N_VOLUMES, 49)
 
     with pytest.raises(ValueError, match="Unrecognized parameter string"):
-        load_confound_matrix(params="test", img_file=bold_file)
+        load_confound_matrix(params="test", img_file=bold_file, confounds_file=confounds_file)
 
     with pytest.raises(ValueError):
-        load_confound_matrix(params="custom", img_file=bold_file)
+        load_confound_matrix(params="custom", img_file=bold_file, confounds_file=confounds_file)

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -340,7 +340,7 @@ def describe_censoring(
 def _get_acompcor_confounds(confounds_file):
     confounds_df = pd.read_table(confounds_file)
     csf_compcor_columns = [c for c in confounds_df.columns if c.startswith("c_comp_cor")]
-    wm_compcor_columns = [c for c in confounds_df.columns if c.startswith("wm_comp_cor")]
+    wm_compcor_columns = [c for c in confounds_df.columns if c.startswith("w_comp_cor")]
     if not csf_compcor_columns:
         raise ValueError(f"No c_comp_cor columns in {confounds_file}")
 

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -113,6 +113,7 @@ def get_custom_confounds(custom_confounds_folder, fmriprep_confounds_file):
 def consolidate_confounds(
     img_file,
     params,
+    fmriprep_confounds_file,
     custom_confounds_file=None,
 ):
     """Combine confounds files into a single tsv.
@@ -141,6 +142,7 @@ def consolidate_confounds(
     confounds_df = load_confound_matrix(
         img_file=img_file,
         params=params,
+        confounds_file=fmriprep_confounds_file,
         custom_confounds=custom_confounds_file,
     )
     confounds_df["linear_trend"] = np.arange(confounds_df.shape[0])
@@ -335,8 +337,24 @@ def describe_censoring(
     )
 
 
+def _get_acompcor_confounds(confounds_file):
+    confounds_df = pd.read_table(confounds_file)
+    csf_compcor_columns = [c for c in confounds_df.columns if c.startswith("c_comp_cor")]
+    wm_compcor_columns = [c for c in confounds_df.columns if c.startswith("wm_comp_cor")]
+    if not csf_compcor_columns:
+        raise ValueError(f"No c_comp_cor columns in {confounds_file}")
+
+    if not wm_compcor_columns:
+        raise ValueError(f"No w_comp_cor columns in {confounds_file}")
+
+    csf_compcor_columns = csf_compcor_columns[: min((5, len(csf_compcor_columns)))]
+    wm_compcor_columns = wm_compcor_columns[: min((5, len(wm_compcor_columns)))]
+    selected_columns = csf_compcor_columns + wm_compcor_columns
+    return confounds_df[selected_columns]
+
+
 @fill_doc
-def load_confound_matrix(params, img_file, custom_confounds=None):
+def load_confound_matrix(params, img_file, confounds_file, custom_confounds=None):
     """Load a subset of the confounds associated with a given file.
 
     Parameters
@@ -344,6 +362,8 @@ def load_confound_matrix(params, img_file, custom_confounds=None):
     %(params)s
     img_file : :obj:`str`
         The path to the bold file.
+    confounds_file : :obj:`str`
+        Only used if aCompCor regressors are required and load_confounds can't find them.
     custom_confounds : :obj:`str` or None, optional
         Custom confounds TSV if there is one. Default is None.
 
@@ -416,6 +436,11 @@ def load_confound_matrix(params, img_file, custom_confounds=None):
 
     else:
         raise ValueError(f"Unrecognized parameter string '{params}'")
+
+    # A workaround for the compcor bug in load_confounds with fMRIPrep v22+
+    if "acompcor" in params and all("comp_cor" not in col for col in confounds_df.columns):
+        LOGGER.warning("No aCompCor confounds detected with load_confounds. Extracting manually.")
+        confounds_df = pd.concat((_get_acompcor_confounds(confounds_file), confounds_df), axis=1)
 
     if "aroma" in params:
         ica_mixing_matrix = _get_mixing_matrix(img_file)

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -177,8 +177,9 @@ def init_prepare_confounds_wf(
         niu.Function(
             input_names=[
                 "img_file",
-                "custom_confounds_file",
                 "params",
+                "fmriprep_confounds_file",
+                "custom_confounds_file",
             ],
             output_names=["confounds_file"],
             function=consolidate_confounds,
@@ -192,6 +193,7 @@ def init_prepare_confounds_wf(
     workflow.connect([
         (inputnode, consolidate_confounds_node, [
             ("name_source", "img_file"),
+            ("fmriprep_confounds_file", "fmriprep_confounds_file"),
             ("custom_confounds_file", "custom_confounds_file"),
         ]),
     ])


### PR DESCRIPTION
Closes #849.

## Changes proposed in this pull request
- If `load_confounds` can't find compcor regressors, use a custom function to find them and add them to the other confounds load_confounds found.
