### PR TITLE
Use appropriate T1w/T2w in brainsprite workflow

### DIFF
--- a/xcp_d/tests/data/nibabies_outputs.txt
+++ b/xcp_d/tests/data/nibabies_outputs.txt
@@ -13,6 +13,7 @@ xcp_d/space-MNIInfant_atlas-Schaefer817_cohort-1_dseg.nii.gz
 xcp_d/space-MNIInfant_atlas-Schaefer917_cohort-1_dseg.nii.gz
 xcp_d/space-MNIInfant_atlas-subcortical_cohort-1_dseg.nii.gz
 xcp_d/sub-01.html
+xcp_d/sub-01_executive_summary.html
 xcp_d/logs
 xcp_d/logs/CITATION.md
 xcp_d/sub-01

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -317,6 +317,7 @@ def test_nibabies(datasets, output_dir, working_dir):
         "--head_radius=auto",
         "--smoothing=6",
         "--fd-thresh=0",
+        "--dcan-qc",
     ]
     opts = get_parser().parse_args(parameters)
     retval = {}

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -434,8 +434,10 @@ def init_postprocess_surfaces_wf(
         ])
         # fmt:on
 
-        if not process_surfaces:
-            # Use native-space T1w and surfaces for brainsprite.
+        if (not process_surfaces) or (mesh_available and standard_space_mesh):
+            # Use original surfaces for brainsprite.
+            # For fMRIPrep derivatives, this will be the native-space surfaces.
+            # For DCAN/HCP derivatives, it will be standard-space surfaces.
             # fmt:off
             workflow.connect([
                 (inputnode, brainsprite_wf, [

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -549,12 +549,29 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
                 ("lh_cortical_thickness", "inputnode.lh_cortical_thickness"),
                 ("rh_cortical_thickness", "inputnode.rh_cortical_thickness"),
             ]),
-            (postprocess_anat_wf, postprocess_surfaces_wf, [
-                ("outputnode.t1w", "inputnode.t1w"),
-                ("outputnode.t2w", "inputnode.t2w"),
-            ]),
         ])
         # fmt:on
+
+        if process_surfaces or standard_space_mesh:
+            # Use standard-space structurals
+            # fmt:off
+            workflow.connect([
+                (postprocess_anat_wf, postprocess_surfaces_wf, [
+                    ("outputnode.t1w", "inputnode.t1w"),
+                    ("outputnode.t2w", "inputnode.t2w"),
+                ]),
+            ])
+            # fmt:on
+        else:
+            # Use native-space structurals
+            # fmt:off
+            workflow.connect([
+                (inputnode, postprocess_surfaces_wf, [
+                    ("t1w", "inputnode.t1w"),
+                    ("t2w", "inputnode.t2w"),
+                ]),
+            ])
+            # fmt:on
 
     # Estimate head radius, if necessary
     head_radius = estimate_brain_radius(

--- a/xcp_d/workflows/outputs.py
+++ b/xcp_d/workflows/outputs.py
@@ -37,8 +37,8 @@ def init_copy_inputs_to_outputs_wf(output_dir, name="copy_inputs_to_outputs_wf")
     ------
     lh_pial_surf
     rh_pial_surf
-    lh_pial_wm
-    rh_pial_wm
+    lh_wm_surf
+    rh_wm_surf
     lh_sulcal_depth
     rh_sulcal_depth
     lh_sulcal_curv
@@ -53,8 +53,8 @@ def init_copy_inputs_to_outputs_wf(output_dir, name="copy_inputs_to_outputs_wf")
             fields=[
                 "lh_pial_surf",
                 "rh_pial_surf",
-                "lh_pial_wm",
-                "rh_pial_wm",
+                "lh_wm_surf",
+                "rh_wm_surf",
                 "lh_sulcal_depth",
                 "rh_sulcal_depth",
                 "lh_sulcal_curv",
@@ -78,8 +78,8 @@ def init_copy_inputs_to_outputs_wf(output_dir, name="copy_inputs_to_outputs_wf")
             # fsLR-space surface mesh files
             ("lh_pial_surf", "in1"),
             ("rh_pial_surf", "in2"),
-            ("lh_pial_wm", "in3"),
-            ("rh_pial_wm", "in4"),
+            ("lh_wm_surf", "in3"),
+            ("rh_wm_surf", "in4"),
             # fsLR-space surface shape files
             ("lh_sulcal_depth", "in5"),
             ("rh_sulcal_depth", "in6"),


### PR DESCRIPTION
Closes #858.

## Changes proposed in this pull request

- There was a bug where standard-space T1w/T2ws were fed into the brainsprite workflow, even if the surfaces wouldn't be warped to fsLR space. This feeds in the native-space T1w/T2w in that situation.