### PR TITLE
Concatenate across directions as well as runs

### DIFF
--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -259,13 +259,13 @@ def test_group_across_runs():
     ]
     grouped_files = xbids.group_across_runs(in_files)
     assert isinstance(grouped_files, list)
-    assert len(grouped_files[0] == 3)
+    assert len(grouped_files[0]) == 3
     assert grouped_files[0] == [
         "/path/sub-01_task-axcpt_run-01_bold.nii.gz",
         "/path/sub-01_task-axcpt_run-02_bold.nii.gz",
         "/path/sub-01_task-axcpt_run-03_bold.nii.gz",
     ]
-    assert len(grouped_files[1] == 3)
+    assert len(grouped_files[1]) == 3
     assert grouped_files[1] == [
         "/path/sub-01_task-rest_run-01_bold.nii.gz",
         "/path/sub-01_task-rest_run-02_bold.nii.gz",
@@ -282,12 +282,12 @@ def test_group_across_runs():
     ]
     grouped_files = xbids.group_across_runs(in_files)
     assert isinstance(grouped_files, list)
-    assert len(grouped_files[0] == 2)
+    assert len(grouped_files[0]) == 2
     assert grouped_files[0] == [
         "/path/sub-01_task-axcpt_dir-LR_bold.nii.gz",
         "/path/sub-01_task-axcpt_dir-RL_bold.nii.gz",
     ]
