### PR TITLE
Don't interpolate volumes at beginning/end of run

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -277,12 +277,15 @@ Denoising
 =========
 :class:`~xcp_d.interfaces.nilearn.DenoiseNifti`, :class:`~xcp_d.interfaces.nilearn.DenoiseCifti`
 
-Temporal censoring
-------------------
+Temporal censoring [OPTIONAL]
+-----------------------------
 
 Prior to confound regression, high-motion volumes will be removed from the BOLD data.
 These volumes will also be removed from the nuisance regressors.
 Please refer to :footcite:t:`power2012spurious` for more information.
+
+.. tip::
+   Censoring can be disabled by setting ``--fd-thresh 0``.
 
 
 Confound regression
@@ -339,6 +342,18 @@ Interpolation
 
 An interpolated version of the ``denoised BOLD`` is then created by filling in the high-motion
 outlier volumes with cubic spline interpolated data, as implemented in ``Nilearn``.
+
+.. warning::
+   In versions 0.4.0rc2 - 0.5.0, XCP-D used cubic spline interpolation,
+   followed by bandpass filtering.
+
+   However, cubic spline interpolation can introduce large spikes and drops in the signal
+   when the censored volumes are at the beginning or end of the run,
+   which are then propagated to the filtered data.
+
+   To address this, XCP-D now replaces interpolated volumes at the edges of the run with the
+   closest non-outlier volume's data, as of 0.5.1.
+
 The resulting ``interpolated, denoised BOLD`` is primarily used for bandpass filtering.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "matplotlib ~= 3.4.2",
     "networkx ~= 2.8.8",  # nipype needs networkx, but 3+ isn't compatible with nipype 1.8.5
     "nibabel >= 3.2.1",
-    "nilearn ~= 0.10.0",
+    "nilearn == 0.10.1",
     "nipype ~= 1.8.5",
     "niworkflows == 1.7.3",
     "num2words",  # for boilerplates

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -212,8 +212,8 @@ def test_pnc_cifti(data_dir, output_dir, working_dir):
 
     motion_file = os.path.join(
         dataset_dir,
-        "sub-1648798153/ses-PNC1/func",
-        "sub-1648798153_ses-PNC1_task-rest_desc-confounds_timeseries.tsv",
+        "sub-1648798153/ses-PNC1/func/"
+        "sub-1648798153_ses-PNC1_task-rest_acq-singleband_desc-confounds_timeseries.tsv",
     )
     motion_df = pd.read_table(motion_file)
     motion_df.loc[-5:, "trans_x"] = 100

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -213,13 +213,14 @@ def test_pnc_cifti(data_dir, output_dir, working_dir):
     test_data_dir = get_test_data_path()
     filter_file = os.path.join(test_data_dir, "pnc_cifti_filter.json")
 
+    # Make the last few volumes outliers to check https://github.com/PennLINC/xcp_d/issues/949
     motion_file = os.path.join(
         dataset_dir,
         "sub-1648798153/ses-PNC1/func/"
         "sub-1648798153_ses-PNC1_task-rest_acq-singleband_desc-confounds_timeseries.tsv",
     )
     motion_df = pd.read_table(motion_file)
-    motion_df.loc[54:, "trans_x"] = np.arange(6) * 20
+    motion_df.loc[56:, "trans_x"] = np.arange(1, 5) * 20
     motion_df.to_csv(motion_file, sep="\t", index=False)
     LOGGER.warning(f"Overwrote confounds file at {motion_file}.")
 

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -216,8 +216,9 @@ def test_pnc_cifti(data_dir, output_dir, working_dir):
         "sub-1648798153_ses-PNC1_task-rest_acq-singleband_desc-confounds_timeseries.tsv",
     )
     motion_df = pd.read_table(motion_file)
-    motion_df.loc[-5:, "trans_x"] = 100
+    motion_df.loc[-10:, "trans_x"] = 100
     motion_df.to_csv(motion_file, sep="\t", index=False)
