### PR TITLE
Fix dscalar CIFTI generation

### DIFF
--- a/xcp_d/tests/test_utils_write_save.py
+++ b/xcp_d/tests/test_utils_write_save.py
@@ -58,15 +58,15 @@ def test_write_ndata(ds001419_data, tmp_path_factory):
     assert (cifti_data_loaded[1000, 25] - 1000) < 1
 
     # Write a dscalar file (no time points)
-    cifti_data = cifti_data[:, 24:25].T
-    assert cifti_data.shape == (1, 91282)
+    cifti_data = cifti_data[:, 24:25]
+    assert cifti_data.shape == (91282, 1)
     temp_cifti = os.path.join(tmpdir, "file.dscalar.nii")
     write_save.write_ndata(cifti_data, template=orig_cifti, filename=temp_cifti)
     assert os.path.isfile(temp_cifti)
     cifti_data_loaded = write_save.read_ndata(temp_cifti)
-    assert cifti_data_loaded.shape == (1, 91282)
+    assert cifti_data_loaded.shape == (91282, 1)
     # It won't equal exactly 1000
-    assert (cifti_data_loaded[0, 1000] - 1000) < 1
+    assert (cifti_data_loaded[1000, 0] - 1000) < 1
 
     # Try writing out a different filetype (should fail)
     temp_cifti = os.path.join(tmpdir, "file.pscalar.nii")

--- a/xcp_d/tests/test_utils_write_save.py
+++ b/xcp_d/tests/test_utils_write_save.py
@@ -86,5 +86,10 @@ def test_write_ndata(ds001419_data, tmp_path_factory):
 
     # Try writing out a completely different filetype (should fail)
     out_file = os.path.join(tmpdir, "file.txt")
-    with pytest.raises(ValueError, match="Unknown extension"):
+    with pytest.raises(ValueError, match="Unsupported CIFTI extension"):
         write_save.write_ndata(cifti_data, template=orig_cifti, filename=out_file)
+
+    # Try using a txt file as a template
+    fake_template = os.path.join(tmpdir, "file.txt")
+    with pytest.raises(ValueError, match="Unknown extension"):
+        write_save.write_ndata(cifti_data, template=fake_template, filename=temp_cifti)

--- a/xcp_d/tests/test_utils_write_save.py
+++ b/xcp_d/tests/test_utils_write_save.py
@@ -46,10 +46,9 @@ def test_write_ndata(ds001419_data, tmp_path_factory):
     # It won't equal exactly 1000
     assert (cifti_data_loaded[1000, 50] - 1000) < 1
 
-    # Write a shortened CIFTI
+    # Write a shortened CIFTI, so that the time axis will need to be created by write_ndata
     cifti_data = cifti_data[:, ::2]
     assert cifti_data.shape == (91282, 30)
-
     temp_cifti = os.path.join(tmpdir, "file.dtseries.nii")
     write_save.write_ndata(cifti_data, template=orig_cifti, filename=temp_cifti)
     assert os.path.isfile(temp_cifti)
@@ -58,20 +57,9 @@ def test_write_ndata(ds001419_data, tmp_path_factory):
     # It won't equal exactly 1000, but check that the modified value is in the right place
     assert (cifti_data_loaded[1000, 25] - 1000) < 1
 
-    # Write a CIFTI image (no time points)
-    # NOTE: Would this ever be the case? A dtseries.nii without a time axis doesn't make sense.
-    cifti_data = cifti_data[:, 25]
-    assert cifti_data.shape == (91282,)
-
-    temp_cifti = os.path.join(tmpdir, "file.dtseries.nii")
-    write_save.write_ndata(cifti_data, template=orig_cifti, filename=temp_cifti)
-    assert os.path.isfile(temp_cifti)
-    cifti_data_loaded = write_save.read_ndata(temp_cifti)
-    assert cifti_data_loaded.shape == (91282,)
-    # It won't equal exactly 1000
-    assert (cifti_data_loaded[1000] - 1000) < 1
-
-    # Write a dscalar file
+    # Write a dscalar file (no time points)
+    cifti_data = cifti_data[:, 24:25].T
+    assert cifti_data.shape == (1, 91282)
     temp_cifti = os.path.join(tmpdir, "file.dscalar.nii")
     write_save.write_ndata(cifti_data, template=orig_cifti, filename=temp_cifti)
     assert os.path.isfile(temp_cifti)
@@ -79,3 +67,8 @@ def test_write_ndata(ds001419_data, tmp_path_factory):
     assert cifti_data_loaded.shape == (1, 91282)
     # It won't equal exactly 1000
     assert (cifti_data_loaded[0, 1000] - 1000) < 1
+
+    # Try writing out a different filetype (should fail)
+    temp_cifti = os.path.join(tmpdir, "file.pscalar.nii")
+    with pytest.raises(ValueError, match="Unsupported CIFTI extension"):
+        write_save.write_ndata(cifti_data, template=orig_cifti, filename=temp_cifti)

--- a/xcp_d/tests/test_utils_write_save.py
+++ b/xcp_d/tests/test_utils_write_save.py
@@ -14,8 +14,8 @@ def test_read_ndata(ds001419_data):
         write_save.read_ndata(gifti_file)
 
     # Load cifti
