### PR TITLE
Allow motion filtering when motion-based censoring is disabled

### DIFF
--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -732,25 +732,12 @@ def _validate_parameters(opts, build_log):
 
     # Scrubbing parameters
     if opts.fd_thresh <= 0:
-        ignored_params = "\n\t".join(
-            [
-                "--min-time",
-                "--motion-filter-type",
-                "--band-stop-min",
-                "--band-stop-max",
-                "--motion-filter-order",
-                "--head_radius",
-            ]
-        )
+        ignored_params = "\n\t".join(["--min-time"])
         build_log.warning(
             "Framewise displacement-based scrubbing is disabled. "
             f"The following parameters will have no effect:\n\t{ignored_params}"
         )
         opts.min_time = 0
-        opts.motion_filter_type = None
-        opts.band_stop_min = None
-        opts.band_stop_max = None
-        opts.motion_filter_order = None
 
     # Motion filtering parameters
     if opts.motion_filter_type == "notch":

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -118,10 +118,6 @@ def test_validate_parameters_06(base_opts, caplog):
     opts, return_code = run._validate_parameters(deepcopy(opts), build_log)
 
     assert opts.min_time == 0
-    assert opts.motion_filter_type is None
-    assert opts.band_stop_min is None
-    assert opts.band_stop_max is None
-    assert opts.motion_filter_order is None
     assert "Framewise displacement-based scrubbing is disabled." in caplog.text
     assert return_code == 0
 


### PR DESCRIPTION
Closes #993.

## Changes proposed in this pull request

- Dont override motion filtering parameters when `--fd-thresh <= 0`.