### PR TITLE
Update the QC metrics

### DIFF
--- a/xcp_d/interfaces/plotting.py
+++ b/xcp_d/interfaces/plotting.py
@@ -384,7 +384,7 @@ class QCPlots(SimpleInterface):
         # Calculate QC measures
         mean_fd = np.mean(preproc_fd_timeseries)
         mean_censored_fd = np.mean(postproc_fd_timeseries)
-        mean_rms = np.nanmean(rmsd_censored)  # first value can be NaN if no dummy scans
+        mean_relative_rms = np.nanmean(rmsd_censored)  # first value can be NaN if no dummy scans
         mean_dvars_before_processing = np.mean(dvars_before_processing)
         mean_dvars_after_processing = np.mean(dvars_after_processing)
         fd_dvars_correlation_initial = np.corrcoef(preproc_fd_timeseries, dvars_before_processing)[
@@ -400,7 +400,7 @@ class QCPlots(SimpleInterface):
             {
                 "mean_fd": [mean_fd],
                 "mean_censored_fd": [mean_censored_fd],
-                "mean_relative_rms": [mean_rms],
+                "mean_relative_rms": [mean_relative_rms],
                 "max_relative_rms": [rmsd_max_value],
                 "mean_dvars_initial": [mean_dvars_before_processing],
                 "mean_dvars_final": [mean_dvars_after_processing],
@@ -420,7 +420,7 @@ class QCPlots(SimpleInterface):
                     "This value includes high-motion outliers, but not dummy volumes. "
                     "FD is calculated according to the Power definition."
                 ),
-                "Units": "mm",
+                "Units": "mm / volume",
                 "Term URL": "https://doi.org/10.1016/j.neuroimage.2011.10.018",
             },
             "mean_relative_rms": {

--- a/xcp_d/interfaces/plotting.py
+++ b/xcp_d/interfaces/plotting.py
@@ -383,7 +383,7 @@ class QCPlots(SimpleInterface):
 
         # Calculate QC measures
         mean_fd = np.mean(preproc_fd_timeseries)
-        mean_censored_fd = np.mean(postproc_fd_timeseries)
+        mean_fd_post_censoring = np.mean(postproc_fd_timeseries)
         mean_relative_rms = np.nanmean(rmsd_censored)  # first value can be NaN if no dummy scans
         mean_dvars_before_processing = np.mean(dvars_before_processing)
         mean_dvars_after_processing = np.mean(dvars_after_processing)
@@ -399,7 +399,7 @@ class QCPlots(SimpleInterface):
         qc_values_dict.update(
             {
                 "mean_fd": [mean_fd],
-                "mean_censored_fd": [mean_censored_fd],
+                "mean_fd_post_censoring": [mean_fd_post_censoring],
                 "mean_relative_rms": [mean_relative_rms],
                 "max_relative_rms": [rmsd_max_value],
                 "mean_dvars_initial": [mean_dvars_before_processing],
@@ -418,6 +418,16 @@ class QCPlots(SimpleInterface):
                 "Description": (
                     "Average framewise displacement without any motion parameter filtering. "
                     "This value includes high-motion outliers, but not dummy volumes. "
+                    "FD is calculated according to the Power definition."
+                ),
+                "Units": "mm / volume",
+                "Term URL": "https://doi.org/10.1016/j.neuroimage.2011.10.018",
+            },
+            "mean_fd_post_censoring": {
+                "LongName": "Mean Framewise Displacement After Censoring",
+                "Description": (
+                    "Average framewise displacement without any motion parameter filtering. "
+                    "This value does not include high-motion outliers or dummy volumes. "
                     "FD is calculated according to the Power definition."
                 ),
                 "Units": "mm / volume",
@@ -457,6 +467,12 @@ class QCPlots(SimpleInterface):
                 ),
                 "TermURL": "https://doi.org/10.1016/j.neuroimage.2011.02.073",
             },
+            "num_dummy_volumes": {
+                "LongName": "Number of Dummy Volumes",
+                "Description": (
+                    "The number of non-steady state volumes removed from the time series by XCP-D."
+                ),
+            },
             "num_censored_volumes": {
                 "LongName": "Number of Censored Volumes",
                 "Description": (
@@ -464,10 +480,11 @@ class QCPlots(SimpleInterface):
                     "This does not include dummy volumes."
                 ),
             },
-            "num_dummy_volumes": {
-                "LongName": "Number of Dummy Volumes",
+            "num_retained_volumes": {
+                "LongName": "Number of Retained Volumes",
                 "Description": (
-                    "The number of non-steady state volumes removed from the time series by XCP-D."
+                    "The number of volumes retained in the denoised dataset. "
+                    "This does not include dummy volumes or high-motion outliers."
                 ),
             },
             "fd_dvars_correlation_initial": {

--- a/xcp_d/interfaces/plotting.py
+++ b/xcp_d/interfaces/plotting.py
@@ -277,7 +277,7 @@ class QCPlots(SimpleInterface):
     output_spec = _QCPlotsOutputSpec
 
     def _run_interface(self, runtime):
-        # Load confound matrix and load motion with motion filtering
+        # Load confound matrix and load motion without motion filtering
         confounds_df = pd.read_table(self.inputs.fmriprep_confounds_file)
         preproc_motion_df = load_motion(
             confounds_df.copy(),

--- a/xcp_d/interfaces/report.py
+++ b/xcp_d/interfaces/report.py
@@ -30,12 +30,13 @@ QC_TEMPLATE = """\t\t<h3 class="elem-title">Summary</h3>
 \t\t<ul class="elem-desc">
 \t\t\t<li>BOLD volume space: {space}</li>
 \t\t\t<li>Repetition Time (TR): {TR:.03g}</li>
-\t\t\t<li>Mean Framewise Displacement: {meanFD}</li>
-\t\t\t<li>Mean Relative RMS Motion: {meanRMS}</li>
-\t\t\t<li>Max Relative RMS Motion: {maxRMS}</li>
+\t\t\t<li>Mean Framewise Displacement: {mean_fd}</li>
+\t\t\t<li>Mean Relative RMS Motion: {mean_relative_rms}</li>
+\t\t\t<li>Max Relative RMS Motion: {max_relative_rms}</li>
 \t\t\t<li>DVARS Before and After Processing : {dvars_before_after}</li>
-\t\t\t<li>Correlation between DVARS and FD Before and After Processing : {corrfddv}</li>
-\t\t\t<li>Number of Volumes Censored : {volcensored}</li>
+\t\t\t<li>Correlation between DVARS and FD Before and After Processing :
+{fd_dvars_correlation}</li>
+\t\t\t<li>Number of Volumes Censored : {num_vols_censored}</li>
 \t\t</ul>
 """
 
@@ -145,10 +146,13 @@ class FunctionalSummary(SummaryInterface):
     def _generate_segment(self):
         space = get_entity(self.inputs.bold_file, "space")
         qcfile = pd.read_csv(self.inputs.qc_file)
-        meanFD = str(round(qcfile["meanFD"][0], 4))
-        meanRMS = str(round(qcfile["relMeansRMSMotion"][0], 4))
-        maxRMS = str(round(qcfile["relMaxRMSMotion"][0], 4))
-        dvars = f"{round(qcfile['meanDVInit'][0], 4)}, {round(qcfile['meanDVFinal'][0], 4)}"
+        mean_fd = str(round(qcfile["mean_fd"][0], 4))
+        mean_relative_rms = str(round(qcfile["mean_relative_rms"][0], 4))
+        max_relative_rms = str(round(qcfile["max_relative_rms"][0], 4))
+        dvars = (
+            f"{round(qcfile['mean_dvars_initial'][0], 4)}, "
+            f"{round(qcfile['mean_dvars_final'][0], 4)}"
+        )
         fd_dvars_correlation = (
             f"{round(qcfile['motionDVCorrInit'][0], 4)}, "
             f"{round(qcfile['motionDVCorrFinal'][0], 4)}"
@@ -158,12 +162,12 @@ class FunctionalSummary(SummaryInterface):
         return QC_TEMPLATE.format(
             space=space,
             TR=self.inputs.TR,
-            meanFD=meanFD,
-            meanRMS=meanRMS,
-            maxRMS=maxRMS,
+            mean_fd=mean_fd,
+            mean_relative_rms=mean_relative_rms,
+            max_relative_rms=max_relative_rms,
             dvars_before_after=dvars,
-            corrfddv=fd_dvars_correlation,
-            volcensored=num_vols_censored,
+            fd_dvars_correlation=fd_dvars_correlation,
+            num_vols_censored=num_vols_censored,
         )
 
 

--- a/xcp_d/interfaces/report.py
+++ b/xcp_d/interfaces/report.py
@@ -154,8 +154,8 @@ class FunctionalSummary(SummaryInterface):
             f"{round(qcfile['mean_dvars_final'][0], 4)}"
         )
         fd_dvars_correlation = (
-            f"{round(qcfile['motionDVCorrInit'][0], 4)}, "
-            f"{round(qcfile['motionDVCorrFinal'][0], 4)}"
+            f"{round(qcfile['fd_dvars_correlation_initial'][0], 4)}, "
+            f"{round(qcfile['fd_dvars_correlation_final'][0], 4)}"
         )
         num_vols_censored = str(round(qcfile["num_censored_volumes"][0], 4))
 

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -46,15 +46,15 @@ def compute_registration_qc(bold2t1w_mask, anat_brainmask, bold2template_mask, t
     template_mask_arr = nb.load(template_mask).get_fdata()
 
     reg_qc = {
-        "coregDice": [dice(bold2t1w_mask_arr, t1w_mask_arr)],
-        "coregPearson": [pearson(bold2t1w_mask_arr, t1w_mask_arr)],
-        "coregCoverage": [overlap(bold2t1w_mask_arr, t1w_mask_arr)],
-        "normDice": [dice(bold2template_mask_arr, template_mask_arr)],
-        "normPearson": [pearson(bold2template_mask_arr, template_mask_arr)],
-        "normCoverage": [overlap(bold2template_mask_arr, template_mask_arr)],
+        "coreg_dice": [dice(bold2t1w_mask_arr, t1w_mask_arr)],
+        "coreg_correlation": [pearson(bold2t1w_mask_arr, t1w_mask_arr)],
+        "coreg_overlap": [overlap(bold2t1w_mask_arr, t1w_mask_arr)],
+        "norm_dice": [dice(bold2template_mask_arr, template_mask_arr)],
+        "norm_correlation": [pearson(bold2template_mask_arr, template_mask_arr)],
+        "norm_overlap": [overlap(bold2template_mask_arr, template_mask_arr)],
     }
     qc_metadata = {
-        "coregDice": {
+        "coreg_dice": {
             "LongName": "Coregistration Sørensen-Dice Coefficient",
             "Description": (
                 "The Sørensen-Dice coefficient calculated between the binary brain masks from the "
@@ -64,7 +64,7 @@ def compute_registration_qc(bold2t1w_mask, anat_brainmask, bold2template_mask, t
             ),
             "Term URL": "https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient",
         },
-        "coregPearson": {
+        "coreg_correlation": {
             "LongName": "Coregistration Pearson Correlation",
             "Description": (
                 "The Pearson correlation coefficient calculated between the binary brain masks "
@@ -74,7 +74,7 @@ def compute_registration_qc(bold2t1w_mask, anat_brainmask, bold2template_mask, t
             ),
             "Term URL": "https://en.wikipedia.org/wiki/Pearson_correlation_coefficient",
         },
-        "coregCoverage": {
+        "coreg_overlap": {
             "LongName": "Coregistration Coverage Metric",
             "Description": (
                 "The Szymkiewicz-Simpson overlap coefficient calculated between the binary brain "
@@ -83,7 +83,7 @@ def compute_registration_qc(bold2t1w_mask, anat_brainmask, bold2template_mask, t
             ),
             "Term URL": "https://en.wikipedia.org/wiki/Overlap_coefficient",
         },
-        "normDice": {
+        "norm_dice": {
             "LongName": "Normalization Sørensen-Dice Coefficient",
             "Description": (
                 "The Sørensen-Dice coefficient calculated between the binary brain masks from the "
@@ -93,7 +93,7 @@ def compute_registration_qc(bold2t1w_mask, anat_brainmask, bold2template_mask, t
             ),
             "Term URL": "https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient",
         },
-        "normPearson": {
+        "norm_correlation": {
             "LongName": "Normalization Pearson Correlation",
             "Description": (
                 "The Pearson correlation coefficient calculated between the binary brain masks "
@@ -103,7 +103,7 @@ def compute_registration_qc(bold2t1w_mask, anat_brainmask, bold2template_mask, t
             ),
             "Term URL": "https://en.wikipedia.org/wiki/Pearson_correlation_coefficient",
         },
-        "normCoverage": {
+        "norm_overlap": {
             "LongName": "Normalization Overlap Coefficient",
             "Description": (
                 "The Szymkiewicz-Simpson overlap coefficient calculated between the binary brain "


### PR DESCRIPTION
Closes #957.

I'd _really_ love to also change the extension from `csv` to `tsv`, for BIDS compatibility. I guess I'll wait until a later release for that part.

## Changes proposed in this pull request

- Rename LINC QC metrics to follow snake case, per BIDS recommendation.
    - `meanFD` --> `mean_fd`
    - `relMeansRMSMotion` --> `mean_relative_rms`
    - `relMaxRMSMotion` --> `max_relative_rms`
    - `meanDVInit` --> `mean_dvars_initial`
    - `meanDVFinal` --> `mean_dvars_final`
    - `nVolsRemoved ` --> `num_dummy_volumes`
    - `motionDVCorrInit` --> `fd_dvars_correlation_initial`
    - `motionDVCorrFinal` --> `fd_dvars_correlation_final`
    - `num_censored_volumes` stays the same.
    - `coregDice` --> `coreg_dice`
    - `coregPearson` --> `coreg_correlation`
    - `coregCoverage` --> `coreg_overlap`
    - `normDice` --> `norm_dice`
    - `normPearson` --> `norm_correlation`
    - `normCoverage` --> `norm_overlap`
- Add `num_retained_volumes` and `mean_fd_post_censoring` QC metrics.