-    cifti_file = ds001419_data["cifti_file"]
-    cifti_data = write_save.read_ndata(cifti_file)
+    orig_cifti = ds001419_data["orig_cifti"]
+    cifti_data = write_save.read_ndata(orig_cifti)
     assert cifti_data.shape == (91282, 60)
 
     # Load nifti
@@ -33,15 +33,15 @@ def test_write_ndata(ds001419_data, tmp_path_factory):
     """Test write_save.write_ndata."""
     tmpdir = tmp_path_factory.mktemp("test_write_ndata")
 
-    cifti_file = ds001419_data["cifti_file"]
-    cifti_data = write_save.read_ndata(cifti_file)
+    orig_cifti = ds001419_data["orig_cifti"]
+    cifti_data = write_save.read_ndata(orig_cifti)
     cifti_data[1000, 50] = 1000
 
     # Write an unmodified CIFTI
-    temp_cifti_file = os.path.join(tmpdir, "cifti_file.dtseries.nii")
-    write_save.write_ndata(cifti_data, template=cifti_file, filename=temp_cifti_file)
-    assert os.path.isfile(temp_cifti_file)
-    cifti_data_loaded = write_save.read_ndata(temp_cifti_file)
+    temp_cifti = os.path.join(tmpdir, "file.dtseries.nii")
+    write_save.write_ndata(cifti_data, template=orig_cifti, filename=temp_cifti)
+    assert os.path.isfile(temp_cifti)
+    cifti_data_loaded = write_save.read_ndata(temp_cifti)
     assert cifti_data_loaded.shape == (91282, 60)
     # It won't equal exactly 1000
     assert (cifti_data_loaded[1000, 50] - 1000) < 1
@@ -50,22 +50,32 @@ def test_write_ndata(ds001419_data, tmp_path_factory):
     cifti_data = cifti_data[:, ::2]
     assert cifti_data.shape == (91282, 30)
 
-    temp_cifti_file = os.path.join(tmpdir, "shortened_cifti_file.dtseries.nii")
-    write_save.write_ndata(cifti_data, template=cifti_file, filename=temp_cifti_file)
-    assert os.path.isfile(temp_cifti_file)
-    cifti_data_loaded = write_save.read_ndata(temp_cifti_file)
+    temp_cifti = os.path.join(tmpdir, "file.dtseries.nii")
+    write_save.write_ndata(cifti_data, template=orig_cifti, filename=temp_cifti)
+    assert os.path.isfile(temp_cifti)
+    cifti_data_loaded = write_save.read_ndata(temp_cifti)
     assert cifti_data_loaded.shape == (91282, 30)
     # It won't equal exactly 1000, but check that the modified value is in the right place
     assert (cifti_data_loaded[1000, 25] - 1000) < 1
 
     # Write a CIFTI image (no time points)
+    # NOTE: Would this ever be the case? A dtseries.nii without a time axis doesn't make sense.
     cifti_data = cifti_data[:, 25]
     assert cifti_data.shape == (91282,)
 
-    temp_cifti_file = os.path.join(tmpdir, "shortened_cifti_file.dtseries.nii")
-    write_save.write_ndata(cifti_data, template=cifti_file, filename=temp_cifti_file)
-    assert os.path.isfile(temp_cifti_file)
-    cifti_data_loaded = write_save.read_ndata(temp_cifti_file)
+    temp_cifti = os.path.join(tmpdir, "file.dtseries.nii")
+    write_save.write_ndata(cifti_data, template=orig_cifti, filename=temp_cifti)
+    assert os.path.isfile(temp_cifti)
+    cifti_data_loaded = write_save.read_ndata(temp_cifti)
     assert cifti_data_loaded.shape == (91282,)
     # It won't equal exactly 1000
     assert (cifti_data_loaded[1000] - 1000) < 1
+
+    # Write a dscalar file
+    temp_cifti = os.path.join(tmpdir, "file.dscalar.nii")
+    write_save.write_ndata(cifti_data, template=orig_cifti, filename=temp_cifti)
+    assert os.path.isfile(temp_cifti)
+    cifti_data_loaded = write_save.read_ndata(temp_cifti)
+    assert cifti_data_loaded.shape == (1, 91282)
+    # It won't equal exactly 1000
+    assert (cifti_data_loaded[0, 1000] - 1000) < 1

--- a/xcp_d/tests/test_utils_write_save.py
+++ b/xcp_d/tests/test_utils_write_save.py
@@ -91,5 +91,8 @@ def test_write_ndata(ds001419_data, tmp_path_factory):
 
     # Try using a txt file as a template
     fake_template = os.path.join(tmpdir, "file.txt")
+    with open(fake_template, "w") as fo:
+        fo.write("TEST")
+
     with pytest.raises(ValueError, match="Unknown extension"):
         write_save.write_ndata(cifti_data, template=fake_template, filename=temp_cifti)

