### PR TITLE
Document how to process multiple, but not all, tasks

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -190,7 +190,7 @@ In this example file, we only run XCP-D on resting-state preprocessed BOLD runs 
    {
       "bold": {
          "session": ["01"],
-         "task": "rest"
+         "task": ["rest"]
       }
    }
 

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -92,7 +92,10 @@ def get_parser():
         action="store",
         help=(
             "The name of a specific task to postprocess. "
-            "By default, all tasks will be postprocessed."
+            "By default, all tasks will be postprocessed. "
+            "If you want to select more than one task to postprocess (but not all of them), "
+            "you can either run XCP-D with the --task-id parameter, separately for each task, "
+            "or you can use the --bids-filter-file to specify the tasks to postprocess."
         ),
     )
     g_bids.add_argument(


### PR DESCRIPTION
Closes #873.

## Changes proposed in this pull request

- Expand help message for `--task-id` pointing toward `--bids-filter-file`.