### PR TITLE
Support high-pass or low-pass only filtering

### DIFF
--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -668,9 +668,9 @@ def build_workflow(opts, retval):
     if opts.lower_bpf == 0 and opts.upper_bpf == 0:
         opts.bandpass_filter = False
     if (
-        opts.bandpass_filter and
-        (opts.lower_bpf >= opts.upper_bpf) and
-        (opts.lower_bpf > 0 and opts.upper_bpf > 0)
+        opts.bandpass_filter
+        and (opts.lower_bpf >= opts.upper_bpf)
+        and (opts.lower_bpf > 0 and opts.upper_bpf > 0)
     ):
         build_log.error(
             f"'--lower-bpf' ({opts.lower_bpf}) must be lower than "

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -665,6 +665,8 @@ def build_workflow(opts, retval):
         retval["return_code"] = 1
 
     # Bandpass filter parameters
+    if opts.lower_bpf == 0 and opts.upper_bpf == 0:
+        opts.bandpass_filter = False
     if (
         opts.bandpass_filter and
         (opts.lower_bpf >= opts.upper_bpf) and

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -291,7 +291,7 @@ def get_parser():
         type=float,
         help=(
             "Lower cut-off frequency (Hz) for the Butterworth bandpass filter to be applied to "
-            "the denoised BOLD data. "
+            "the denoised BOLD data. Set to 0.0 or negative to disable high-pass filtering. "
             "See Satterthwaite et al. (2013)."
         ),
     )
@@ -302,7 +302,7 @@ def get_parser():
         type=float,
         help=(
             "Upper cut-off frequency (Hz) for the Butterworth bandpass filter to be applied to "
-            "the denoised BOLD data. "
+            "the denoised BOLD data. Set to 0.0 or negative to disable low-pass filtering. "
             "See Satterthwaite et al. (2013)."
         ),
     )
@@ -665,7 +665,7 @@ def build_workflow(opts, retval):
         retval["return_code"] = 1
 
     # Bandpass filter parameters
