### PR TITLE
Fix resting-state plots in executive summary

### DIFF
--- a/xcp_d/data/executive_summary_templates/executive_summary.html.jinja
+++ b/xcp_d/data/executive_summary_templates/executive_summary.html.jinja
@@ -138,16 +138,15 @@
     #}
     {% include "anatomical_registration_plots.html.jinja" %}
 
-    {# Carpet/line plot for pre- and post-regression, concatenate across runs. #}
-    {% include "concatenated_task_static_plots.html.jinja" %}
-
     {#
-        Task static plots. One section per run of each task.
-        1. Task in T1
-        2. T1 in Task
-        3. BOLD mean(?) image on the left
-        4. BOLD reference image on the left
-        3/4. Pre and post regression carpet/line plots on right.
+        "Functional Data" section, with BOLD figures.
+        1. Concatenated resting-state carpet plots.
+        2. One section per run of each task.
+            1. Task in T1
+            2. T1 in Task
+            3. BOLD mean(?) image on the left
+            4. BOLD reference image on the left
+            3/4. Pre and post regression carpet/line plots on right.
     #}
     {% include "task_static_plots.html.jinja" %}
 

--- a/xcp_d/data/executive_summary_templates/task_static_plots.html.jinja
+++ b/xcp_d/data/executive_summary_templates/task_static_plots.html.jinja
@@ -4,8 +4,7 @@
     Inputs:
     - concatenated_rest_files{"preproc_carpet"}
     - concatenated_rest_files{"postproc_carpet"}
-    - task_files[]{"task"}
-    - task_files[]{"run"}
+    - task_files[]{"key"}
     - task_files[]{"registration_files"}
     - task_files[]{"registration_titles"}
     - task_files[]{"bold"}
@@ -31,8 +30,7 @@
             <div>
                 {% for run_dict in task_files %}
 
-                    {% set task = run_dict["task"] %}
-                    {% set run = run_dict["run"] %}
+                    {% set key = run_dict["key"] %}
                     {% set registration_files = run_dict["registration_files"] %}
                     {% set registration_titles = run_dict["registration_titles"] %}
                     {% set bold = run_dict["bold"] %}
@@ -44,7 +42,7 @@
                         Add the task name for the next few rows.
                     #}
                     <div class="w3-row"></div>
-                        <div class="w3-left label2">task-{{ task }} run-{{ run }}:</div>
+                        <div class="w3-left label2">{{ key }}:</div>
                     <div class="w3-row"></div>
 
                     {# Full rows for registration files #}

--- a/xcp_d/data/executive_summary_templates/task_static_plots.html.jinja
+++ b/xcp_d/data/executive_summary_templates/task_static_plots.html.jinja
@@ -2,6 +2,8 @@
     Start the tasks section and  put in the column headings for the task-specific data.
 
     Inputs:
+    - concatenated_rest_files{"preproc_carpet"}
+    - concatenated_rest_files{"postproc_carpet"}
     - task_files[]{"task"}
     - task_files[]{"run"}
     - task_files[]{"registration_files"}
@@ -22,6 +24,10 @@
     <div class="w3-container">
         <div class="w3-row-padding">
             <div class="w3-center"><h2>Functional Data</h2></div>
+
+            {# Carpet/line plot for pre- and post-regression, concatenate across runs. #}
+            {% include "concatenated_task_static_plots.html.jinja" %}
+
             <div>
                 {% for run_dict in task_files %}
 

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -242,10 +242,9 @@ class ExecutiveSummary(object):
 
                 task_file_figures["registration_files"].append(found_file)
 
-            # If there are no registration files, then this "run" was produced by the
-            # concatenation workflow.
+            # If there no mean BOLD figure, then the "run" was made by the concatenation workflow.
             # Skip the concatenated resting-state scan, since it has its own section.
-            if query["task"] == "rest" and not task_file_figures["registration_files"]:
+            if query["task"] == "rest" and not task_file_figures["bold"]:
                 continue
 
             task_files.append(task_file_figures)

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -182,7 +182,7 @@ class ExecutiveSummary(object):
         }
         concatenated_rest_files["preproc_carpet"] = self._get_bids_file(query)
 
-        query["desc"] = "postcarpetplot"
+        query["desc"] = "postprocESQC"
         concatenated_rest_files["postproc_carpet"] = self._get_bids_file(query)
 
         self.concatenated_rest_files_ = concatenated_rest_files

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -4,6 +4,8 @@ import os
 import re
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
 from bids.layout import BIDSLayout, Query
 from bs4 import BeautifulSoup
 from jinja2 import Environment, FileSystemLoader, Markup
@@ -166,10 +168,17 @@ class ExecutiveSummary(object):
         task_entity_sets = []
         for entity_set in unique_entity_sets:
             for entity in ORDERING:
-                entity_set[entity] = entity_set.get(entity, Query.NONE)
+                entity_set[entity] = entity_set.get(entity, np.nan)
 
             task_entity_sets.append(entity_set)
 
+        # Now sort the entity sets by each entity
+        task_entity_sets = pd.DataFrame(task_entity_sets)
+        task_entity_sets = task_entity_sets.sort_values(by=task_entity_sets.columns.tolist())
+        task_entity_sets = task_entity_sets.fillna(Query.NONE)
+        task_entity_sets = task_entity_sets.to_dict(orient="records")
+
+        # Collect figures for concatenated resting-state data (if any)
         concatenated_rest_files = {}
 
         query = {

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -215,7 +215,7 @@ class ExecutiveSummary(object):
             # Convert any floats in the name to ints
             temp_dict = task_entity_namer[i_set]
             temp_dict = {
-                key: int(value) if np.isscalar(value) and value.is_integer() else value
+                key: int(value) if np.isscalar(value) and float(value).is_integer() else value
                 for key, value in temp_dict.items()
             }
             task_file_figures["key"] = "_".join([f"{k}-{v}" for k, v in temp_dict.items()])

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -242,6 +242,12 @@ class ExecutiveSummary(object):
 
                 task_file_figures["registration_files"].append(found_file)
 
+            # If there are no registration files, then this "run" was produced by the
+            # concatenation workflow.
+            # Skip the concatenated resting-state scan, since it has its own section.
+            if query["task"] == "rest" and not task_file_figures["registration_files"]:
+                continue
+
             task_files.append(task_file_figures)
 
         # Sort the files by the desired key

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -215,10 +215,9 @@ class ExecutiveSummary(object):
             # Convert any floats in the name to ints
             temp_dict = task_entity_namer[i_set]
             temp_dict = {
-                key: int(value) if isinstance(value, float) and value.is_integer() else value
+                key: int(value) if np.isscalar(value) and value.is_integer() else value
                 for key, value in temp_dict.items()
             }
-            raise Exception(temp_dict)
             task_file_figures["key"] = "_".join([f"{k}-{v}" for k, v in temp_dict.items()])
 
             query = {

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -213,11 +213,13 @@ class ExecutiveSummary(object):
             task_file_figures = task_entity_set.copy()
 
             # Convert any floats in the name to ints
-            temp_dict = task_entity_namer[i_set]
-            temp_dict = {
-                key: int(value) if np.isscalar(value) and float(value).is_integer() else value
-                for key, value in temp_dict.items()
-            }
+            temp_dict = {}
+            for k, v in task_entity_namer[i_set].items():
+                try:
+                    temp_dict[k] = int(v)
+                except ValueError:
+                    temp_dict[k] = v
+
             task_file_figures["key"] = "_".join([f"{k}-{v}" for k, v in temp_dict.items()])
 
             query = {

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -146,6 +146,24 @@ class ExecutiveSummary(object):
 
         self.structural_files_ = structural_files
 
+        # Collect figures for concatenated resting-state data (if any)
+        concatenated_rest_files = {}
+
+        query = {
+            "subject": self.subject_id,
+            "task": "rest",
+            "run": Query.NONE,
+            "desc": "preprocESQC",
+            "suffix": "bold",
+            "extension": ".svg",
+        }
+        concatenated_rest_files["preproc_carpet"] = self._get_bids_file(query)
+
+        query["desc"] = "postprocESQC"
+        concatenated_rest_files["postproc_carpet"] = self._get_bids_file(query)
+
+        self.concatenated_rest_files_ = concatenated_rest_files
+
         # Determine the unique entity-sets for the task data.
         postproc_files = self.layout.get(
             subject=self.subject_id,
@@ -188,24 +206,6 @@ class ExecutiveSummary(object):
         # Convert back to dictionary
         task_entity_sets = task_entity_sets.to_dict(orient="records")
         task_entity_namer = task_entity_namer.to_dict(orient="records")
-
-        # Collect figures for concatenated resting-state data (if any)
-        concatenated_rest_files = {}
-
-        query = {
-            "subject": self.subject_id,
-            "task": "rest",
-            "run": Query.NONE,
-            "desc": "preprocESQC",
-            "suffix": "bold",
-            "extension": ".svg",
-        }
-        concatenated_rest_files["preproc_carpet"] = self._get_bids_file(query)
-
-        query["desc"] = "postprocESQC"
-        concatenated_rest_files["postproc_carpet"] = self._get_bids_file(query)
-
-        self.concatenated_rest_files_ = concatenated_rest_files
 
         task_files = []
 

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -210,7 +210,7 @@ class ExecutiveSummary(object):
         task_files = []
 
         for i_set, task_entity_set in enumerate(task_entity_sets):
-            task_file_figures = task_entity_set.copy()
+            task_file_figures = {}
 
             # Convert any floats in the name to ints
             temp_dict = {}
@@ -220,7 +220,8 @@ class ExecutiveSummary(object):
                 except (ValueError, TypeError):
                     temp_dict[k] = v
 
-            task_file_figures["key"] = "_".join([f"{k}-{v}" for k, v in temp_dict.items()])
+            # String used for subsection headers
+            task_file_figures["key"] = " ".join([f"{k}-{v}" for k, v in temp_dict.items()])
 
             query = {
                 "subject": self.subject_id,
@@ -255,9 +256,6 @@ class ExecutiveSummary(object):
                 continue
 
             task_files.append(task_file_figures)
-
-        # Sort the files by the desired key
-        task_files = sorted(task_files, key=lambda d: d["key"])
 
         self.task_files_ = task_files
 

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -211,9 +211,14 @@ class ExecutiveSummary(object):
 
         for i_set, task_entity_set in enumerate(task_entity_sets):
             task_file_figures = task_entity_set.copy()
-            task_file_figures["key"] = "_".join(
-                [f"{k}-{v}" for k, v in task_entity_namer[i_set].items()]
-            )
+
+            # Convert any floats in the name to ints
+            temp_dict = task_entity_namer[i_set]
+            temp_dict = {
+                key: int(value) if isinstance(value, float) and value.is_integer() else value
+                for key, value in temp_dict.items()
+            }
+            task_file_figures["key"] = "_".join([f"{k}-{v}" for k, v in temp_dict.items()])
 
             query = {
                 "subject": self.subject_id,

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -217,7 +217,7 @@ class ExecutiveSummary(object):
             for k, v in task_entity_namer[i_set].items():
                 try:
                     temp_dict[k] = int(v)
-                except ValueError:
+                except (ValueError, TypeError):
                     temp_dict[k] = v
 
             task_file_figures["key"] = "_".join([f"{k}-{v}" for k, v in temp_dict.items()])

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -218,6 +218,7 @@ class ExecutiveSummary(object):
                 key: int(value) if isinstance(value, float) and value.is_integer() else value
                 for key, value in temp_dict.items()
             }
+            raise Exception(temp_dict)
             task_file_figures["key"] = "_".join([f"{k}-{v}" for k, v in temp_dict.items()])
 
             query = {


### PR DESCRIPTION
Closes #938 and closes #940.

## Changes proposed in this pull request

- Fix the description entity in the postprocessing carpet plot's query in the executive summary.
- Sort task file entities for the executive summary.
    - Previously, only the task name and run number were used to sort the task section.
- Build the task section names from task and run entities, along with any entities that are not constant across all of the subject's BOLD runs. This should help with datasets like the mobile-phenomics pilot, where single-echo and multi-echo runs are dissociated with the `acq` entity.
- Skip the final task section (carpets + mean BOLD + boldref + registration plots) for concatenated resting-state data, since (1) there's a section higher up for the concatenated resting-state carpets and (2) there are no mean BOLD, bolref, or registration plots for "runs" generated by the concatenation workflow.
- Move the "concatenated resting-state" carpet plot subsection from the "Anatomical Data" section to the "Functional Data" section.