### PR TITLE
Generate executive summary figures without `--dcan-qc`

### DIFF
--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -90,7 +90,6 @@ def test_postprocess_anat_wf(ds001419_data, tmp_path_factory):
         t1w_available=True,
         t2w_available=True,
         target_space="MNI152NLin2009cAsym",
-        dcan_qc=False,
         omp_nthreads=1,
         mem_gb=0.1,
         name="postprocess_anat_wf",

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -46,7 +46,6 @@ def init_postprocess_anat_wf(
     t1w_available,
     t2w_available,
     target_space,
-    dcan_qc,
     omp_nthreads,
     mem_gb,
     name="postprocess_anat_wf",
@@ -68,7 +67,6 @@ def init_postprocess_anat_wf(
                 t1w_available=True,
                 t2w_available=True,
                 target_space="MNI152NLin6Asym",
-                dcan_qc=True,
                 omp_nthreads=1,
                 mem_gb=0.1,
                 name="postprocess_anat_wf",
@@ -84,7 +82,6 @@ def init_postprocess_anat_wf(
         True if a preprocessed T2w is available, False if not.
     target_space : :obj:`str`
         Target NIFTI template for T1w.
-    %(dcan_qc)s
     %(omp_nthreads)s
     %(mem_gb)s
     %(name)s
@@ -279,33 +276,32 @@ def init_postprocess_anat_wf(
             ])
             # fmt:on
 
-    if dcan_qc:
-        execsummary_anatomical_plots_wf = init_execsummary_anatomical_plots_wf(
-            t1w_available=t1w_available,
-            t2w_available=t2w_available,
-            output_dir=output_dir,
-            name="execsummary_anatomical_plots_wf",
-        )
+    execsummary_anatomical_plots_wf = init_execsummary_anatomical_plots_wf(
+        t1w_available=t1w_available,
+        t2w_available=t2w_available,
+        output_dir=output_dir,
+        name="execsummary_anatomical_plots_wf",
+    )
 
+    # fmt:off
+    workflow.connect([
+        (inputnode, execsummary_anatomical_plots_wf, [("template", "inputnode.template")]),
+    ])
+    # fmt:on
+
+    if t1w_available:
         # fmt:off
         workflow.connect([
-            (inputnode, execsummary_anatomical_plots_wf, [("template", "inputnode.template")]),
+            (ds_t1w_std, execsummary_anatomical_plots_wf, [("out_file", "inputnode.t1w")]),
         ])
         # fmt:on
 
-        if t1w_available:
-            # fmt:off
-            workflow.connect([
-                (ds_t1w_std, execsummary_anatomical_plots_wf, [("out_file", "inputnode.t1w")]),
-            ])
-            # fmt:on
-
-        if t2w_available:
-            # fmt:off
-            workflow.connect([
-                (ds_t2w_std, execsummary_anatomical_plots_wf, [("out_file", "inputnode.t2w")]),
-            ])
-            # fmt:on
+    if t2w_available:
+        # fmt:off
+        workflow.connect([
+            (ds_t2w_std, execsummary_anatomical_plots_wf, [("out_file", "inputnode.t2w")]),
+        ])
+        # fmt:on
 
     return workflow
 

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -520,7 +520,6 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
         t1w_available=t1w_available,
         t2w_available=t2w_available,
         target_space=target_space,
-        dcan_qc=dcan_qc,
         omp_nthreads=omp_nthreads,
         mem_gb=1,
         name="postprocess_anat_wf",

--- a/xcp_d/workflows/bold.py
+++ b/xcp_d/workflows/bold.py
@@ -570,27 +570,26 @@ def init_postprocess_nifti_wf(
         # fmt:on
 
     # executive summary workflow
-    if dcan_qc:
-        execsummary_functional_plots_wf = init_execsummary_functional_plots_wf(
-            preproc_nifti=bold_file,
-            t1w_available=t1w_available,
-            t2w_available=t2w_available,
-            output_dir=output_dir,
-            layout=layout,
-            name="execsummary_functional_plots_wf",
-        )
+    execsummary_functional_plots_wf = init_execsummary_functional_plots_wf(
+        preproc_nifti=bold_file,
+        t1w_available=t1w_available,
+        t2w_available=t2w_available,
+        output_dir=output_dir,
+        layout=layout,
+        name="execsummary_functional_plots_wf",
+    )
 
-        # fmt:off
-        workflow.connect([
-            # Use inputnode for executive summary instead of downcast_data
-            # because T1w is used as name source.
-            (inputnode, execsummary_functional_plots_wf, [
-                ("boldref", "inputnode.boldref"),
-                ("t1w", "inputnode.t1w"),
-                ("t2w", "inputnode.t2w"),
-            ]),
-        ])
-        # fmt:on
+    # fmt:off
+    workflow.connect([
+        # Use inputnode for executive summary instead of downcast_data
+        # because T1w is used as name source.
+        (inputnode, execsummary_functional_plots_wf, [
+            ("boldref", "inputnode.boldref"),
+            ("t1w", "inputnode.t1w"),
+            ("t2w", "inputnode.t2w"),
+        ]),
+    ])
+    # fmt:on
 
     return workflow
 

--- a/xcp_d/workflows/cifti.py
+++ b/xcp_d/workflows/cifti.py
@@ -544,29 +544,28 @@ def init_postprocess_cifti_wf(
     # fmt:on
 
     # executive summary workflow
-    if dcan_qc:
-        execsummary_functional_plots_wf = init_execsummary_functional_plots_wf(
-            preproc_nifti=run_data["nifti_file"],
-            t1w_available=t1w_available,
-            t2w_available=t2w_available,
-            output_dir=output_dir,
-            layout=layout,
-            name="execsummary_functional_plots_wf",
-        )
+    execsummary_functional_plots_wf = init_execsummary_functional_plots_wf(
+        preproc_nifti=run_data["nifti_file"],
+        t1w_available=t1w_available,
+        t2w_available=t2w_available,
+        output_dir=output_dir,
+        layout=layout,
+        name="execsummary_functional_plots_wf",
+    )
 
+    # Use inputnode for executive summary instead of downcast_data
+    # because T1w is used as name source.
+    # fmt:off
+    workflow.connect([
         # Use inputnode for executive summary instead of downcast_data
         # because T1w is used as name source.
-        # fmt:off
-        workflow.connect([
-            # Use inputnode for executive summary instead of downcast_data
-            # because T1w is used as name source.
-            (inputnode, execsummary_functional_plots_wf, [
-                ("boldref", "inputnode.boldref"),
-                ("t1w", "inputnode.t1w"),
-                ("t2w", "inputnode.t2w"),
-            ]),
-        ])
-        # fmt:on
+        (inputnode, execsummary_functional_plots_wf, [
+            ("boldref", "inputnode.boldref"),
+            ("t1w", "inputnode.t1w"),
+            ("t2w", "inputnode.t2w"),
+        ]),
+    ])
+    # fmt:on
 
     return workflow
 

--- a/xcp_d/workflows/plotting.py
+++ b/xcp_d/workflows/plotting.py
@@ -358,75 +358,75 @@ def init_qc_report_wf(
         ])
         # fmt:on
 
-        # Generate preprocessing and postprocessing carpet plots.
-        plot_execsummary_carpets_dcan = pe.Node(
-            QCPlotsES(TR=TR, standardize=params == "none"),
-            name="plot_execsummary_carpets_dcan",
-            mem_gb=mem_gb,
-            n_procs=omp_nthreads,
-        )
+    # Generate preprocessing and postprocessing carpet plots.
+    plot_execsummary_carpets_dcan = pe.Node(
+        QCPlotsES(TR=TR, standardize=params == "none"),
+        name="plot_execsummary_carpets_dcan",
+        mem_gb=mem_gb,
+        n_procs=omp_nthreads,
+    )
 
+    # fmt:off
+    workflow.connect([
+        (inputnode, plot_execsummary_carpets_dcan, [
+            ("preprocessed_bold", "preprocessed_bold"),
+            ("uncensored_denoised_bold", "uncensored_denoised_bold"),
+            ("interpolated_filtered_bold", "interpolated_filtered_bold"),
+            ("filtered_motion", "filtered_motion"),
+            ("run_index", "run_index"),
+        ]),
+    ])
+    # fmt:on
+
+    if not cifti:
         # fmt:off
         workflow.connect([
-            (inputnode, plot_execsummary_carpets_dcan, [
-                ("preprocessed_bold", "preprocessed_bold"),
-                ("uncensored_denoised_bold", "uncensored_denoised_bold"),
-                ("interpolated_filtered_bold", "interpolated_filtered_bold"),
-                ("filtered_motion", "filtered_motion"),
-                ("run_index", "run_index"),
+            (inputnode, plot_execsummary_carpets_dcan, [("bold_mask", "mask")]),
+            (warp_dseg_to_bold, plot_execsummary_carpets_dcan, [
+                ("output_image", "seg_data"),
             ]),
         ])
         # fmt:on
 
-        if not cifti:
-            # fmt:off
-            workflow.connect([
-                (inputnode, plot_execsummary_carpets_dcan, [("bold_mask", "mask")]),
-                (warp_dseg_to_bold, plot_execsummary_carpets_dcan, [
-                    ("output_image", "seg_data"),
-                ]),
-            ])
-            # fmt:on
+    ds_preproc_execsummary_carpet_dcan = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            dismiss_entities=["den"],
+            datatype="figures",
+            desc="preprocESQC",
+        ),
+        name="ds_preproc_execsummary_carpet_dcan",
+        run_without_submitting=True,
+    )
 
-        ds_preproc_execsummary_carpet_dcan = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                dismiss_entities=["den"],
-                datatype="figures",
-                desc="preprocESQC",
-            ),
-            name="ds_preproc_execsummary_carpet_dcan",
-            run_without_submitting=True,
-        )
+    # fmt:off
+    workflow.connect([
+        (inputnode, ds_preproc_execsummary_carpet_dcan, [("name_source", "source_file")]),
+        (plot_execsummary_carpets_dcan, ds_preproc_execsummary_carpet_dcan, [
+            ("before_process", "in_file"),
+        ]),
+    ])
+    # fmt:on
 
-        # fmt:off
-        workflow.connect([
-            (inputnode, ds_preproc_execsummary_carpet_dcan, [("name_source", "source_file")]),
-            (plot_execsummary_carpets_dcan, ds_preproc_execsummary_carpet_dcan, [
-                ("before_process", "in_file"),
-            ]),
-        ])
-        # fmt:on
+    ds_postproc_execsummary_carpet_dcan = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            dismiss_entities=["den"],
+            datatype="figures",
+            desc="postprocESQC",
+        ),
+        name="ds_postproc_execsummary_carpet_dcan",
+        run_without_submitting=True,
+    )
 
-        ds_postproc_execsummary_carpet_dcan = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                dismiss_entities=["den"],
-                datatype="figures",
-                desc="postprocESQC",
-            ),
-            name="ds_postproc_execsummary_carpet_dcan",
-            run_without_submitting=True,
-        )
-
-        # fmt:off
-        workflow.connect([
-            (inputnode, ds_postproc_execsummary_carpet_dcan, [("name_source", "source_file")]),
-            (plot_execsummary_carpets_dcan, ds_postproc_execsummary_carpet_dcan, [
-                ("after_process", "in_file"),
-            ]),
-        ])
-        # fmt:on
+    # fmt:off
+    workflow.connect([
+        (inputnode, ds_postproc_execsummary_carpet_dcan, [("name_source", "source_file")]),
+        (plot_execsummary_carpets_dcan, ds_postproc_execsummary_carpet_dcan, [
+            ("after_process", "in_file"),
+        ]),
+    ])
+    # fmt:on
 
     if not cifti:
         # fmt:off


### PR DESCRIPTION
Closes none, but related to #933.

## Changes proposed in this pull request

Even though the executive summary is generated no matter what, the actual figures that go into are not currently being created if `--dcan-qc` isn't used. This PR creates most of the executive summary's figures no matter what.