--- a/xcp_d/tests/test_utils_write_save.py
+++ b/xcp_d/tests/test_utils_write_save.py
@@ -68,7 +68,23 @@ def test_write_ndata(ds001419_data, tmp_path_factory):
     # It won't equal exactly 1000
     assert (cifti_data_loaded[1000, 0] - 1000) < 1
 
-    # Try writing out a different filetype (should fail)
+    # Write a 1D dscalar file (no time points)
+    cifti_data = cifti_data[:, 0]
+    assert cifti_data.shape == (91282,)
+    temp_cifti = os.path.join(tmpdir, "file.dscalar.nii")
+    write_save.write_ndata(cifti_data, template=orig_cifti, filename=temp_cifti)
+    assert os.path.isfile(temp_cifti)
+    cifti_data_loaded = write_save.read_ndata(temp_cifti)
+    assert cifti_data_loaded.shape == (91282, 1)
+    # It won't equal exactly 1000
+    assert (cifti_data_loaded[1000, 0] - 1000) < 1
+
+    # Try writing out a different CIFTI filetype (should fail)
     temp_cifti = os.path.join(tmpdir, "file.pscalar.nii")
     with pytest.raises(ValueError, match="Unsupported CIFTI extension"):
         write_save.write_ndata(cifti_data, template=orig_cifti, filename=temp_cifti)
+
+    # Try writing out a completely different filetype (should fail)
+    out_file = os.path.join(tmpdir, "file.txt")
+    with pytest.raises(ValueError, match="Unknown extension"):
+        write_save.write_ndata(cifti_data, template=orig_cifti, filename=out_file)

--- a/xcp_d/tests/test_utils_write_save.py
+++ b/xcp_d/tests/test_utils_write_save.py
@@ -14,8 +14,8 @@ def test_read_ndata(ds001419_data):
         write_save.read_ndata(gifti_file)
 
     # Load cifti
-    orig_cifti = ds001419_data["orig_cifti"]
-    cifti_data = write_save.read_ndata(orig_cifti)
+    cifti_file = ds001419_data["cifti_file"]
+    cifti_data = write_save.read_ndata(cifti_file)
     assert cifti_data.shape == (91282, 60)
 
     # Load nifti
@@ -33,7 +33,7 @@ def test_write_ndata(ds001419_data, tmp_path_factory):
     """Test write_save.write_ndata."""
     tmpdir = tmp_path_factory.mktemp("test_write_ndata")
 
-    orig_cifti = ds001419_data["orig_cifti"]
+    orig_cifti = ds001419_data["cifti_file"]
     cifti_data = write_save.read_ndata(orig_cifti)
     cifti_data[1000, 50] = 1000
 

--- a/xcp_d/utils/write_save.py
+++ b/xcp_d/utils/write_save.py
@@ -164,11 +164,8 @@ def write_ndata(data_matrix, template, filename, mask=None, TR=1):
         else:
             raise ValueError(f"Unsupported CIFTI extension '{out_extension}'")
 
-        # Modify the intent code if it doesn't match the extension.
-        target_intent = cifti_intents.get(out_extension, None)
-        if target_intent is None:
-            raise ValueError(f"Unknown CIFTI extension '{out_extension}'")
-
+        # Modify the intent code
+        target_intent = cifti_intents[out_extension]
         img.nifti_header.set_intent(target_intent)
 
     else:

--- a/xcp_d/utils/write_save.py
+++ b/xcp_d/utils/write_save.py
@@ -131,8 +131,8 @@ def write_ndata(data_matrix, template, filename, mask=None, TR=1):
         n_volumes = data_matrix.shape[0]
         _, _, out_extension = split_filename(filename)
 
-        if filename.endswith(".dlabel.nii"):
-            # Dense label files have (ScalarAxis, BrainModelAxis)
+        if filename.endswith(".dscalar.nii"):
+            # Dense scalar files have (ScalarAxis, BrainModelAxis)
             scalar_names = [f"#{i + 1}" for i in range(n_volumes)]
             ax_0 = nb.cifti2.cifti2_axes.ScalarAxis(name=scalar_names)
             ax_1 = template_img.header.get_axis(1)

--- a/xcp_d/utils/write_save.py
+++ b/xcp_d/utils/write_save.py
@@ -32,7 +32,7 @@ def read_ndata(datafile, maskfile=None):
         Vertices or voxels by timepoints.
     """
     # read cifti series
-    cifti_extensions = [".dtseries.nii", ".dlabel.nii", ".ptseries.nii"]
+    cifti_extensions = [".dtseries.nii", ".dlabel.nii", ".ptseries.nii", ".dscalar.nii"]
     if any([datafile.endswith(ext) for ext in cifti_extensions]):
         data = nb.load(datafile).get_fdata()
 


### PR DESCRIPTION
Closes #1035.

## Changes proposed in this pull request

- Fix a bug in `xcp_d.utils.write_save.write_ndata()`, in which all CIFTIs were written out with a SeriesAxis. In the fixed version, `.dtseries.nii` files have a SeriesAxis and a BrainModelAxis (same as before), but `.dscalar.nii` files have a _ScalarAxis_ and a BrainModelAxis. Other extensions aren't supported yet, but there shouldn't be any cases in XCP-D where we use `write_ndata` to write out any other types of CIFTI.