### PR TITLE
Make "DatasetType" key recommended, not required

### DIFF
--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -698,7 +698,16 @@ def write_dataset_description(fmri_dir, xcpd_dir, custom_confounds_folder=None):
     with open(orig_dset_description, "r") as fo:
         dset_desc = json.load(fo)
 
-    assert dset_desc["DatasetType"] == "derivative"
+    # Check if the dataset type is derivative
+    if "DatasetType" not in dset_desc.keys():
+        LOGGER.warning(f"DatasetType key not in {orig_dset_description}. Assuming 'derivative'.")
+        dset_desc["DatasetType"] = "derivative"
+
+    if dset_desc.get("DatasetType", "derivative") != "derivative":
+        raise ValueError(
+            f"DatasetType key in {orig_dset_description} is not 'derivative'. "
+            "XCP-D only works on derivative datasets."
+        )
 
     # Update dataset description
     dset_desc["Name"] = "XCP-D: A Robust Postprocessing Pipeline of fMRI data"

--- a/xcp_d/workflows/connectivity.py
+++ b/xcp_d/workflows/connectivity.py
@@ -781,7 +781,7 @@ def init_functional_connectivity_cifti_wf(
     workflow = Workflow(name=name)
     workflow.__desc__ = f"""
 Processed functional timeseries were extracted from residual BOLD using
-Connectome Workbench [@hcppipelines] for the following atlases:
+Connectome Workbench [@marcus2011informatics] for the following atlases:
 the Schaefer Supplemented with Subcortical Structures (4S) atlas
 [@Schaefer_2017,@pauli2018high,@king2019functional,@najdenovska2018vivo,@glasser2013minimal] at
 10 different resolutions (156, 256, 356, 456, 556, 656, 756, 856, 956, and 1056 parcels),


### PR DESCRIPTION
Closes none, but addresses an issue reported in https://neurostars.org/t/xcp-d-dataset-type-key-error/28385.

## Changes proposed in this pull request

- Raise a warning if "DatasetType" is not defined in the preprocessing derivatives' `dataset_description.json`.
- Raise an informative error if "DatasetType" is "raw" in the preprocessing derivatives' `dataset_description.json`.