-    assert len(grouped_files[1] == 4)
+    assert len(grouped_files[1]) == 4
     assert grouped_files[1] == [
         "/path/sub-01_task-rest_dir-LR_run-1_bold.nii.gz",
         "/path/sub-01_task-rest_dir-RL_run-1_bold.nii.gz",

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -250,42 +250,47 @@ def test_get_entity(datasets):
 def test_group_across_runs():
     """Test group_across_runs."""
     in_files = [
+        "/path/sub-01_task-axcpt_run-03_bold.nii.gz",
         "/path/sub-01_task-rest_run-03_bold.nii.gz",
         "/path/sub-01_task-rest_run-01_bold.nii.gz",
-        "/path/sub-01_task-rest_run-02_bold.nii.gz",
         "/path/sub-01_task-axcpt_run-02_bold.nii.gz",
+        "/path/sub-01_task-rest_run-02_bold.nii.gz",
         "/path/sub-01_task-axcpt_run-01_bold.nii.gz",
-        "/path/sub-01_task-axcpt_run-03_bold.nii.gz",
     ]
     grouped_files = xbids.group_across_runs(in_files)
-    assert isinstance(grouped_files, dict)
-    assert "sub-01_task-rest_bold.nii.gz" in grouped_files.keys()
-    assert len(grouped_files["sub-01_task-rest_bold.nii.gz"] == 3)
-    assert grouped_files["sub-01_task-rest_bold.nii.gz"] == [
+    assert isinstance(grouped_files, list)
+    assert len(grouped_files[0] == 3)
+    assert grouped_files[0] == [
+        "/path/sub-01_task-axcpt_run-01_bold.nii.gz",
+        "/path/sub-01_task-axcpt_run-02_bold.nii.gz",
+        "/path/sub-01_task-axcpt_run-03_bold.nii.gz",
+    ]
+    assert len(grouped_files[1] == 3)
+    assert grouped_files[1] == [
         "/path/sub-01_task-rest_run-01_bold.nii.gz",
         "/path/sub-01_task-rest_run-02_bold.nii.gz",
         "/path/sub-01_task-rest_run-03_bold.nii.gz",
     ]
-    assert "sub-01_task-axcpt_bold.nii.gz" in grouped_files.keys()
-    assert len(grouped_files["sub-01_task-axcpt_bold.nii.gz"] == 3)
 
     in_files = [
-        "/path/sub-01_task-rest_dir-RL_run-1_bold.nii.gz",
-        "/path/sub-01_task-rest_dir-LR_run-1_bold.nii.gz",
-        "/path/sub-01_task-rest_dir-RL_run-2_bold.nii.gz",
         "/path/sub-01_task-rest_dir-LR_run-2_bold.nii.gz",
+        "/path/sub-01_task-rest_dir-RL_run-1_bold.nii.gz",
         "/path/sub-01_task-axcpt_dir-LR_bold.nii.gz",
+        "/path/sub-01_task-rest_dir-RL_run-2_bold.nii.gz",
+        "/path/sub-01_task-rest_dir-LR_run-1_bold.nii.gz",
         "/path/sub-01_task-axcpt_dir-RL_bold.nii.gz",
     ]
     grouped_files = xbids.group_across_runs(in_files)
-    assert isinstance(grouped_files, dict)
-    assert "sub-01_task-rest_bold.nii.gz" in grouped_files.keys()
-    assert len(grouped_files["sub-01_task-rest_bold.nii.gz"] == 4)
-    assert grouped_files["sub-01_task-rest_bold.nii.gz"] == [
+    assert isinstance(grouped_files, list)
+    assert len(grouped_files[0] == 2)
+    assert grouped_files[0] == [
+        "/path/sub-01_task-axcpt_dir-LR_bold.nii.gz",
+        "/path/sub-01_task-axcpt_dir-RL_bold.nii.gz",
+    ]
+    assert len(grouped_files[1] == 4)
+    assert grouped_files[1] == [
         "/path/sub-01_task-rest_dir-LR_run-1_bold.nii.gz",
         "/path/sub-01_task-rest_dir-RL_run-1_bold.nii.gz",
         "/path/sub-01_task-rest_dir-LR_run-2_bold.nii.gz",
         "/path/sub-01_task-rest_dir-RL_run-2_bold.nii.gz",
     ]
-    assert "sub-01_task-axcpt_bold.nii.gz" in grouped_files.keys()
-    assert len(grouped_files["sub-01_task-axcpt_bold.nii.gz"] == 2)

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -245,3 +245,47 @@ def test_get_entity(datasets):
     )
     with pytest.raises(ValueError, match="Unknown space"):
         xbids.get_entity(fname, "space")
+
+
+def test_group_across_runs():
+    """Test group_across_runs."""
+    in_files = [
+        "/path/sub-01_task-rest_run-03_bold.nii.gz",
+        "/path/sub-01_task-rest_run-01_bold.nii.gz",
+        "/path/sub-01_task-rest_run-02_bold.nii.gz",
+        "/path/sub-01_task-axcpt_run-02_bold.nii.gz",
+        "/path/sub-01_task-axcpt_run-01_bold.nii.gz",
+        "/path/sub-01_task-axcpt_run-03_bold.nii.gz",
+    ]
+    grouped_files = xbids.group_across_runs(in_files)
+    assert isinstance(grouped_files, dict)
+    assert "sub-01_task-rest_bold.nii.gz" in grouped_files.keys()
+    assert len(grouped_files["sub-01_task-rest_bold.nii.gz"] == 3)
+    assert grouped_files["sub-01_task-rest_bold.nii.gz"] == [
+        "/path/sub-01_task-rest_run-01_bold.nii.gz",
+        "/path/sub-01_task-rest_run-02_bold.nii.gz",
+        "/path/sub-01_task-rest_run-03_bold.nii.gz",
+    ]
+    assert "sub-01_task-axcpt_bold.nii.gz" in grouped_files.keys()
+    assert len(grouped_files["sub-01_task-axcpt_bold.nii.gz"] == 3)
+
+    in_files = [
+        "/path/sub-01_task-rest_dir-RL_run-1_bold.nii.gz",
+        "/path/sub-01_task-rest_dir-LR_run-1_bold.nii.gz",
+        "/path/sub-01_task-rest_dir-RL_run-2_bold.nii.gz",
+        "/path/sub-01_task-rest_dir-LR_run-2_bold.nii.gz",
+        "/path/sub-01_task-axcpt_dir-LR_bold.nii.gz",
+        "/path/sub-01_task-axcpt_dir-RL_bold.nii.gz",
+    ]
+    grouped_files = xbids.group_across_runs(in_files)
+    assert isinstance(grouped_files, dict)
+    assert "sub-01_task-rest_bold.nii.gz" in grouped_files.keys()
+    assert len(grouped_files["sub-01_task-rest_bold.nii.gz"] == 4)
+    assert grouped_files["sub-01_task-rest_bold.nii.gz"] == [
+        "/path/sub-01_task-rest_dir-LR_run-1_bold.nii.gz",
+        "/path/sub-01_task-rest_dir-RL_run-1_bold.nii.gz",
+        "/path/sub-01_task-rest_dir-LR_run-2_bold.nii.gz",
+        "/path/sub-01_task-rest_dir-RL_run-2_bold.nii.gz",
+    ]
+    assert "sub-01_task-axcpt_bold.nii.gz" in grouped_files.keys()
+    assert len(grouped_files["sub-01_task-axcpt_bold.nii.gz"] == 2)

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -931,12 +931,12 @@ def group_across_runs(in_files):
         directions.append(direction)
 
     # Combine the three lists into a list of tuples
-    combined_data = list(zip(directions, run_numbers, in_files))
+    combined_data = list(zip(run_numbers, directions, in_files))
 
-    # Sort the list of tuples first by directions and then by run_numbers
+    # Sort the list of tuples first by run and then by direction
     sorted_data = sorted(combined_data, key=lambda x: (x[0], x[1]))
 
-    # Extract the sorted in_files list
+    # Sort the file list
     sorted_in_files = [item[2] for item in sorted_data]
 
     # Extract the unique sets of entities (i.e., the filename, minus the run and dir entities).

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -896,7 +896,11 @@ def get_entity(filename, entity):
 
 
 def group_across_runs(in_files):
-    """Group preprocessed BOLD files by unique sets of entities, ignoring run.
+    """Group preprocessed BOLD files by unique sets of entities, ignoring run and direction.
+
+    We only ignore direction for the sake of HCP.
+    This may lead to small problems for non-HCP datasets that differentiate scans based on
+    both run and direction.
 
     Parameters
     ----------
@@ -913,17 +917,27 @@ def group_across_runs(in_files):
 
     # First, extract run information and sort the input files by the runs,
     # so that any cases where files are not already in ascending run order get fixed.
-    run_numbers = []
+    run_numbers, directions = [], []
     for in_file in in_files:
         run = get_entity(in_file, "run")
         if run is None:
             run = 0
 
-        run_numbers.append(int(run))
+        direction = get_entity(in_file, "dir")
+        if direction is None:
+            direction = "none"
 
-    # Sort the files by the run numbers.
-    zipped_pairs = zip(run_numbers, in_files)
-    sorted_in_files = [x for _, x in sorted(zipped_pairs)]
+        run_numbers.append(int(run))
+        directions.append(direction)
+
+    # Combine the three lists into a list of tuples
+    combined_data = list(zip(directions, run_numbers, in_files))
+
+    # Sort the list of tuples first by directions and then by run_numbers
+    sorted_data = sorted(combined_data, key=lambda x: (x[0], x[1]))
+
+    # Extract the sorted in_files list
+    sorted_in_files = [item[2] for item in sorted_data]
 
     # Extract the unique sets of entities (i.e., the filename, minus the run and dir entities).
     unique_filenames = [re.sub("_run-[0-9]+_", "_", os.path.basename(f)) for f in sorted_in_files]

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -934,7 +934,7 @@ def group_across_runs(in_files):
     combined_data = list(zip(run_numbers, directions, in_files))
 
     # Sort the list of tuples first by run and then by direction
-    sorted_data = sorted(combined_data, key=lambda x: (x[0], x[1]))
+    sorted_data = sorted(combined_data, key=lambda x: (x[0], x[1], x[2]))
 
     # Sort the file list
     sorted_in_files = [item[2] for item in sorted_data]

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -925,8 +925,9 @@ def group_across_runs(in_files):
     zipped_pairs = zip(run_numbers, in_files)
     sorted_in_files = [x for _, x in sorted(zipped_pairs)]
 
-    # Extract the unique sets of entities (i.e., the filename, minus the run entity).
+    # Extract the unique sets of entities (i.e., the filename, minus the run and dir entities).
     unique_filenames = [re.sub("_run-[0-9]+_", "_", os.path.basename(f)) for f in sorted_in_files]
+    unique_filenames = [re.sub("_dir-[0-9a-zA-Z]+_", "_", f) for f in unique_filenames]
 
     # Assign each in_file to a group of files with the same entities, except run.
     out_files, grouped_unique_filenames = [], []

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -635,7 +635,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
     )
 
     n_runs = len(preproc_files)
-    preproc_files = group_across_runs(preproc_files)
+    preproc_files = group_across_runs(preproc_files)  # group files across runs and directions
     run_counter = 0
     for ent_set, task_files in enumerate(preproc_files):
         # Assuming TR is constant across runs for a given combination of entities.

--- a/xcp_d/workflows/concatenation.py
+++ b/xcp_d/workflows/concatenation.py
@@ -28,7 +28,7 @@ def init_concatenate_data_wf(
     dcan_qc,
     name="concatenate_data_wf",
 ):
-    """Concatenate postprocessed data.
+    """Concatenate postprocessed data across runs and directions.
 
     Workflow Graph
         .. workflow::
@@ -99,7 +99,7 @@ def init_concatenate_data_wf(
     workflow = Workflow(name=name)
 
     workflow.__desc__ = """
-Postprocessing derivatives from multi-run tasks were then concatenated across runs.
+Postprocessing derivatives from multi-run tasks were then concatenated across runs and directions.
 """
 
     inputnode = pe.Node(


### PR DESCRIPTION
Closes none. This will primarily (only?) affect HCP data, which acquires fMRI runs with both run entities and dir entities. The acquisition order is counterbalanced, so we can't ensure that the data will be concatenated in the right order, but it should still be an improvement.

## Changes proposed in this pull request

- Concatenate BOLD data across run and dir entities.
- Sort the files first by run, then by direction.
     - This is because HCP acquires run 1 in session 1 and run 2 in session 2. The order of directions (LR and RL) is counterbalanced, but run is consistent. Therefore we can't guarantee that LR --> RL is right (it'll be right for one run, but not the other), but we _can_ guarantee that run 1 --> run 2.