### PR TITLE
Fix coverage CIFTIs

### DIFF
--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -1168,3 +1168,71 @@ class CiftiCreateDenseFromTemplate(WBCommand):
     input_spec = _CiftiCreateDenseFromTemplateInputSpec
     output_spec = _CiftiCreateDenseFromTemplateOutputSpec
     _cmd = "wb_command -cifti-create-dense-from-template"
+
+
+class _CiftiChangeMappingInputSpec(CommandLineInputSpec):
+    """Input specification for the CiftiCreateDenseFromTemplate command."""
+
+    data_cifti = File(
+        exists=True,
+        mandatory=True,
+        argstr="%s",
+        position=0,
+        desc="The cifti file to use the data from.",
+    )
+    direction = traits.Enum(
+        "ROW",
+        "COLUMN",
+        mandatory=True,
+        argstr="%s",
+        position=1,
+        desc="Which mapping to parcellate (integer, ROW, or COLUMN)",
+    )
+    cifti_out = File(
+        name_source=["label"],
+        name_template="converted_%s.dscalar.nii",
+        keep_extension=False,
+        argstr="%s",
+        position=2,
+        desc="The output cifti file.",
+    )
+    scalar = traits.Bool(
+        False,
+        usedefault=True,
+        argstr="-scalar",
+        position=3,
+        desc="Set the mapping to scalar",
+    )
+
+
+class _CiftiChangeMappingOutputSpec(TraitedSpec):
+    """Output specification for the CiftiCreateDenseFromTemplate command."""
+
+    cifti_out = File(exists=True, desc="output CIFTI file")
+
+
+class CiftiChangeMapping(WBCommand):
+    """Convert to scalar, copy mapping, etc.
+
+    Take an existing cifti file and change one of the mappings.
+    Exactly one of -series, -scalar, or -from-cifti must be specified.
+    The direction can be either an integer starting from 1, or the strings 'ROW' or 'COLUMN'.
+
+    Examples
+    --------
+    >>> ccdft = CiftiChangeMapping()
+    >>> ccdft.inputs.data_cifti = "tpl-fsLR_atlas-Gordon_den-32k_dseg.dlabel.nii"
+    >>> ccdft.inputs.direction = "ROW"
+    >>> ccdft.inputs.cifti_out = "out.dscalar.nii"
+    >>> ccdft.inputs.scalar = True
+    >>> ccdft.cmdline
+    wb_command -cifti-change-mapping \
+        tpl-fsLR_atlas-Gordon_den-32k_dseg.dlabel.nii \
+        ROW \
+        out.dscalar.nii \
+        -scalar
+    """
+
+    input_spec = _CiftiChangeMappingInputSpec
+    output_spec = _CiftiChangeMappingOutputSpec
+    _cmd = "wb_command -cifti-change-mapping"


### PR DESCRIPTION
Closes #997.

## Changes proposed in this pull request

- Change atlas CIFTIs to dscalars after resampling them to the data CIFTI's resolution, but before parcellating them. This produces a valid pscalar file, which can then be used to produce a valid coverage CIFTI (also a pscalar file).