### PR TITLE
Add colorbar to ALFF and ReHo plots

### DIFF
--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -851,5 +851,6 @@ class ConnectPlot(SimpleInterface):
         )
 
         fig.savefig(self._results["connectplot"], bbox_inches="tight", pad_inches=None)
+        plt.close(fig)
 
         return runtime

--- a/xcp_d/interfaces/plotting.py
+++ b/xcp_d/interfaces/plotting.py
@@ -195,6 +195,7 @@ class CensoringPlot(SimpleInterface):
         )
 
         fig.savefig(self._results["out_file"])
+        plt.close(fig)
         return runtime
 
 
@@ -351,6 +352,7 @@ class QCPlots(SimpleInterface):
             self._results["raw_qcplot"],
             bbox_inches="tight",
         )
+        plt.close(preproc_fig)
 
         postproc_confounds = pd.DataFrame(
             {
@@ -370,6 +372,7 @@ class QCPlots(SimpleInterface):
             self._results["clean_qcplot"],
             bbox_inches="tight",
         )
+        plt.close(postproc_fig)
 
         # Get the different components in the bold file name
         # eg: ['sub-colornest001', 'ses-1'], etc.
@@ -682,6 +685,7 @@ class AnatomicalPlot(SimpleInterface):
         fig = plt.figure(constrained_layout=False, figsize=(25, 10))
         plot_anat(img, draw_cross=False, figure=fig, vmin=np.min(arr), vmax=np.max(arr))
         fig.savefig(self._results["out_file"], bbox_inches="tight", pad_inches=None)
+        plt.close(fig)
 
         return runtime
 

--- a/xcp_d/tests/test_utils_execsummary.py
+++ b/xcp_d/tests/test_utils_execsummary.py
@@ -18,8 +18,8 @@ def test_make_mosaic(tmp_path_factory):
     ax.set_facecolor("yellow")
     ax.set_xticks([])
     ax.set_yticks([])
-    plt.close(fig)
     fig.savefig(png_file)
+    plt.close(fig)
 
     png_files = [png_file] * 10
     with chdir(tmpdir):

--- a/xcp_d/utils/plotting.py
+++ b/xcp_d/utils/plotting.py
@@ -688,6 +688,7 @@ def plot_fmri_es(
 
         # Save out the before processing file
         fig.savefig(figure_name, bbox_inches="tight", pad_inches=None, dpi=300)
+        plt.close(fig)
 
     # Remove temporary files
     if rm_temp_file:
@@ -1283,6 +1284,7 @@ def plot_alff_reho_surface(output_path, filename, name_source):
     axes[0, 1].set_title("Right Hemisphere", fontsize=10)
     fig.tight_layout()
     fig.savefig(output_path)
+    plt.close(fig)
     return output_path
 
 

--- a/xcp_d/utils/plotting.py
+++ b/xcp_d/utils/plotting.py
@@ -1135,7 +1135,12 @@ def plot_alff_reho_volumetric(output_path, filename, name_source):
     template = str(template_file)
     output_path = os.path.abspath(output_path)
     plott.plot_stat_map(
-        filename, bg_img=template, display_mode="mosaic", cut_coords=8, output_file=output_path
+        filename,
+        bg_img=template,
+        display_mode="mosaic",
+        cut_coords=8,
+        colorbar=True,
+        output_file=output_path,
     )
     return output_path
 


### PR DESCRIPTION
Closes #627.

## Changes proposed in this pull request

- Add a colorbar to the volumetric ALFF and ReHo plots.
- Close figures after saving them to prevent bleedover.