+    print("Overwrote confounds file.")
 
     parameters = [
         dataset_dir,

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -210,6 +210,15 @@ def test_pnc_cifti(data_dir, output_dir, working_dir):
     test_data_dir = get_test_data_path()
     filter_file = os.path.join(test_data_dir, "pnc_cifti_filter.json")
 
+    motion_file = os.path.join(
+        dataset_dir,
+        "sub-1648798153/ses-PNC1/func",
+        "sub-1648798153_ses-PNC1_task-rest_desc-confounds_timeseries.tsv",
+    )
+    motion_df = pd.read_table(motion_file)
+    motion_df.loc[-5:, "trans_x"] = 100
+    motion_df.to_csv(motion_file, sep="\t", index=False)
+
     parameters = [
         dataset_dir,
         out_dir,

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -5,6 +5,7 @@ import shutil
 import numpy as np
 import pandas as pd
 import pytest
+from nipype import logging
 from pkg_resources import resource_filename as pkgrf
 
 from xcp_d.cli import combineqc, parser_utils, run
@@ -16,6 +17,8 @@ from xcp_d.tests.utils import (
     get_test_data_path,
     run_command,
 )
+
+LOGGER = logging.getLogger("nipype.utils")
 
 
 @pytest.mark.ds001419_nifti
@@ -218,7 +221,7 @@ def test_pnc_cifti(data_dir, output_dir, working_dir):
     motion_df = pd.read_table(motion_file)
     motion_df.loc[-10:, "trans_x"] = 100
     motion_df.to_csv(motion_file, sep="\t", index=False)
-    print("Overwrote confounds file.")
+    LOGGER.warning(f"Overwrote confounds file at {motion_file}.")
 
     parameters = [
         dataset_dir,

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -219,7 +219,7 @@ def test_pnc_cifti(data_dir, output_dir, working_dir):
         "sub-1648798153_ses-PNC1_task-rest_acq-singleband_desc-confounds_timeseries.tsv",
     )
     motion_df = pd.read_table(motion_file)
-    motion_df.loc[-10:, "trans_x"] = 100
+    motion_df.loc[50:, "trans_x"] = np.arange(10) * 20
     motion_df.to_csv(motion_file, sep="\t", index=False)
     LOGGER.warning(f"Overwrote confounds file at {motion_file}.")
 

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -219,7 +219,7 @@ def test_pnc_cifti(data_dir, output_dir, working_dir):
         "sub-1648798153_ses-PNC1_task-rest_acq-singleband_desc-confounds_timeseries.tsv",
     )
     motion_df = pd.read_table(motion_file)
-    motion_df.loc[50:, "trans_x"] = np.arange(10) * 20
+    motion_df.loc[54:, "trans_x"] = np.arange(6) * 20
     motion_df.to_csv(motion_file, sep="\t", index=False)
     LOGGER.warning(f"Overwrote confounds file at {motion_file}.")
 
@@ -231,6 +231,7 @@ def test_pnc_cifti(data_dir, output_dir, working_dir):
         "--nthreads=2",
         "--omp-nthreads=2",
         f"--bids-filter-file={filter_file}",
+        "--min-time=60",
         "--nuisance-regressors=acompcor_gsr",
         "--despike",
         "--head_radius=40",

--- a/xcp_d/tests/test_utils_utils.py
+++ b/xcp_d/tests/test_utils_utils.py
@@ -152,6 +152,37 @@ def test_denoise_with_nilearn(ds001419_data, tmp_path_factory):
     assert uncensored_denoised_bold.shape == (n_volumes, n_voxels)
     assert interpolated_filtered_bold.shape == (n_volumes, n_voxels)
 
+    # Ensure that interpolation + filtering doesn't cause problems at beginning/end of scan
+    # Create an updated censoring file with outliers at first and last two volumes
+    censoring_df = confounds_df[["framewise_displacement"]]
+    censoring_df["framewise_displacement"] = False
+    censoring_df.iloc[:2]["framewise_displacement"] = True
+    censoring_df.iloc[-2:]["framewise_displacement"] = True
+    n_censored_volumes = censoring_df["framewise_displacement"].sum()
+    assert n_censored_volumes == 4
+    temporal_mask = os.path.join(tmpdir, "censoring.tsv")
+    censoring_df.to_csv(temporal_mask, sep="\t", index=False)
+
+    # Run without denoising or filtering
+    _, interpolated_filtered_bold = utils.denoise_with_nilearn(
+        preprocessed_bold=preprocessed_bold_arr,
+        confounds_file=None,
+        temporal_mask=temporal_mask,
+        low_pass=None,
+        high_pass=None,
+        filter_order=0,
+        TR=TR,
+    )
+    assert interpolated_filtered_bold.shape == (n_volumes, n_voxels)
+    # The first two volumes should be the same as the third (first non-outlier) volume
+    assert np.array_equal(interpolated_filtered_bold[0, :], interpolated_filtered_bold[2, :])
+    assert np.array_equal(interpolated_filtered_bold[1, :], interpolated_filtered_bold[2, :])
+    assert not np.array_equal(interpolated_filtered_bold[2, :], interpolated_filtered_bold[3, :])
+    # The last volume should be the same as the third-to-last (last non-outlier) volume
+    assert np.array_equal(interpolated_filtered_bold[-1, :], interpolated_filtered_bold[-3, :])
+    assert np.array_equal(interpolated_filtered_bold[-2, :], interpolated_filtered_bold[-3, :])
+    assert not np.array_equal(interpolated_filtered_bold[-3, :], interpolated_filtered_bold[-4, :])
+
 
 def test_list_to_str():
     """Test the list_to_str function."""

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -474,6 +474,9 @@ def denoise_with_nilearn(
         first_outliers = consecutive_outliers_idx[0]
         last_outliers = consecutive_outliers_idx[-1]
 
+        LOGGER.warning(consecutive_outliers_idx)
+        LOGGER.warning(n_volumes)
+
         # Replace outliers at beginning of run
         if first_outliers[0] == 0:
             LOGGER.warning(

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -480,10 +480,9 @@ def denoise_with_nilearn(
                 f"Outlier volumes at beginning of run ({first_outliers[0]}-{first_outliers[1]}) "
                 "will be replaced with first non-outlier volume's values."
             )
-            for i_vol in range(first_outliers[1]):
-                interpolated_unfiltered_bold[i_vol, :] = interpolated_unfiltered_bold[
-                    first_outliers[1] + 1, :
-                ]
+            interpolated_unfiltered_bold[: first_outliers[1], :] = interpolated_unfiltered_bold[
+                first_outliers[1] + 1, :
+            ]
 
         # Replace outliers at end of run
         if last_outliers[1] == n_volumes:
@@ -491,10 +490,9 @@ def denoise_with_nilearn(
                 f"Outlier volumes at end of run ({last_outliers[0]}-{last_outliers[1]}) "
                 "will be replaced with last non-outlier volume's values."
             )
-            for i_vol in range(last_outliers[0], -1):
-                interpolated_unfiltered_bold[i_vol, :] = interpolated_unfiltered_bold[
-                    last_outliers[0] - 1, :
-                ]
+            interpolated_unfiltered_bold[last_outliers[0] :, :] = interpolated_unfiltered_bold[
+                last_outliers[0] - 1, :
+            ]
         elif last_outliers[1] > n_volumes:
             raise ValueError(f"Something's wrong: {last_outliers} > {n_volumes}")
 

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -465,7 +465,7 @@ def denoise_with_nilearn(
     )
     # Replace any high-motion volumes at the beginning or end of the run with the closest
     # low-motion volume's data.
-    outlier_idx = np.where(~sample_mask)[0]
+    outlier_idx = list(np.where(~sample_mask)[0])
     if outlier_idx:
         # Use https://stackoverflow.com/a/48106843/2589328 to group consecutive blocks of outliers.
         gaps = [[s, e] for s, e in zip(outlier_idx, outlier_idx[1:]) if s + 1 < e]

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -465,9 +465,9 @@ def denoise_with_nilearn(
     )
     # Replace any high-motion volumes at the beginning or end of the run with the closest
     # low-motion volume's data.
-    # From https://stackoverflow.com/a/48106843/2589328
-    outlier_idx = sorted(set(np.where(~sample_mask)[0]))
+    outlier_idx = np.where(~sample_mask)[0]
     if outlier_idx:
+        # Use https://stackoverflow.com/a/48106843/2589328 to group consecutive blocks of outliers.
         gaps = [[s, e] for s, e in zip(outlier_idx, outlier_idx[1:]) if s + 1 < e]
         edges = iter(outlier_idx[:1] + sum(gaps, []) + outlier_idx[-1:])
         consecutive_outliers_idx = list(zip(edges, edges))

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -466,7 +466,7 @@ def denoise_with_nilearn(
     # Replace any high-motion volumes at the beginning or end of the run with the closest
     # low-motion volume's data.
     # From https://stackoverflow.com/a/48106843/2589328
-    outlier_idx = sorted(set(np.where(sample_mask)[0]))
+    outlier_idx = sorted(set(np.where(~sample_mask)[0]))
     if outlier_idx:
         gaps = [[s, e] for s, e in zip(outlier_idx, outlier_idx[1:]) if s + 1 < e]
         edges = iter(outlier_idx[:1] + sum(gaps, []) + outlier_idx[-1:])

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -467,7 +467,7 @@ def denoise_with_nilearn(
     # low-motion volume's data.
     # From https://stackoverflow.com/a/48106843/2589328
     outlier_idx = sorted(set(np.where(~sample_mask)[0]))
-    if outlier_idx and False:
+    if outlier_idx:
         gaps = [[s, e] for s, e in zip(outlier_idx, outlier_idx[1:]) if s + 1 < e]
         edges = iter(outlier_idx[:1] + sum(gaps, []) + outlier_idx[-1:])
         consecutive_outliers_idx = list(zip(edges, edges))

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -474,18 +474,15 @@ def denoise_with_nilearn(
         first_outliers = consecutive_outliers_idx[0]
         last_outliers = consecutive_outliers_idx[-1]
 
-        LOGGER.warning(consecutive_outliers_idx)
-        LOGGER.warning(n_volumes)
-
         # Replace outliers at beginning of run
         if first_outliers[0] == 0:
             LOGGER.warning(
                 f"Outlier volumes at beginning of run ({first_outliers[0]}-{first_outliers[1]}) "
                 "will be replaced with first non-outlier volume's values."
             )
-            interpolated_unfiltered_bold[: first_outliers[1], :] = interpolated_unfiltered_bold[
-                first_outliers[1] + 1, :
-            ]
+            interpolated_unfiltered_bold[
+                : first_outliers[1] + 1, :
+            ] = interpolated_unfiltered_bold[first_outliers[1] + 1, :]
 
         # Replace outliers at end of run
         if last_outliers[1] == n_volumes:

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -467,7 +467,7 @@ def denoise_with_nilearn(
     # low-motion volume's data.
     # From https://stackoverflow.com/a/48106843/2589328
     outlier_idx = sorted(set(np.where(~sample_mask)[0]))
-    if outlier_idx:
+    if outlier_idx and False:
         gaps = [[s, e] for s, e in zip(outlier_idx, outlier_idx[1:]) if s + 1 < e]
         edges = iter(outlier_idx[:1] + sum(gaps, []) + outlier_idx[-1:])
         consecutive_outliers_idx = list(zip(edges, edges))

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -474,6 +474,11 @@ def denoise_with_nilearn(
         first_outliers = consecutive_outliers_idx[0]
         last_outliers = consecutive_outliers_idx[-1]
 
+        LOGGER.warning("TEST")
+        LOGGER.warning(last_outliers)
+        LOGGER.warning(n_volumes)
+        LOGGER.warning("END TEST")
+
         # Replace outliers at beginning of run
         if first_outliers[0] == 0:
             LOGGER.warning(

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -474,11 +474,6 @@ def denoise_with_nilearn(
         first_outliers = consecutive_outliers_idx[0]
         last_outliers = consecutive_outliers_idx[-1]
 
-        LOGGER.warning("TEST")
-        LOGGER.warning(last_outliers)
-        LOGGER.warning(n_volumes)
-        LOGGER.warning("END TEST")
-
         # Replace outliers at beginning of run
         if first_outliers[0] == 0:
             LOGGER.warning(
@@ -490,7 +485,7 @@ def denoise_with_nilearn(
             ] = interpolated_unfiltered_bold[first_outliers[1] + 1, :]
 
         # Replace outliers at end of run
-        if last_outliers[1] == n_volumes:
+        if last_outliers[1] == n_volumes - 1:
             LOGGER.warning(
                 f"Outlier volumes at end of run ({last_outliers[0]}-{last_outliers[1]}) "
                 "will be replaced with last non-outlier volume's values."
@@ -498,8 +493,6 @@ def denoise_with_nilearn(
             interpolated_unfiltered_bold[last_outliers[0] :, :] = interpolated_unfiltered_bold[
                 last_outliers[0] - 1, :
             ]
-        elif last_outliers[1] > n_volumes:
-            raise ValueError(f"Something's wrong: {last_outliers} > {n_volumes}")
 
     # Now apply the bandpass filter to the interpolated, denoised data
     if low_pass is not None and high_pass is not None:


### PR DESCRIPTION
Closes #949.

## Changes proposed in this pull request

- After interpolation, but before bandpass filtering, replace any interpolated volumes at the beginning or end of the run with the closest non-outlier volume's data. This should act much like the `constant` buffer we use for the bandpass filter.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
