### PR TITLE
Update docker image link

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,7 +35,7 @@ of the image: ::
 
     $ docker pull pennlinc/xcp_d:<latest-version>
 
-The image can also be found here: https://registry.hub.docker.com/r/pennlinc/xcp_d
+The image can also be found here: https://hub.docker.com/r/pennlinc/xcp_d
 
 *xcp_d* can be run interacting directly with the Docker Engine via the `docker run` command,
 or through a lightweight wrapper that was created for convenience.


### PR DESCRIPTION
The old link https://registry.hub.docker.com/r/pennlinc/xcp_d shows error for now.

<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

Just fix docker image link.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
