### PR TITLE
Rescale ALFF based on original BOLD standard deviation

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -474,15 +474,22 @@ spontaneous neural activity in resting-state BOLD data.
 It is calculated by the following:
 
 1. The ``filtered, interpolated, denoised BOLD`` is passed along to the ALFF workflow.
-2. Voxel-wise BOLD time series are normalized (mean-centered and scaled to unit standard deviation)
+2. If censoring+interpolation was performed, then the interpolated time series is censored at this
+   point.
+3. Voxel-wise BOLD time series are normalized (mean-centered and scaled to unit standard deviation)
    over time.
-3. The power spectrum and associated frequencies are estimated from the BOLD data.
+4. The power spectrum and associated frequencies are estimated from the BOLD data.
+
    -  If censoring+interpolation was not performed, then this uses :func:`scipy.signal.periodogram`.
    -  If censoring+interpolation was performed, then this uses :func:`scipy.signal.lombscargle`.
-4. The square root of the power spectrum is calculated.
-5. The power spectrum values corresponding to the frequency range retained by the
+
+5. The square root of the power spectrum is calculated.
+6. The power spectrum values corresponding to the frequency range retained by the
    temporal filtering step are extracted from the full power spectrum.
-6. The mean of the within-band power spectrum is calculated and multiplied by 2.
+7. The mean of the within-band power spectrum is calculated and multiplied by 2.
+8. The ALFF value is multiplied by the standard deviation of the voxel-wise
+   ``filtered, interpolated, denoised BOLD`` time series.
+   This brings ALFF back to its original scale, as if the time series was not normalized.
 
 ALFF will only be calculated if the bandpass filter is enabled
 (i.e., if the ``--disable-bandpass-filter`` flag is not used).

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -477,7 +477,8 @@ It is calculated by the following:
 2. If censoring+interpolation was performed, then the interpolated time series is censored at this
    point.
 3. Voxel-wise BOLD time series are normalized (mean-centered and scaled to unit standard deviation)
-   over time.
+   over time. This will ensure that the power spectrum from ``periodogram`` and ``lombscargle``
+   are roughly equivalent.
 4. The power spectrum and associated frequencies are estimated from the BOLD data.
 
    -  If censoring+interpolation was not performed, then this uses :func:`scipy.signal.periodogram`.

--- a/xcp_d/utils/restingstate.py
+++ b/xcp_d/utils/restingstate.py
@@ -143,8 +143,8 @@ def compute_alff(data_matrix, low_pass, high_pass, TR, sample_mask=None):
 
         # Normalize data matrix over time. This will ensure that the standard periodogram and
         # Lomb-Scargle periodogram will have the same scale.
-        voxel_data -= np.mean(voxel_data)
-        voxel_data /= np.std(voxel_data)
+        # voxel_data -= np.mean(voxel_data)
+        # voxel_data /= np.std(voxel_data)
 
         if sample_mask is not None:
             voxel_data_censored = voxel_data[sample_mask]

--- a/xcp_d/utils/restingstate.py
+++ b/xcp_d/utils/restingstate.py
@@ -141,13 +141,17 @@ def compute_alff(data_matrix, low_pass, high_pass, TR, sample_mask=None):
             alff[i_voxel] = 0
             continue
 
-        # Normalize data matrix over time. This will ensure that the standard periodogram and
-        # Lomb-Scargle periodogram will have the same scale.
-        # voxel_data -= np.mean(voxel_data)
-        # voxel_data /= np.std(voxel_data)
+        # We will normalize data matrix over time.
+        # This will ensure that the power spectra from the standard and Lomb-Scargle periodograms
+        # have the same scale.
+        # However, this also changes ALFF's scale, so we retain the SD to rescale ALFF.
+        sd_scale = np.std(voxel_data)
 
         if sample_mask is not None:
             voxel_data_censored = voxel_data[sample_mask]
+            voxel_data_censored -= np.mean(voxel_data_censored)
+            voxel_data_censored /= np.std(voxel_data_censored)
+
             time_arr = np.arange(0, n_volumes * TR, TR)
             assert sample_mask.size == time_arr.size, f"{sample_mask.size} != {time_arr.size}"
             time_arr = time_arr[sample_mask]
@@ -160,6 +164,8 @@ def compute_alff(data_matrix, low_pass, high_pass, TR, sample_mask=None):
                 normalize=True,
             )
         else:
+            voxel_data -= np.mean(voxel_data)
+            voxel_data /= np.std(voxel_data)
             # get array of sample frequencies + power spectrum density
             frequencies_hz, power_spectrum = signal.periodogram(
                 voxel_data,
@@ -178,6 +184,8 @@ def compute_alff(data_matrix, low_pass, high_pass, TR, sample_mask=None):
         # from the value closest to the low pass cutoff, to the value closest
         # to the high pass pass cutoff
         alff[i_voxel] = len(ff_alff) * np.mean(power_spectrum_sqrt[ff_alff[0] : ff_alff[1]])
+        # Rescale ALFF based on original BOLD scale
+        alff[i_voxel] *= sd_scale
 
     assert alff.size == n_voxels, f"{alff.shape} != {n_voxels}"
 

--- a/xcp_d/workflows/restingstate.py
+++ b/xcp_d/workflows/restingstate.py
@@ -114,11 +114,13 @@ def init_alff_wf(
 
     workflow.__desc__ = f""" \
 The amplitude of low-frequency fluctuation (ALFF) [@alff] was computed by transforming
-the mean-centered, standard deviation-normalized, denoised BOLD timeseries to the frequency
+the mean-centered, standard deviation-normalized, denoised BOLD time series to the frequency
 domain{periodogram_desc}.
 The power spectrum was computed within the {high_pass}-{low_pass} Hz frequency band and the
 mean square root of the power spectrum was calculated at each voxel to yield voxel-wise ALFF
 measures.
+The resulting ALFF values were then multiplied by the standard deviation of the denoised BOLD time
+series to retain the original scaling.
 """
 
     inputnode = pe.Node(


### PR DESCRIPTION
Related to #1032.

## Changes proposed in this pull request

- Calculate the SD of the denoised BOLD data, then multiply the ALFF computed on the scaled BOLD data by that SD. This brings ALFF back to its original scale, and the censored version of ALFF will has the same scale as the uncensored version.
