### PR TITLE
Use output path when provided in ApplyTransforms interface

### DIFF
--- a/xcp_d/interfaces/ants.py
+++ b/xcp_d/interfaces/ants.py
@@ -10,6 +10,7 @@ from nipype.interfaces.base import (
     InputMultiPath,
     Str,
     TraitedSpec,
+    isdefined,
     traits,
 )
 from niworkflows.interfaces.fixes import (
@@ -186,12 +187,13 @@ class ApplyTransforms(FixHeaderApplyTransforms):
     input_spec = _ApplyTransformsInputSpec
 
     def _run_interface(self, runtime):
-        # Run normally
-        self.inputs.output_image = fname_presuffix(
-            self.inputs.input_image,
-            suffix="_trans.nii.gz",
-            newpath=runtime.cwd,
-            use_ext=False,
-        )
+        if not isdefined(self.inputs.output_image):
+            self.inputs.output_image = fname_presuffix(
+                self.inputs.input_image,
+                suffix="_trans.nii.gz",
+                newpath=runtime.cwd,
+                use_ext=False,
+            )
+
         runtime = super(ApplyTransforms, self)._run_interface(runtime)
         return runtime


### PR DESCRIPTION
Closes None.

## Changes proposed in this pull request

- Currently, ApplyTransforms overwrites the output image input no matter what. This change uses that input for the output filename, but only when it is provided. This shouldn't affect anything in XCP-D, since XCP-D relies on the auto-generated output filename, but it makes it easier to use ApplyTransforms elsewhere.