### PR TITLE
Allow for smoothing to be zero

### DIFF
--- a/xcp_d/tests/data/nibabies_outputs.txt
+++ b/xcp_d/tests/data/nibabies_outputs.txt
@@ -67,12 +67,8 @@ xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfan
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_atlas-subcortical_cohort-1_measure-pearsoncorrelation_conmat.tsv
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_atlas-subcortical_cohort-1_coverage.tsv
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_atlas-subcortical_cohort-1_timeseries.tsv
-xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_cohort-1_desc-denoisedSmoothed_bold.json
-xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_cohort-1_desc-denoisedSmoothed_bold.nii.gz
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_cohort-1_desc-denoised_bold.json
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_cohort-1_desc-denoised_bold.nii.gz
-xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_cohort-1_desc-smooth_alff.json
-xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_cohort-1_desc-smooth_alff.nii.gz
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_cohort-1_desc-linc_qc.csv
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_cohort-1_reho.json
 xcp_d/sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_cohort-1_reho.nii.gz

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -315,7 +315,7 @@ def test_nibabies(datasets, output_dir, working_dir):
         "--nuisance-regressors=27P",
         "--despike",
         "--head_radius=auto",
-        "--smoothing=6",
+        "--smoothing=0",
         "--fd-thresh=0",
     ]
     opts = get_parser().parse_args(parameters)

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -626,22 +626,25 @@ def init_denoise_bold_wf(
     ])
     # fmt:on
 
-    resd_smoothing_wf = init_resd_smoothing_wf(
-        smoothing=smoothing,
-        cifti=cifti,
-        mem_gb=mem_gb,
-        omp_nthreads=omp_nthreads,
-        name="resd_smoothing_wf",
-    )
+    if smoothing:
+        resd_smoothing_wf = init_resd_smoothing_wf(
+            smoothing=smoothing,
+            cifti=cifti,
+            mem_gb=mem_gb,
+            omp_nthreads=omp_nthreads,
+            name="resd_smoothing_wf",
+        )
 
-    # fmt:off
-    workflow.connect([
-        (censor_interpolated_data, resd_smoothing_wf, [
-            ("censored_denoised_bold", "inputnode.bold_file"),
-        ]),
-        (resd_smoothing_wf, outputnode, [("outputnode.smoothed_bold", "smoothed_denoised_bold")]),
-    ])
-    # fmt:on
+        # fmt:off
+        workflow.connect([
+            (censor_interpolated_data, resd_smoothing_wf, [
+                ("censored_denoised_bold", "inputnode.bold_file"),
+            ]),
+            (resd_smoothing_wf, outputnode, [
+                ("outputnode.smoothed_bold", "smoothed_denoised_bold"),
+            ]),
+        ])
+        # fmt:on
 
     return workflow
 


### PR DESCRIPTION
Closes #859. I probably introduced this bug in my recent round of refactors.

## Changes proposed in this pull request
- Only run the smoothing workflow if the smoothing kernel is > 0.
