### PR TITLE
Correct ABCD/HCP surface ingression

### DIFF
--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -812,6 +812,7 @@ class _CiftiCreateDenseScalarInputSpec(CommandLineInputSpec):
     out_file = File(
         exists=False,
         mandatory=False,
+        genfile=True,
         argstr="%s",
         position=0,
         desc="The CIFTI output.",
@@ -849,7 +850,7 @@ class _CiftiCreateDenseScalarInputSpec(CommandLineInputSpec):
 class _CiftiCreateDenseScalarOutputSpec(TraitedSpec):
     """Output specification for the CiftiCreateDenseScalar command."""
 
-    out_file = File(exists=True, genfile=True, desc="output CIFTI file")
+    out_file = File(exists=True, desc="output CIFTI file")
 
 
 class CiftiCreateDenseScalar(WBCommand):

--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -812,7 +812,6 @@ class _CiftiCreateDenseScalarInputSpec(CommandLineInputSpec):
     out_file = File(
         exists=False,
         mandatory=False,
-        genfile=True,
         argstr="%s",
         position=0,
         desc="The CIFTI output.",
@@ -883,7 +882,9 @@ class CiftiCreateDenseScalar(WBCommand):
         if name != "out_file":
             return None
 
-        if isdefined(self.inputs.volume_data):
+        if isdefined(self.inputs.out_file):
+            return self.inputs.out_file
+        elif isdefined(self.inputs.volume_data):
             _, fname, _ = split_filename(self.inputs.volume_data)
         else:
             _, fname, _ = split_filename(self.inputs.left_metric)

--- a/xcp_d/utils/dcan2fmriprep.py
+++ b/xcp_d/utils/dcan2fmriprep.py
@@ -166,7 +166,6 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
 
         # Collect surface files to copy
         surfaces_dict = collect_surfaces(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents)
-        copy_dictionary = {**copy_dictionary, **surfaces_dict}
         LOGGER.info("Finished collecting anatomical files")
 
         # Get masks to be used to extract confounds
@@ -323,6 +322,7 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
         write_json(dataset_description_dict, dataset_description_fmriprep)
 
     # Write out the mapping from DCAN to fMRIPrep
+    copy_dictionary = {**copy_dictionary, **surfaces_dict}
     scans_dict = {}
     for key, values in copy_dictionary.items():
         for item in values:

--- a/xcp_d/utils/dcan2fmriprep.py
+++ b/xcp_d/utils/dcan2fmriprep.py
@@ -116,6 +116,11 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
     if not ses_entities:
         raise FileNotFoundError(f"No session volumes found in {os.path.join(in_dir, sub_ent)}")
 
+    dataset_description_fmriprep = os.path.join(out_dir, "dataset_description.json")
+    if os.path.isfile(dataset_description_fmriprep):
+        LOGGER.info("Converted dataset folder already exists. Skipping conversion.")
+        return
+
     # A dictionary of mappings from HCP derivatives to fMRIPrep derivatives.
     # Values will be lists, to allow one-to-many mappings.
     copy_dictionary = {}
@@ -129,11 +134,6 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
         LOGGER.info(f"Processing {ses_ent}")
         subses_ents = f"{sub_ent}_{ses_ent}"
         session_dir_fmriprep = os.path.join(subject_dir_fmriprep, ses_ent)
-
-        if os.path.isdir(session_dir_fmriprep):
-            LOGGER.info("Converted session folder already exists. Skipping conversion.")
-            continue
-
         anat_dir_orig = os.path.join(in_dir, sub_ent, ses_ent, "files", "MNINonLinear")
         anat_dir_fmriprep = os.path.join(session_dir_fmriprep, "anat")
         func_dir_orig = os.path.join(anat_dir_orig, "Results")
@@ -324,12 +324,11 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
             },
         ],
     }
-    dataset_description_fmriprep = os.path.join(out_dir, "dataset_description.json")
+
     if not os.path.isfile(dataset_description_fmriprep):
         write_json(dataset_description_dict, dataset_description_fmriprep)
 
     # Write out the mapping from DCAN to fMRIPrep
-    raise Exception(morph_dict_all_ses)
     copy_dictionary = {**copy_dictionary, **morph_dict_all_ses}
     scans_dict = {}
     for key, values in copy_dictionary.items():

--- a/xcp_d/utils/dcan2fmriprep.py
+++ b/xcp_d/utils/dcan2fmriprep.py
@@ -123,6 +123,7 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
     # The identity xform is used in place of any actual ones.
     identity_xfm = pkgrf("xcp_d", "/data/transform/itkIdentityTransform.txt")
     copy_dictionary[identity_xfm] = []
+    morph_dict_all_ses = {}
 
     for ses_ent in ses_entities:
         LOGGER.info(f"Processing {ses_ent}")
