### PR TITLE
Always generate the DCAN executive summary

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -33,7 +33,7 @@ Summary Reports
 ***************
 
 There are two summary reports - a Nipreps-style participant summary and an executive summary per
-session (if ``--dcan-qc`` is used).
+session.
 The executive summary is based on the DCAN lab's
 `ExecutiveSummary tool <https://github.com/DCAN-Labs/ExecutiveSummary>`_.
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -447,8 +447,8 @@ anatomical data and the BOLD data before and after regression.
 The anatomical image viewer allows the user to see the segmentation overlaid on the anatomical
 image.
 Next, for each session, the user can see the segmentation registered onto the BOLD images.
-Beside the segmentations, users can see the pre-regression and post-regression "carpet" plot, as well as DVARS, FD, the global
-signal.
+Beside the segmentations, users can see the pre-regression and post-regression "carpet" plot,
+as well as DVARS, FD, the global signal.
 The number of volumes remaining at various FD thresholds are shown.
 
 Second, XCP-D generates an HTML "report" for each subject and session.

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -465,7 +465,7 @@ By default, this workflow is disabled.
         action="store_true",
         dest="dcan_qc",
         default=False,
-        help="Run DCAN QC, including executive summary generation.",
+        help="Run DCAN QC.",
     )
 
     return parser
@@ -633,7 +633,6 @@ def main(args=None):
             run_uuid=run_uuid,
             config=pkgrf("xcp_d", "data/reports.yml"),
             packagename="xcp_d",
-            dcan_qc=opts.dcan_qc,
         )
 
         if failed_reports and not opts.notrack:

--- a/xcp_d/interfaces/report_core.py
+++ b/xcp_d/interfaces/report_core.py
@@ -93,7 +93,6 @@ def generate_reports(
     run_uuid,
     config=None,
     packagename=None,
-    dcan_qc=False,
 ):
     """Execute run_reports on a list of subjects.
 
@@ -111,8 +110,6 @@ def generate_reports(
         Configuration file.
     packagename : None or :obj:`str`, optional
         The name of the package.
-    dcan_qc : :obj:`bool`, optional
-        Whether to perform DCAN QC steps or not. Default is False.
     """
     # reportlets_dir = None
     if work_dir is not None:
@@ -143,23 +140,22 @@ def generate_reports(
             error_list,
         )
     else:
-        if dcan_qc:
-            LOGGER.info("Generating executive summary.")
-            for subject_label in subject_list:
-                brainplotfile = glob.glob(
-                    os.path.join(
-                        output_dir,
-                        f"xcp_d/sub-{subject_label}",
-                        "figures/*_bold.svg",
-                    ),
-                )[0]
-                exsumm = ExecutiveSummary(
-                    xcpd_path=os.path.join(output_dir, "xcp_d"),
-                    subject_id=subject_label,
-                    session_id=get_entity(brainplotfile, "ses"),
-                )
-                exsumm.collect_inputs()
-                exsumm.generate_report()
+        LOGGER.info("Generating executive summary.")
+        for subject_label in subject_list:
+            brainplotfile = glob.glob(
+                os.path.join(
+                    output_dir,
+                    f"xcp_d/sub-{subject_label}",
+                    "figures/*_bold.svg",
+                ),
+            )[0]
+            exsumm = ExecutiveSummary(
+                xcpd_path=os.path.join(output_dir, "xcp_d"),
+                subject_id=subject_label,
+                session_id=get_entity(brainplotfile, "ses"),
+            )
+            exsumm.collect_inputs()
+            exsumm.generate_report()
 
         print("Reports generated successfully")
     return errno

--- a/xcp_d/tests/data/ds001419-fmriprep_nifti_outputs.txt
+++ b/xcp_d/tests/data/ds001419-fmriprep_nifti_outputs.txt
@@ -13,6 +13,7 @@ xcp_d/space-MNI152NLin2009cAsym_atlas-Schaefer817_res-2_dseg.nii.gz
 xcp_d/space-MNI152NLin2009cAsym_atlas-Schaefer917_res-2_dseg.nii.gz
 xcp_d/space-MNI152NLin2009cAsym_atlas-subcortical_res-2_dseg.nii.gz
 xcp_d/sub-01.html
+xcp_d/sub-01_executive_summary.html
 xcp_d/logs
 xcp_d/logs/CITATION.md
 xcp_d/sub-01

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -64,7 +64,6 @@ def test_ds001419_nifti(datasets, output_dir, working_dir):
         run_uuid=run_uuid,
         config=pkgrf("xcp_d", "data/reports.yml"),
         packagename="xcp_d",
-        dcan_qc=opts.dcan_qc,
     )
 
     output_list_file = os.path.join(test_data_dir, "ds001419-fmriprep_nifti_outputs.txt")
@@ -136,7 +135,6 @@ def test_ds001419_cifti(datasets, output_dir, working_dir):
         run_uuid=run_uuid,
         config=pkgrf("xcp_d", "data/reports.yml"),
         packagename="xcp_d",
-        dcan_qc=opts.dcan_qc,
     )
 
     output_list_file = os.path.join(test_data_dir, "ds001419-fmriprep_cifti_outputs.txt")
@@ -224,7 +222,6 @@ def test_ds001419_cifti_t2wonly(datasets, output_dir, working_dir):
         run_uuid=run_uuid,
         config=pkgrf("xcp_d", "data/reports.yml"),
         packagename="xcp_d",
-        dcan_qc=opts.dcan_qc,
     )
 
     output_list_file = os.path.join(test_data_dir, "ds001419-fmriprep_cifti_t2wonly_outputs.txt")
@@ -337,7 +334,6 @@ def test_nibabies(datasets, output_dir, working_dir):
         run_uuid=run_uuid,
         config=pkgrf("xcp_d", "data/reports.yml"),
         packagename="xcp_d",
-        dcan_qc=opts.dcan_qc,
     )
 
     output_list_file = os.path.join(test_data_dir, "nibabies_outputs.txt")


### PR DESCRIPTION
Closes #875.

## Changes proposed in this pull request

- Generate the executive summary even when `--dcan-qc` isn't used.

