### PR TITLE
Remove unused native-space support

### DIFF
--- a/xcp_d/interfaces/concatenation.py
+++ b/xcp_d/interfaces/concatenation.py
@@ -121,11 +121,6 @@ class _FilterOutFailedRunsInputSpec(BaseInterfaceInputSpec):
         Undefined,
         desc="BOLD reference files. Only used for NIFTI processing.",
     )
-    anat_to_native_xfm = traits.Either(
-        traits.List(File(exists=True)),
-        Undefined,
-        desc="T1w-to-native space transform files. Only used for NIFTI processing.",
-    )
     timeseries = traits.List(
         traits.List(File(exists=True)),
         mandatory=True,
@@ -191,13 +186,6 @@ class _FilterOutFailedRunsOutputSpec(TraitedSpec):
         ),
         desc="Smoothed, denoised BOLD data.",
     )
-    anat_to_native_xfm = traits.List(
-        traits.Either(
-            File(exists=True),
-            Undefined,
-        ),
-        desc="Smoothed, denoised BOLD data.",
-    )
     timeseries = traits.List(
         traits.List(File(exists=True)),
         desc="List of lists of parcellated time series TSV files.",
@@ -232,7 +220,6 @@ class FilterOutFailedRuns(SimpleInterface):
             "smoothed_denoised_bold": self.inputs.smoothed_denoised_bold,
             "bold_mask": self.inputs.bold_mask,
             "boldref": self.inputs.boldref,
-            "anat_to_native_xfm": self.inputs.anat_to_native_xfm,
             "timeseries": self.inputs.timeseries,
             "timeseries_ciftis": self.inputs.timeseries_ciftis,
         }

--- a/xcp_d/tests/conftest.py
+++ b/xcp_d/tests/conftest.py
@@ -111,10 +111,6 @@ def ds001419_data(datasets):
         anat_dir,
         "sub-01_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5",
     )
