### PR TITLE
Fix potential atlas file race condition

### DIFF
--- a/xcp_d/utils/atlas.py
+++ b/xcp_d/utils/atlas.py
@@ -190,5 +190,8 @@ def copy_atlas(name_source, in_file, output_dir, atlas):
     atlas_out_dir = os.path.join(output_dir, f"xcp_d/atlases/atlas-{atlas}")
     os.makedirs(atlas_out_dir, exist_ok=True)
     out_atlas_file = os.path.join(atlas_out_dir, atlas_basename)
-    shutil.copyfile(in_file, out_atlas_file)
+    # Don't copy the file if it exists, to prevent any race conditions between parallel processes.
+    if not os.path.isfile(out_atlas_file):
+        shutil.copyfile(in_file, out_atlas_file)
+
     return out_atlas_file


### PR DESCRIPTION
Closes #1064.

## Changes proposed in this pull request

- Skip writing out the atlas file if it already exists in the atlases subfolder.