-    if opts.bandpass_filter and (opts.lower_bpf >= opts.upper_bpf):
+    if opts.bandpass_filter and (opts.lower_bpf >= opts.upper_bpf) and (opts.lower_bpf > 0 and opts.upper_bpf > 0):
         build_log.error(
             f"'--lower-bpf' ({opts.lower_bpf}) must be lower than "
             f"'--upper-bpf' ({opts.upper_bpf})."

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -666,7 +666,7 @@ def build_workflow(opts, retval):
 
     # Bandpass filter parameters
     if opts.bandpass_filter and (opts.lower_bpf >= opts.upper_bpf) and \
-        (opts.lower_bpf > 0 and opts.upper_bpf > 0):
+            (opts.lower_bpf > 0 and opts.upper_bpf > 0):
         build_log.error(
             f"'--lower-bpf' ({opts.lower_bpf}) must be lower than "
             f"'--upper-bpf' ({opts.upper_bpf})."

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -665,7 +665,8 @@ def build_workflow(opts, retval):
         retval["return_code"] = 1
 
     # Bandpass filter parameters
-    if opts.bandpass_filter and (opts.lower_bpf >= opts.upper_bpf) and (opts.lower_bpf > 0 and opts.upper_bpf > 0):
+    if opts.bandpass_filter and (opts.lower_bpf >= opts.upper_bpf) and \
+        (opts.lower_bpf > 0 and opts.upper_bpf > 0):
         build_log.error(
             f"'--lower-bpf' ({opts.lower_bpf}) must be lower than "
             f"'--upper-bpf' ({opts.upper_bpf})."

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -665,8 +665,11 @@ def build_workflow(opts, retval):
         retval["return_code"] = 1
 
     # Bandpass filter parameters
-    if opts.bandpass_filter and (opts.lower_bpf >= opts.upper_bpf) and \
-            (opts.lower_bpf > 0 and opts.upper_bpf > 0):
+    if (
+        opts.bandpass_filter and
+        (opts.lower_bpf >= opts.upper_bpf) and
+        (opts.lower_bpf > 0 and opts.upper_bpf > 0)
+    ):
         build_log.error(
             f"'--lower-bpf' ({opts.lower_bpf}) must be lower than "
             f"'--upper-bpf' ({opts.upper_bpf})."

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -665,8 +665,9 @@ def build_workflow(opts, retval):
         retval["return_code"] = 1
 
     # Bandpass filter parameters
-    if opts.lower_bpf == 0 and opts.upper_bpf == 0:
+    if opts.lower_bpf <= 0 and opts.upper_bpf <= 0:
         opts.bandpass_filter = False
+
     if (
         opts.bandpass_filter
         and (opts.lower_bpf >= opts.upper_bpf)

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -118,6 +118,7 @@ def test_ds001419_cifti(datasets, output_dir, working_dir):
         "--dcan-qc",
         "--dummy-scans=auto",
         "--fd-thresh=0.3",
+        "--upper-bpf=0.0",
     ]
     opts = get_parser().parse_args(parameters)
     retval = {}
@@ -205,6 +206,7 @@ def test_ds001419_cifti_t2wonly(datasets, output_dir, working_dir):
         "--dcan-qc",
         "--dummy-scans=auto",
         "--fd-thresh=0.3",
+        "--lower-bpf=0.0",
     ]
     opts = get_parser().parse_args(parameters)
     retval = {}
@@ -342,115 +344,3 @@ def test_nibabies(datasets, output_dir, working_dir):
     check_generated_files(out_dir, output_list_file)
 
     check_affines(data_dir, out_dir, input_type="nibabies")
-
-@pytest.mark.ds001419_highpass
-def test_ds001419_highpass(datasets, output_dir, working_dir):
-    """Run xcp_d on ds001419 fMRIPrep derivatives, while disabling low-pass filtering."""
-    test_name = "test_ds001419_highpass"
-
-    data_dir = datasets["ds001419"]
-    out_dir = os.path.join(output_dir, test_name)
-    work_dir = os.path.join(working_dir, test_name)
-
-    test_data_dir = get_test_data_path()
-    filter_file = os.path.join(test_data_dir, "ds001419-fmriprep_nifti_filter.json")
-
-    parameters = [
-        data_dir,
-        out_dir,
-        "participant",
-        f"-w={work_dir}",
-        "--nthreads=2",
-        "--omp-nthreads=2",
-        f"--bids-filter-file={filter_file}",
-        "--nuisance-regressors=aroma_gsr",
-        "--despike",
-        "--dummy-scans=4",
-        "--fd-thresh=0.3",
-        "--head_radius=40",
-        "--smoothing=6",
-        "--motion-filter-type=lp",
-        "--band-stop-min=6",
-        "--min-coverage=1",
-        "--upper-bpf=0",
-    ]
-    opts = get_parser().parse_args(parameters)
-
-    retval = {}
-    retval = build_workflow(opts, retval=retval)
-    run_uuid = retval.get("run_uuid", None)
-    xcpd_wf = retval.get("workflow", None)
-    plugin_settings = retval["plugin_settings"]
-    xcpd_wf.run(**plugin_settings)
-
-    generate_reports(
-        subject_list=["01"],
-        fmri_dir=data_dir,
-        work_dir=work_dir,
-        output_dir=out_dir,
-        run_uuid=run_uuid,
-        config=pkgrf("xcp_d", "data/reports.yml"),
-        packagename="xcp_d",
-        dcan_qc=opts.dcan_qc,
-    )
-
-    output_list_file = os.path.join(test_data_dir, "ds001419-fmriprep_highpass_outputs.txt")
-    check_generated_files(out_dir, output_list_file)
-
-    check_affines(data_dir, out_dir, input_type="nifti")
-
-@pytest.mark.ds001419_lowpass
-def test_ds001419_lowpass(datasets, output_dir, working_dir):
-    """Run xcp_d on ds001419 fMRIPrep derivatives, while disabling high-pass filtering."""
-    test_name = "test_ds001419_lowpass"
-
-    data_dir = datasets["ds001419"]
-    out_dir = os.path.join(output_dir, test_name)
-    work_dir = os.path.join(working_dir, test_name)
-
-    test_data_dir = get_test_data_path()
-    filter_file = os.path.join(test_data_dir, "ds001419-fmriprep_nifti_filter.json")
-
-    parameters = [
-        data_dir,
-        out_dir,
-        "participant",
-        f"-w={work_dir}",
-        "--nthreads=2",
-        "--omp-nthreads=2",
-        f"--bids-filter-file={filter_file}",
-        "--nuisance-regressors=aroma_gsr",
-        "--despike",
-        "--dummy-scans=4",
-        "--fd-thresh=0.3",
-        "--head_radius=40",
-        "--smoothing=6",
-        "--motion-filter-type=lp",
-        "--band-stop-min=6",
-        "--min-coverage=1",
-        "--lower-bpf=0",
-    ]
-    opts = get_parser().parse_args(parameters)
-
-    retval = {}
-    retval = build_workflow(opts, retval=retval)
-    run_uuid = retval.get("run_uuid", None)
-    xcpd_wf = retval.get("workflow", None)
-    plugin_settings = retval["plugin_settings"]
-    xcpd_wf.run(**plugin_settings)
-
-    generate_reports(
-        subject_list=["01"],
-        fmri_dir=data_dir,
-        work_dir=work_dir,
-        output_dir=out_dir,
-        run_uuid=run_uuid,
-        config=pkgrf("xcp_d", "data/reports.yml"),
-        packagename="xcp_d",
-        dcan_qc=opts.dcan_qc,
-    )
-
-    output_list_file = os.path.join(test_data_dir, "ds001419-fmriprep_lowpass_outputs.txt")
-    check_generated_files(out_dir, output_list_file)
-
-    check_affines(data_dir, out_dir, input_type="nifti")

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -342,3 +342,115 @@ def test_nibabies(datasets, output_dir, working_dir):
     check_generated_files(out_dir, output_list_file)
 
     check_affines(data_dir, out_dir, input_type="nibabies")
+
+@pytest.mark.ds001419_highpass
+def test_ds001419_highpass(datasets, output_dir, working_dir):
+    """Run xcp_d on ds001419 fMRIPrep derivatives, while disabling low-pass filtering."""
+    test_name = "test_ds001419_highpass"
+
+    data_dir = datasets["ds001419"]
+    out_dir = os.path.join(output_dir, test_name)
+    work_dir = os.path.join(working_dir, test_name)
+
+    test_data_dir = get_test_data_path()
+    filter_file = os.path.join(test_data_dir, "ds001419-fmriprep_nifti_filter.json")
+
+    parameters = [
+        data_dir,
+        out_dir,
+        "participant",
+        f"-w={work_dir}",
+        "--nthreads=2",
+        "--omp-nthreads=2",
+        f"--bids-filter-file={filter_file}",
+        "--nuisance-regressors=aroma_gsr",
+        "--despike",
+        "--dummy-scans=4",
+        "--fd-thresh=0.3",
+        "--head_radius=40",
+        "--smoothing=6",
+        "--motion-filter-type=lp",
+        "--band-stop-min=6",
+        "--min-coverage=1",
+        "--upper-bpf=0",
+    ]
+    opts = get_parser().parse_args(parameters)
+
+    retval = {}
+    retval = build_workflow(opts, retval=retval)
+    run_uuid = retval.get("run_uuid", None)
+    xcpd_wf = retval.get("workflow", None)
+    plugin_settings = retval["plugin_settings"]
+    xcpd_wf.run(**plugin_settings)
+
+    generate_reports(
+        subject_list=["01"],
+        fmri_dir=data_dir,
+        work_dir=work_dir,
+        output_dir=out_dir,
+        run_uuid=run_uuid,
+        config=pkgrf("xcp_d", "data/reports.yml"),
+        packagename="xcp_d",
+        dcan_qc=opts.dcan_qc,
+    )
+
+    output_list_file = os.path.join(test_data_dir, "ds001419-fmriprep_highpass_outputs.txt")
+    check_generated_files(out_dir, output_list_file)
+
+    check_affines(data_dir, out_dir, input_type="nifti")
+
+@pytest.mark.ds001419_lowpass
+def test_ds001419_lowpass(datasets, output_dir, working_dir):
+    """Run xcp_d on ds001419 fMRIPrep derivatives, while disabling high-pass filtering."""
+    test_name = "test_ds001419_lowpass"
+
+    data_dir = datasets["ds001419"]
+    out_dir = os.path.join(output_dir, test_name)
+    work_dir = os.path.join(working_dir, test_name)
+
+    test_data_dir = get_test_data_path()
+    filter_file = os.path.join(test_data_dir, "ds001419-fmriprep_nifti_filter.json")
+
+    parameters = [
+        data_dir,
+        out_dir,
+        "participant",
+        f"-w={work_dir}",
+        "--nthreads=2",
+        "--omp-nthreads=2",
+        f"--bids-filter-file={filter_file}",
+        "--nuisance-regressors=aroma_gsr",
+        "--despike",
+        "--dummy-scans=4",
+        "--fd-thresh=0.3",
+        "--head_radius=40",
+        "--smoothing=6",
+        "--motion-filter-type=lp",
+        "--band-stop-min=6",
+        "--min-coverage=1",
+        "--upper-bpf=0",
+    ]
+    opts = get_parser().parse_args(parameters)
+
+    retval = {}
+    retval = build_workflow(opts, retval=retval)
+    run_uuid = retval.get("run_uuid", None)
+    xcpd_wf = retval.get("workflow", None)
+    plugin_settings = retval["plugin_settings"]
+    xcpd_wf.run(**plugin_settings)
+
+    generate_reports(
+        subject_list=["01"],
+        fmri_dir=data_dir,
+        work_dir=work_dir,
+        output_dir=out_dir,
+        run_uuid=run_uuid,
+        config=pkgrf("xcp_d", "data/reports.yml"),
+        packagename="xcp_d",
+        dcan_qc=opts.dcan_qc,
+    )
+
+    output_list_file = os.path.join(test_data_dir, "ds001419-fmriprep_lowpass_outputs.txt")
+    check_generated_files(out_dir, output_list_file)
+
+    check_affines(data_dir, out_dir, input_type="nifti")

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -428,7 +428,7 @@ def test_ds001419_lowpass(datasets, output_dir, working_dir):
         "--motion-filter-type=lp",
         "--band-stop-min=6",
         "--min-coverage=1",
-        "--upper-bpf=0",
+        "--lower-bpf=0",
     ]
     opts = get_parser().parse_args(parameters)
 

--- a/xcp_d/utils/doc.py
+++ b/xcp_d/utils/doc.py
@@ -210,7 +210,7 @@ high_pass : :obj:`float`
     Bandpass filtering will only be performed if ``bandpass_filter`` is True.
     This internal parameter corresponds to the command-line parameter ``--lower-bpf``.
     If set to <= 0, high-pass filtering will be disabled.
-    
+
     Default value is 0.01.
 """
 
@@ -223,7 +223,7 @@ low_pass : :obj:`float`
     Bandpass filtering will only be performed if ``bandpass_filter`` is True.
     This internal parameter corresponds to the command-line parameter ``--upper-bpf``.
     If set to <= 0, low-pass filtering will be disabled.
-    
+
     Default value is 0.08.
 """
 

--- a/xcp_d/utils/doc.py
+++ b/xcp_d/utils/doc.py
@@ -209,7 +209,8 @@ high_pass : :obj:`float`
     The bandpass filter is applied to the fMRI data after post-processing and denoising.
     Bandpass filtering will only be performed if ``bandpass_filter`` is True.
     This internal parameter corresponds to the command-line parameter ``--lower-bpf``.
-
+    If set to <= 0, high-pass filtering will be disabled.
+    
     Default value is 0.01.
 """
 
@@ -221,7 +222,8 @@ low_pass : :obj:`float`
     The bandpass filter is applied to the fMRI data after post-processing and denoising.
     Bandpass filtering will only be performed if ``bandpass_filter`` is True.
     This internal parameter corresponds to the command-line parameter ``--upper-bpf``.
-
+    If set to <= 0, low-pass filtering will be disabled.
+    
     Default value is 0.08.
 """
 

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -313,7 +313,7 @@ def butter_bandpass(
     """
     from scipy.signal import butter, filtfilt
 
-    if (low_pass > 0 and high_pass > 0) and (low_pass > high_pass):
+    if low_pass > 0 and high_pass > 0:
         btype = "bandpass"
         filt_input = [high_pass, low_pass]
     elif high_pass > 0:

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -313,15 +313,15 @@ def butter_bandpass(
     """
     from scipy.signal import butter, filtfilt
 
-    if low_pass == 0 and high_pass > 0:
-        btype = "highpass"
-        filt_input = high_pass
-    elif low_pass > 0 and high_pass == 0:
-        btype = "lowpass"
-        filt_input = low_pass
-    elif low_pass > 0 and high_pass > 0:
+    if (low_pass > 0 and high_pass > 0) and (low_pass > high_pass):
         btype = "bandpass"
         filt_input = [high_pass, low_pass]
+    elif high_pass > 0:
+        btype = "highpass"
+        filt_input = high_pass
+    elif low_pass > 0:
+        btype = "lowpass"
+        filt_input = low_pass
     else:
         raise Exception("Filter parameters are not valid.")
     

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -313,10 +313,20 @@ def butter_bandpass(
     """
     from scipy.signal import butter, filtfilt
 
+    if low_pass == 0 and high_pass > 0:
+        btype = "highpass"
+        filt_input = high_pass
+    elif low_pass > 0 and high_pass == 0:
+        btype = "lowpass"
+        filt_input = low_pass
+    elif low_pass > 0 and high_pass > 0:
+        btype = "bandpass"
+        filt_input = [high_pass, low_pass]
+    
     b, a = butter(
         order,
-        [high_pass, low_pass],
-        btype="bandpass",
+        filt_input,
+        btype=btype,
         output="ba",
         fs=sampling_rate,  # eliminates need to normalize cutoff frequencies
     )

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -324,7 +324,7 @@ def butter_bandpass(
         filt_input = low_pass
     else:
         raise Exception("Filter parameters are not valid.")
-    
+
     b, a = butter(
         order,
         filt_input,

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -322,6 +322,8 @@ def butter_bandpass(
     elif low_pass > 0 and high_pass > 0:
         btype = "bandpass"
         filt_input = [high_pass, low_pass]
+    else:
+        raise Exception("Filter parameters are not valid.")
     
     b, a = butter(
         order,

--- a/xcp_d/workflows/outputs.py
+++ b/xcp_d/workflows/outputs.py
@@ -249,7 +249,16 @@ def init_postproc_derivatives_wf(
         "nuisance parameters": params,
     }
     if bandpass_filter:
-        cleaned_data_dictionary["Freq Band"] = [high_pass, low_pass]
+        if low_pass > 0 and high_pass > 0:
+            key = "Freq Band"
+            val = [high_pass, low_pass]
+        elif high_pass > 0:
+            key = "High-pass Cutoff"
+            val = high_pass
+        elif low_pass > 0:
+            key = "Low-pass Cutoff"
+            val = low_pass
+        cleaned_data_dictionary[key] = val
 
     smoothed_data_dictionary = {"FWHM": smoothing}  # Separate dictionary for smoothing
 

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -544,12 +544,25 @@ def init_denoise_bold_wf(
         f"as implemented in nilearn {nilearn.__version__} [@abraham2014machine]."
     )
     if bandpass_filter:
+        if low_pass > 0 and high_pass > 0:
+            btype = "band-pass"
+            preposition = "between"
+            filt_input = f"{high_pass}-{low_pass}"
+        elif high_pass > 0:
+            btype = "high-pass"
+            preposition = "above"
+            filt_input = f"{high_pass}"
+        elif low_pass > 0:
+            btype = "low-pass"
+            preposition = "below"
+            filt_input = f"{low_pass}"       
+        
         workflow.__desc__ += (
             " Any volumes censored earlier in the workflow were then interpolated in the residual "
             "time series produced by the regression. "
-            "The interpolated timeseries were then band-pass filtered using a(n) "
+            f"The interpolated timeseries were then {btype} filtered using a(n) "
             f"{num2words(bpf_order, ordinal=True)}-order Butterworth filter, "
-            f"in order to retain signals within the {high_pass}-{low_pass} Hz frequency band. "
+            f"in order to retain signals {preposition} {filt_input} Hz. "
             "The filtered, interpolated time series were then re-censored to remove high-motion "
             "outlier volumes."
         )

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -555,8 +555,8 @@ def init_denoise_bold_wf(
         elif low_pass > 0:
             btype = "low-pass"
             preposition = "below"
-            filt_input = f"{low_pass}"       
-        
+            filt_input = f"{low_pass}"
+
         workflow.__desc__ += (
             " Any volumes censored earlier in the workflow were then interpolated in the residual "
             "time series produced by the regression. "


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
Closes #844. Happy to work on this a bit. Was wondering if you think it would be better to have a separate flag for disabling  the filter components, or rather do something like "set `--lower-bpf` to 0 to disable" (or something else)? What I have begun drafting so far uses a "set to 0" approach.

Can ALFF be run on data that has only been low-passed?
## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