-    files["anat_to_native_xfm"] = os.path.join(
-        func_dir,
-        "sub-01_task-rest_from-T1w_to-scanner_mode-image_xfm.txt",
-    )
     files["boldref"] = os.path.join(
         func_dir,
         "sub-01_task-rest_space-MNI152NLin2009cAsym_res-2_boldref.nii.gz",
@@ -168,10 +164,6 @@ def pnc_data(datasets):
     files["template_to_anat_xfm"] = os.path.join(
         anat_dir,
         "sub-1648798153_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5",
-    )
-    files["anat_to_native_xfm"] = os.path.join(
-        func_dir,
-        "sub-1648798153_task-rest_from-T1w_to-scanner_mode-image_xfm.txt",
     )
     files["boldref"] = os.path.join(
         func_dir,

--- a/xcp_d/tests/test_interfaces_concatenation.py
+++ b/xcp_d/tests/test_interfaces_concatenation.py
@@ -49,7 +49,6 @@ def test_filteroutfailedruns(ds001419_data):
     smoothed_denoised_bold = Undefined
     bold_mask = Undefined
     boldref = Undefined
-    anat_to_native_xfm = Undefined
 
     # Now the lists of lists
     timeseries = [[tsv_file, tsv_file, tsv_file]] * n_runs
@@ -66,7 +65,6 @@ def test_filteroutfailedruns(ds001419_data):
         smoothed_denoised_bold=smoothed_denoised_bold,
         bold_mask=bold_mask,
         boldref=boldref,
-        anat_to_native_xfm=anat_to_native_xfm,
         timeseries=timeseries,
         timeseries_ciftis=timeseries_ciftis,
     )
@@ -82,7 +80,6 @@ def test_filteroutfailedruns(ds001419_data):
     assert len(out.smoothed_denoised_bold) == n_good_runs
     assert len(out.bold_mask) == n_good_runs
     assert len(out.boldref) == n_good_runs
-    assert len(out.anat_to_native_xfm) == n_good_runs
     assert len(out.timeseries) == n_good_runs
     assert len(out.timeseries_ciftis) == n_good_runs
 

--- a/xcp_d/tests/test_utils_utils.py
+++ b/xcp_d/tests/test_utils_utils.py
@@ -243,67 +243,35 @@ def test_get_bold2std_and_t1w_xfms(ds001419_data):
 
     # T1w --> MNI152NLin2009cAsym/T1w
     bold_file_t1w = bold_file_nlin2009c.replace("space-MNI152NLin2009cAsym_", "space-T1w_")
-    (
-        xforms_to_mni,
-        xforms_to_mni_invert,
-        xforms_to_t1w,
-        xforms_to_t1w_invert,
-    ) = utils.get_bold2std_and_t1w_xfms(
-        bold_file_t1w,
-        nlin2009c_to_anat_xfm,
-    )
-    assert len(xforms_to_mni) == 1
-    assert len(xforms_to_mni_invert) == 1
-    assert len(xforms_to_t1w) == 1
-    assert len(xforms_to_t1w_invert) == 1
+    with pytest.raises(ValueError, match="BOLD space 'T1w' not supported."):
+        utils.get_bold2std_and_t1w_xfms(
+            bold_file_t1w,
+            nlin2009c_to_anat_xfm,
+        )
 
     # T1w --> MNI152NLin6Asym --> MNI152NLin2009cAsym/T1w
     bold_file_t1w = bold_file_nlin2009c.replace("space-MNI152NLin2009cAsym_", "space-T1w_")
-    (
-        xforms_to_mni,
-        xforms_to_mni_invert,
-        xforms_to_t1w,
-        xforms_to_t1w_invert,
-    ) = utils.get_bold2std_and_t1w_xfms(
-        bold_file_t1w,
-        nlin6asym_to_anat_xfm,
-    )
-    assert len(xforms_to_mni) == 2
-    assert len(xforms_to_mni_invert) == 2
-    assert len(xforms_to_t1w) == 1
-    assert len(xforms_to_t1w_invert) == 1
+    with pytest.raises(ValueError, match="BOLD space 'T1w' not supported."):
+        utils.get_bold2std_and_t1w_xfms(
+            bold_file_t1w,
+            nlin6asym_to_anat_xfm,
+        )
 
     # native --> MNI152NLin2009cAsym/T1w
     bold_file_native = bold_file_nlin2009c.replace("space-MNI152NLin2009cAsym_", "")
-    (
-        xforms_to_mni,
-        xforms_to_mni_invert,
-        xforms_to_t1w,
-        xforms_to_t1w_invert,
-    ) = utils.get_bold2std_and_t1w_xfms(
-        bold_file_native,
-        nlin2009c_to_anat_xfm,
-    )
-    assert len(xforms_to_mni) == 2
-    assert len(xforms_to_mni_invert) == 2
-    assert len(xforms_to_t1w) == 1
-    assert len(xforms_to_t1w_invert) == 1
+    with pytest.raises(ValueError, match="BOLD space 'native' not supported."):
+        utils.get_bold2std_and_t1w_xfms(
+            bold_file_native,
+            nlin2009c_to_anat_xfm,
+        )
 
     # native --> MNI152NLin6Asym --> MNI152NLin2009cAsym/T1w
     bold_file_native = bold_file_nlin2009c.replace("space-MNI152NLin2009cAsym_", "")
-    (
-        xforms_to_mni,
-        xforms_to_mni_invert,
-        xforms_to_t1w,
-        xforms_to_t1w_invert,
-    ) = utils.get_bold2std_and_t1w_xfms(
-        bold_file_native,
-        nlin6asym_to_anat_xfm,
-    )
-    assert len(xforms_to_mni) == 3
-    assert len(xforms_to_mni_invert) == 3
-    assert len(xforms_to_t1w) == 1
-    assert len(xforms_to_t1w_invert) == 1
+    with pytest.raises(ValueError, match="BOLD space 'native' not supported."):
+        utils.get_bold2std_and_t1w_xfms(
+            bold_file_native,
+            nlin6asym_to_anat_xfm,
+        )
 
     # tofail --> MNI152NLin2009cAsym/T1w
     bold_file_tofail = bold_file_nlin2009c.replace("space-MNI152NLin2009cAsym_", "space-tofail_")

--- a/xcp_d/tests/test_utils_utils.py
+++ b/xcp_d/tests/test_utils_utils.py
@@ -179,7 +179,6 @@ def test_get_bold2std_and_t1w_xfms(ds001419_data):
     """Test get_bold2std_and_t1w_xfms."""
     bold_file_nlin2009c = ds001419_data["nifti_file"]
     nlin2009c_to_anat_xfm = ds001419_data["template_to_anat_xfm"]
-    anat_to_native_xfm = ds001419_data["anat_to_native_xfm"]
 
     # MNI152NLin2009cAsym --> MNI152NLin2009cAsym/T1w
     (
@@ -190,7 +189,6 @@ def test_get_bold2std_and_t1w_xfms(ds001419_data):
     ) = utils.get_bold2std_and_t1w_xfms(
         bold_file_nlin2009c,
         nlin2009c_to_anat_xfm,
-        anat_to_native_xfm,
     )
     assert len(xforms_to_mni) == 1
     assert len(xforms_to_mni_invert) == 1
@@ -214,7 +212,6 @@ def test_get_bold2std_and_t1w_xfms(ds001419_data):
     ) = utils.get_bold2std_and_t1w_xfms(
         bold_file_nlin6asym,
         nlin6asym_to_anat_xfm,
-        anat_to_native_xfm,
     )
     assert len(xforms_to_mni) == 1
     assert len(xforms_to_mni_invert) == 1
