### PR TITLE
Make description of `smoothing` parameter clearer when set to `0`

### DIFF
--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -246,7 +246,7 @@ def get_parser():
         help=(
             "FWHM, in millimeters, of the Gaussian smoothing kernel to apply to the denoised BOLD "
             "data. "
-            "This may be set to 0."
+            "Set to 0 to disable smoothing."
         ),
     )
     g_param.add_argument(


### PR DESCRIPTION
Formerly, for `--smoothing`:

> This may be set to 0.

Such piece of description is a little confusing although one might think smoothing is probably disabled in that case. It could be clearer and more consistent with the description of other parameters, such as `--min-time`, by clearly stating:

> Set to 0 to disable smoothing.

<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

Make the description clearer.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

None.