### PR TITLE
Pin Nilearn version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "matplotlib ~= 3.4.2",
     "networkx ~= 2.8.8",  # nipype needs networkx, but 3+ isn't compatible with nipype 1.8.5
     "nibabel >= 3.2.1",
-    "nilearn ~= 0.10.0",
+    "nilearn == 0.10.1",  # 0.10.2 raises error with compcor from fMRIPrep 23
     "nipype ~= 1.8.5",
     "niworkflows == 1.7.3",
     "num2words",  # for boilerplates


### PR DESCRIPTION
Closes none, but deals with CI errors since 0.10.2 was released.

## Changes proposed in this pull request

- Pin Nilearn version to 0.10.1 to prevent installation of 0.10.2, in which confound selection fails with fMRIPrep 23+ derivatives and compcor regressors.