@@ -238,7 +235,6 @@ def test_get_bold2std_and_t1w_xfms(ds001419_data):
     ) = utils.get_bold2std_and_t1w_xfms(
         bold_file_infant,
         infant_to_anat_xfm,
-        anat_to_native_xfm,
     )
     assert len(xforms_to_mni) == 1
     assert len(xforms_to_mni_invert) == 1
@@ -255,7 +251,6 @@ def test_get_bold2std_and_t1w_xfms(ds001419_data):
     ) = utils.get_bold2std_and_t1w_xfms(
         bold_file_t1w,
         nlin2009c_to_anat_xfm,
-        anat_to_native_xfm,
     )
     assert len(xforms_to_mni) == 1
     assert len(xforms_to_mni_invert) == 1
@@ -272,7 +267,6 @@ def test_get_bold2std_and_t1w_xfms(ds001419_data):
     ) = utils.get_bold2std_and_t1w_xfms(
         bold_file_t1w,
         nlin6asym_to_anat_xfm,
-        anat_to_native_xfm,
     )
     assert len(xforms_to_mni) == 2
     assert len(xforms_to_mni_invert) == 2
@@ -289,7 +283,6 @@ def test_get_bold2std_and_t1w_xfms(ds001419_data):
     ) = utils.get_bold2std_and_t1w_xfms(
         bold_file_native,
         nlin2009c_to_anat_xfm,
-        anat_to_native_xfm,
     )
     assert len(xforms_to_mni) == 2
     assert len(xforms_to_mni_invert) == 2
@@ -306,7 +299,6 @@ def test_get_bold2std_and_t1w_xfms(ds001419_data):
     ) = utils.get_bold2std_and_t1w_xfms(
         bold_file_native,
         nlin6asym_to_anat_xfm,
-        anat_to_native_xfm,
     )
     assert len(xforms_to_mni) == 3
     assert len(xforms_to_mni_invert) == 3
@@ -319,7 +311,6 @@ def test_get_bold2std_and_t1w_xfms(ds001419_data):
         utils.get_bold2std_and_t1w_xfms(
             bold_file_tofail,
             nlin2009c_to_anat_xfm,
-            anat_to_native_xfm,
         )
 
     tofail_to_anat_xfm = nlin2009c_to_anat_xfm.replace("from-MNI152NLin2009cAsym_", "from-tofail_")
@@ -327,7 +318,6 @@ def test_get_bold2std_and_t1w_xfms(ds001419_data):
         utils.get_bold2std_and_t1w_xfms(
             bold_file_tofail,
             tofail_to_anat_xfm,
-            anat_to_native_xfm,
         )
 
 

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -559,7 +559,7 @@ def collect_morphometry_data(layout, participant_label):
 
 
 @fill_doc