@@ -171,6 +172,7 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
 
         # Convert morphometry files
         morphometry_dict = collect_morphs(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents)
+        morph_dict_all_ses = {**morph_dict_all_ses, **morphometry_dict}
         LOGGER.info("Finished collecting anatomical files")
 
         # Get masks to be used to extract confounds
@@ -327,7 +329,8 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
         write_json(dataset_description_dict, dataset_description_fmriprep)
 
     # Write out the mapping from DCAN to fMRIPrep
-    copy_dictionary = {**copy_dictionary, **morphometry_dict}
+    raise Exception(morph_dict_all_ses)
+    copy_dictionary = {**copy_dictionary, **morph_dict_all_ses}
     scans_dict = {}
     for key, values in copy_dictionary.items():
         for item in values:

--- a/xcp_d/utils/dcan2fmriprep.py
+++ b/xcp_d/utils/dcan2fmriprep.py
@@ -14,7 +14,8 @@ from xcp_d.utils.filemanip import ensure_list
 from xcp_d.utils.ingestion import (
     collect_anatomical_files,
     collect_confounds,
-    collect_surfaces,
+    collect_meshes,
+    collect_morphs,
     copy_files_in_dict,
     plot_bbreg,
     write_json,
@@ -165,7 +166,11 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
         copy_dictionary = {**copy_dictionary, **anat_dict}
 
         # Collect surface files to copy
-        surfaces_dict = collect_surfaces(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents)
+        mesh_dict = collect_meshes(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents)
+        copy_dictionary = {**copy_dictionary, **mesh_dict}
+
+        # Convert morphometry files
+        morphometry_dict = collect_morphs(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents)
         LOGGER.info("Finished collecting anatomical files")
 
         # Get masks to be used to extract confounds
@@ -322,7 +327,7 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
         write_json(dataset_description_dict, dataset_description_fmriprep)
 
     # Write out the mapping from DCAN to fMRIPrep
-    copy_dictionary = {**copy_dictionary, **surfaces_dict}
+    copy_dictionary = {**copy_dictionary, **morphometry_dict}
     scans_dict = {}
     for key, values in copy_dictionary.items():
         for item in values:

--- a/xcp_d/utils/hcp2fmriprep.py
+++ b/xcp_d/utils/hcp2fmriprep.py
@@ -13,7 +13,8 @@ from xcp_d.utils.filemanip import ensure_list
 from xcp_d.utils.ingestion import (
     collect_anatomical_files,
     collect_confounds,
-    collect_surfaces,
+    collect_meshes,
+    collect_morphs,
     copy_files_in_dict,
     plot_bbreg,
     write_json,
@@ -179,8 +180,12 @@ def convert_hcp_to_bids_single_subject(in_dir, out_dir, sub_ent):
     anat_dict = collect_anatomical_files(anat_dir_orig, anat_dir_fmriprep, base_anatomical_ents)
     copy_dictionary = {**copy_dictionary, **anat_dict}
 
-    # Collect surface files to copy
-    surfaces_dict = collect_surfaces(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents)
+    # Collect mesh files to copy
+    mesh_dict = collect_meshes(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents)
+    copy_dictionary = {**copy_dictionary, **mesh_dict}
+
+    # Convert morphometry files
+    morphometry_dict = collect_morphs(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents)
     LOGGER.info("Finished collecting anatomical files")
 
     # Collect functional files to copy
@@ -319,7 +324,7 @@ def convert_hcp_to_bids_single_subject(in_dir, out_dir, sub_ent):
         write_json(dataset_description_dict, dataset_description_fmriprep)
 
     # Write out the mapping from HCP to fMRIPrep
-    copy_dictionary = {**copy_dictionary, **surfaces_dict}
+    copy_dictionary = {**copy_dictionary, **morphometry_dict}
     scans_dict = {}
     for key, values in copy_dictionary.items():
         for item in values:

--- a/xcp_d/utils/hcp2fmriprep.py
+++ b/xcp_d/utils/hcp2fmriprep.py
@@ -181,7 +181,6 @@ def convert_hcp_to_bids_single_subject(in_dir, out_dir, sub_ent):
 
     # Collect surface files to copy
     surfaces_dict = collect_surfaces(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents)
-    copy_dictionary = {**copy_dictionary, **surfaces_dict}
     LOGGER.info("Finished collecting anatomical files")
 
     # Collect functional files to copy
@@ -320,6 +319,7 @@ def convert_hcp_to_bids_single_subject(in_dir, out_dir, sub_ent):
         write_json(dataset_description_dict, dataset_description_fmriprep)
 
     # Write out the mapping from HCP to fMRIPrep
+    copy_dictionary = {**copy_dictionary, **surfaces_dict}
     scans_dict = {}
     for key, values in copy_dictionary.items():
         for item in values:

--- a/xcp_d/utils/hcp2fmriprep.py
+++ b/xcp_d/utils/hcp2fmriprep.py
@@ -143,7 +143,9 @@ def convert_hcp_to_bids_single_subject(in_dir, out_dir, sub_ent):
     func_dir_fmriprep = os.path.join(subject_dir_fmriprep, "func")
     work_dir = os.path.join(subject_dir_fmriprep, "work")
 
-    if os.path.isdir(func_dir_fmriprep):
+    dataset_description_fmriprep = os.path.join(out_dir, "dataset_description.json")
+
+    if os.path.isfile(dataset_description_fmriprep):
         LOGGER.info("Converted dataset already exists. Skipping conversion.")
         return
 
@@ -319,7 +321,7 @@ def convert_hcp_to_bids_single_subject(in_dir, out_dir, sub_ent):
             },
         ],
     }
-    dataset_description_fmriprep = os.path.join(out_dir, "dataset_description.json")
+
     if not os.path.isfile(dataset_description_fmriprep):
         write_json(dataset_description_dict, dataset_description_fmriprep)
 

--- a/xcp_d/utils/ingestion.py
+++ b/xcp_d/utils/ingestion.py
@@ -95,6 +95,10 @@ def collect_morphs(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents):
             f"{subses_ents}_space-fsLR_den-32k_{out_str}.dscalar.nii",
         )
 
+        if not os.path.isfile(lh_file) or not os.path.isfile(rh_file):
+            LOGGER.warning(f"File(s) DNE: {in_str}")
+            continue
+
         interface = CiftiCreateDenseScalar(
             left_metric=lh_file,
             right_metric=rh_file,

--- a/xcp_d/utils/ingestion.py
+++ b/xcp_d/utils/ingestion.py
@@ -217,7 +217,8 @@ def extract_mean_signal(mask, nifti, work_dir):
 def write_json(data, outfile):
     """Write dictionary to JSON file."""
     with open(outfile, "w") as f:
-        json.dump(data, f)
+        json.dump(data, f, sortkeys=True, indent=4)
+
     return outfile
 
 

--- a/xcp_d/utils/ingestion.py
+++ b/xcp_d/utils/ingestion.py
@@ -48,11 +48,35 @@ def collect_anatomical_files(anat_dir_orig, anat_dir_fmriprep, base_anatomical_e
     return copy_dictionary
 
 
-def collect_surfaces(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents):
-    """Collect surface files from ABCD or HCP-YA derivatives an convert to CIFTIs."""
+def collect_meshes(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents):
+    """Collect mesh files from ABCD or HCP-YA derivatives."""
     SURFACE_DICT = {
-        ".pial.32k_fs_LR.surf.gii": "pial",
-        ".white.32k_fs_LR.surf.gii": "white",
+        "{hemi}.pial.32k_fs_LR.surf.gii": "hemi-{hemi}_pial.surf.gii",
+        "{hemi}.white.32k_fs_LR.surf.gii": "hemi-{hemi}_smoothwm.surf.gii",
+    }
+
+    fsaverage_dir_orig = os.path.join(anat_dir_orig, "fsaverage_LR32k")
+    copy_dictionary = {}
+    for in_str, out_str in SURFACE_DICT.items():
+        for hemi in ["L", "R"]:
+            hemi_in_str = in_str.format(hemi=hemi)
+            hemi_out_str = out_str.format(hemi=hemi)
+            surf_orig = os.path.join(fsaverage_dir_orig, f"{sub_id}.{hemi_in_str}")
+            surf_fmriprep = os.path.join(
+                anat_dir_fmriprep,
+                f"{subses_ents}_space-fsLR_den-32k_{hemi_out_str}",
+            )
+            if os.path.isfile(surf_orig):
+                copy_dictionary[surf_orig] = [surf_fmriprep]
+            else:
+                LOGGER.warning(f"File DNE: {surf_orig}")
+
+    return copy_dictionary
+
+
+def collect_morphs(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents):
+    """Collect and convert morphometry files to CIFTIs."""
+    SURFACE_DICT = {
         ".thickness.32k_fs_LR.shape.gii": "thickness",
         ".corrThickness.32k_fs_LR.shape.gii": "desc-corrected_thickness",
         ".curvature.32k_fs_LR.shape.gii": "curv",

--- a/xcp_d/utils/ingestion.py
+++ b/xcp_d/utils/ingestion.py
@@ -49,9 +49,6 @@ def collect_anatomical_files(anat_dir_orig, anat_dir_fmriprep, base_anatomical_e
 def collect_surfaces(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents):
     """Collect surface files from ABCD or HCP-YA derivatives."""
     SURFACE_DICT = {
-        "{hemi}.midthickness.32k_fs_LR.surf.gii": "hemi-{hemi}_desc-hcp_midthickness.surf.gii",
-        "{hemi}.inflated.32k_fs_LR.surf.gii": "hemi-{hemi}_desc-hcp_inflated.surf.gii",
-        "{hemi}.very_inflated.32k_fs_LR.surf.gii": "hemi-{hemi}_desc-hcp_vinflated.surf.gii",
         "{hemi}.pial.32k_fs_LR.surf.gii": "hemi-{hemi}_pial.surf.gii",
         "{hemi}.white.32k_fs_LR.surf.gii": "hemi-{hemi}_smoothwm.surf.gii",
         "{hemi}.thickness.32k_fs_LR.shape.gii": "hemi-{hemi}_thickness.shape.gii",

--- a/xcp_d/utils/ingestion.py
+++ b/xcp_d/utils/ingestion.py
@@ -77,12 +77,12 @@ def collect_meshes(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents):
 def collect_morphs(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents):
     """Collect and convert morphometry files to CIFTIs."""
     SURFACE_DICT = {
-        ".thickness.32k_fs_LR.shape.gii": "thickness",
-        ".corrThickness.32k_fs_LR.shape.gii": "desc-corrected_thickness",
-        ".curvature.32k_fs_LR.shape.gii": "curv",
-        ".sulc.32k_fs_LR.shape.gii": "sulc",
-        ".MyelinMap.32k_fs_LR.func.gii": "myelinw",
-        ".SmoothedMyelinMap.32k_fs_LR.func.gii": "desc-smoothed_myelinw",
+        "thickness.32k_fs_LR.shape.gii": "thickness",
+        "corrThickness.32k_fs_LR.shape.gii": "desc-corrected_thickness",
+        "curvature.32k_fs_LR.shape.gii": "curv",
+        "sulc.32k_fs_LR.shape.gii": "sulc",
+        "MyelinMap.32k_fs_LR.func.gii": "myelinw",
+        "SmoothedMyelinMap.32k_fs_LR.func.gii": "desc-smoothed_myelinw",
     }
 
     fsaverage_dir_orig = os.path.join(anat_dir_orig, "fsaverage_LR32k")
@@ -92,11 +92,11 @@ def collect_morphs(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents):
         rh_file = os.path.join(fsaverage_dir_orig, f"{sub_id}.R.{in_str}")
         out_file = os.path.join(
             anat_dir_fmriprep,
-            f"{subses_ents}_space-fsLR_den-32k_{out_str}.dscalar.nii",
+            f"{subses_ents}_space-fsLR_den-91k_{out_str}.dscalar.nii",
         )
 
         if not os.path.isfile(lh_file) or not os.path.isfile(rh_file):
-            LOGGER.warning(f"File(s) DNE: {in_str}")
+            LOGGER.warning(f"File(s) DNE:\n\t{lh_file}\n\t{rh_file}")
             continue
 
         interface = CiftiCreateDenseScalar(
@@ -105,7 +105,6 @@ def collect_morphs(anat_dir_orig, anat_dir_fmriprep, sub_id, subses_ents):
             out_file=out_file,
         )
         interface.run()
-        assert os.path.isfile(out_file), f"File DNE: {out_file}"
         mapping_dictionary[lh_file] = out_file
         mapping_dictionary[rh_file] = out_file
 

--- a/xcp_d/utils/ingestion.py
+++ b/xcp_d/utils/ingestion.py
@@ -217,7 +217,7 @@ def extract_mean_signal(mask, nifti, work_dir):
 def write_json(data, outfile):
     """Write dictionary to JSON file."""
     with open(outfile, "w") as f:
-        json.dump(data, f, sortkeys=True, indent=4)
+        json.dump(data, f, sort_keys=True, indent=4)
 
     return outfile
 

--- a/xcp_d/workflows/connectivity.py
+++ b/xcp_d/workflows/connectivity.py
@@ -294,6 +294,9 @@ def init_parcellate_surfaces_wf(
         "sulcal_depth": "sulc",
         "sulcal_curv": "curv",
         "cortical_thickness": "thickness",
+        "cortical_thickness_corr": "thicknessCorrected",
+        "myelin": "myelin",
+        "myelin_smoothed": "myelinSmoothed",
     }
 
     inputnode = pe.Node(


### PR DESCRIPTION
Hopefully fixes #923. 

## Changes proposed in this pull request

- Convert GIFTI morphometry files to CIFTIs as part of ABCD/HCP ingression.
- Use `out_file` input to set the output filename for `CiftiCreateDenseScalar` when provided.
- Account for multi-session ABCD anatomical data.