-def collect_run_data(layout, bold_file, cifti, primary_anat, target_space):
+def collect_run_data(layout, bold_file, cifti, target_space):
     """Collect data associated with a given BOLD file.
 
     Parameters
@@ -569,8 +569,6 @@ def collect_run_data(layout, bold_file, cifti, primary_anat, target_space):
         Path to the BOLD file.
     %(cifti)s
         Whether to collect files associated with a CIFTI image (True) or a NIFTI (False).
-    primary_anat : {"T1w", "T2w"}
-        The anatomical modality to use for the anat-to-native transform.
     target_space
         Used to find NIfTIs in the appropriate space if ``cifti`` is ``True``.
 

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -608,13 +608,6 @@ def collect_run_data(layout, bold_file, cifti, primary_anat, target_space):
             suffix="mask",
             extension=[".nii", ".nii.gz"],
         )
-        run_data["anat_to_native_xfm"] = layout.get_nearest(
-            bids_file.path,
-            strict=False,
-            **{"from": primary_anat},  # "from" is protected Python kw
-            to="scanner",
-            suffix="xfm",
-        )
     else:
         # Split cohort out of the space for MNIInfant templates.
         cohort = None

--- a/xcp_d/utils/dcan2fmriprep.py
+++ b/xcp_d/utils/dcan2fmriprep.py
@@ -231,19 +231,6 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
             )
             copy_dictionary[bold_cifti_orig] = [bold_cifti_fmriprep]
 
-            # More identity transforms
-            native_to_t1w_fmriprep = os.path.join(
-                func_dir_fmriprep,
-                f"{subses_ents}_{task_ent}_{run_ent}_from-scanner_to-T1w_mode-image_xfm.txt",
-            )
-            copy_dictionary[identity_xfm].append(native_to_t1w_fmriprep)
-
-            t1w_to_native_fmriprep = os.path.join(
-                func_dir_fmriprep,
-                f"{subses_ents}_{task_ent}_{run_ent}_from-T1w_to-scanner_mode-image_xfm.txt",
-            )
-            copy_dictionary[identity_xfm].append(t1w_to_native_fmriprep)
-
             # Extract metadata for JSON files
             bold_metadata = {
                 "RepetitionTime": float(nb.load(bold_nifti_orig).header.get_zooms()[-1]),

--- a/xcp_d/utils/doc.py
+++ b/xcp_d/utils/doc.py
@@ -76,14 +76,6 @@ template_to_anat_xfm : :obj:`str`
 """
 
 docdict[
-    "anat_to_native_xfm"
-] = """
-anat_to_native_xfm : :obj:`str`
-    Path to the T1w-to-native BOLD space transform file.
-    May be "identity", for testing purposes.
-"""
-
-docdict[
     "name_source"
 ] = """
 name_source : :obj:`str`

--- a/xcp_d/utils/hcp2fmriprep.py
+++ b/xcp_d/utils/hcp2fmriprep.py
@@ -246,19 +246,6 @@ def convert_hcp_to_bids_single_subject(in_dir, out_dir, sub_ent):
         )
         copy_dictionary[bold_cifti_orig] = [bold_cifti_fmriprep]
 
-        # More identity transforms
-        native_to_t1w_fmriprep = os.path.join(
-            func_dir_fmriprep,
-            f"{subses_ents}_{task_ent}_{dir_ent}_{run_ent}_from-scanner_to-T1w_mode-image_xfm.txt",
-        )
-        copy_dictionary[identity_xfm].append(native_to_t1w_fmriprep)
-
-        t1w_to_native_fmriprep = os.path.join(
-            func_dir_fmriprep,
-            f"{subses_ents}_{task_ent}_{dir_ent}_{run_ent}_from-T1w_to-scanner_mode-image_xfm.txt",
-        )
-        copy_dictionary[identity_xfm].append(t1w_to_native_fmriprep)
-
         # Extract metadata for JSON files
         bold_metadata = {
             "RepetitionTime": float(nb.load(bold_nifti_orig).header.get_zooms()[-1]),

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -653,7 +653,6 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
                 "interpolated_filtered_bold",
                 "censored_denoised_bold",
                 "smoothed_denoised_bold",
-                "anat_to_native_xfm",
                 "bold_mask",
                 "boldref",
                 "timeseries",

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -379,7 +379,6 @@ def init_subject_wf(
     )
     t1w_available = subj_data["t1w"] is not None
     t2w_available = subj_data["t2w"] is not None
-    primary_anat = "T1w" if subj_data["t1w"] else "T2w"
 
     mesh_available, standard_space_mesh, mesh_files = collect_mesh_data(
         layout=layout,
@@ -671,7 +670,6 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
                 layout=layout,
                 bold_file=bold_file,
                 cifti=cifti,
-                primary_anat=primary_anat,
                 target_space=target_space,
             )
 

--- a/xcp_d/workflows/bold.py
+++ b/xcp_d/workflows/bold.py
@@ -189,7 +189,6 @@ def init_postprocess_nifti_wf(
         Fed from the subject workflow.
     %(fmriprep_confounds_file)s
     fmriprep_confounds_json
-    %(anat_to_native_xfm)s
     %(dummy_scans)s
 
     Outputs
@@ -206,7 +205,6 @@ def init_postprocess_nifti_wf(
     %(smoothed_denoised_bold)s
     %(boldref)s
     bold_mask
-    %(anat_to_native_xfm)s
     %(atlas_names)s
     %(timeseries)s
     %(timeseries_ciftis)s
@@ -234,7 +232,6 @@ def init_postprocess_nifti_wf(
                 "anat_brainmask",
                 "fmriprep_confounds_file",
                 "fmriprep_confounds_json",
-                "anat_to_native_xfm",
                 "dummy_scans",
                 "atlas_names",
                 "atlas_files",
@@ -249,7 +246,6 @@ def init_postprocess_nifti_wf(
     inputnode.inputs.bold_mask = run_data["boldmask"]
     inputnode.inputs.fmriprep_confounds_file = run_data["confounds"]
     inputnode.inputs.fmriprep_confounds_json = run_data["confounds_json"]
-    inputnode.inputs.anat_to_native_xfm = run_data["anat_to_native_xfm"]
     inputnode.inputs.dummy_scans = dummy_scans
 
     # Load custom confounds
@@ -279,7 +275,6 @@ def init_postprocess_nifti_wf(
                 "smoothed_denoised_bold",
                 "boldref",
                 "bold_mask",
-                "anat_to_native_xfm",
                 "timeseries",
                 "timeseries_ciftis",  # will not be defined
             ],
@@ -298,10 +293,7 @@ def init_postprocess_nifti_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, outputnode, [
-            ("bold_file", "name_source"),
-            ("anat_to_native_xfm", "anat_to_native_xfm"),
-        ]),
+        (inputnode, outputnode, [("bold_file", "name_source")]),
         (inputnode, downcast_data, [
             ("bold_file", "bold_file"),
             ("boldref", "boldref"),
@@ -491,7 +483,6 @@ def init_postprocess_nifti_wf(
             ("bold_mask", "inputnode.bold_mask"),
             ("anat_brainmask", "inputnode.anat_brainmask"),
             ("template_to_anat_xfm", "inputnode.template_to_anat_xfm"),
-            ("anat_to_native_xfm", "inputnode.anat_to_native_xfm"),
         ]),
         (prepare_confounds_wf, qc_report_wf, [
             ("outputnode.preprocessed_bold", "inputnode.preprocessed_bold"),

--- a/xcp_d/workflows/bold.py
+++ b/xcp_d/workflows/bold.py
@@ -90,7 +90,6 @@ def init_postprocess_nifti_wf(
                 input_type="fmriprep",
                 bold_file=bold_file,
                 cifti=False,
-                primary_anat="T1w",
             )
 
             custom_confounds_folder = os.path.join(fmri_dir, "sub-01/func")

--- a/xcp_d/workflows/cifti.py
+++ b/xcp_d/workflows/cifti.py
@@ -193,8 +193,6 @@ def init_postprocess_cifti_wf(
     %(boldref)s
     bold_mask
         This will not be defined.
-    %(anat_to_native_xfm)s
-        This will not be defined.
     %(atlas_names)s
     %(timeseries)s
     %(timeseries_ciftis)s
@@ -262,7 +260,6 @@ def init_postprocess_cifti_wf(
                 "smoothed_denoised_bold",
                 "boldref",
                 "bold_mask",  # will not be defined
-                "anat_to_native_xfm",  # will not be defined
                 "atlas_names",
                 "timeseries",
                 "timeseries_ciftis",

--- a/xcp_d/workflows/cifti.py
+++ b/xcp_d/workflows/cifti.py
@@ -90,7 +90,6 @@ def init_postprocess_cifti_wf(
                 input_type="fmriprep",
                 bold_file=bold_file,
                 cifti=True,
-                primary_anat="T1w",
             )
 
             wf = init_postprocess_cifti_wf(

--- a/xcp_d/workflows/concatenation.py
+++ b/xcp_d/workflows/concatenation.py
@@ -121,7 +121,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
                 "smoothed_denoised_bold",
                 "bold_mask",  # only for niftis, from postproc workflows
                 "boldref",  # only for niftis, from postproc workflows
-                "anat_to_native_xfm",  # only for niftis, from postproc workflows
                 "anat_brainmask",  # only for niftis, from data collection
                 "template_to_anat_xfm",  # only for niftis, from data collection
                 "atlas_names",
@@ -156,7 +155,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
             ("smoothed_denoised_bold", "smoothed_denoised_bold"),
             ("bold_mask", "bold_mask"),
             ("boldref", "boldref"),
-            ("anat_to_native_xfm", "anat_to_native_xfm"),
             ("timeseries", "timeseries"),
             ("timeseries_ciftis", "timeseries_ciftis"),
         ])
@@ -210,7 +208,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
             # nifti-only inputs
             (("bold_mask", _select_first), "inputnode.bold_mask"),
             (("boldref", _select_first), "inputnode.boldref"),
-            (("anat_to_native_xfm", _select_first), "inputnode.anat_to_native_xfm"),
         ]),
         (concatenate_inputs, qc_report_wf, [
             ("preprocessed_bold", "inputnode.preprocessed_bold"),

--- a/xcp_d/workflows/plotting.py
+++ b/xcp_d/workflows/plotting.py
@@ -81,8 +81,6 @@ def init_qc_report_wf(
         Only used with non-CIFTI data.
     %(template_to_anat_xfm)s
         Only used with non-CIFTI data.
-    %(anat_to_native_xfm)s
-        Only used with non-CIFTI data.
     %(dummy_scans)s
     %(fmriprep_confounds_file)s
     %(temporal_mask)s
@@ -112,7 +110,6 @@ def init_qc_report_wf(
                 "anat_brainmask",
                 "boldref",
                 "template_to_anat_xfm",
-                "anat_to_native_xfm",
             ],
         ),
         name="inputnode",
@@ -142,7 +139,7 @@ def init_qc_report_wf(
         # This is only possible for nifti inputs.
         get_native2space_transforms = pe.Node(
             Function(
-                input_names=["bold_file", "template_to_anat_xfm", "anat_to_native_xfm"],
+                input_names=["bold_file", "template_to_anat_xfm"],
                 output_names=[
                     "bold_to_std_xfms",
                     "bold_to_std_xfms_invert",
@@ -159,7 +156,6 @@ def init_qc_report_wf(
             (inputnode, get_native2space_transforms, [
                 ("name_source", "bold_file"),
                 ("template_to_anat_xfm", "template_to_anat_xfm"),
-                ("anat_to_native_xfm", "anat_to_native_xfm"),
             ]),
         ])
         # fmt:on


### PR DESCRIPTION
Closes #1002. This is a necessary change for fMRIPrep 23.2.0 compliance.

## Changes proposed in this pull request
- Remove collection of anat-to-native transform, which led to #1002 when fMRIPrep changed their naming convention. The transform was never actually used for anything.
- Remove any unreachable code that ostensibly supported native-space BOLD data.
