### PR TITLE
Do not warn if `fd-thresh` and `min-time` are both set to 0

### DIFF
--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -778,7 +778,7 @@ def _validate_parameters(opts, build_log):
         build_log.warning("Bandpass filtering is disabled. ALFF outputs will not be generated.")
 
     # Scrubbing parameters
-    if opts.fd_thresh <= 0:
+    if opts.fd_thresh <= 0 and opts.min_time > 0:
         ignored_params = "\n\t".join(["--min-time"])
         build_log.warning(
             "Framewise displacement-based scrubbing is disabled. "


### PR DESCRIPTION
Closes #1055.

## Changes proposed in this pull request

- If `--fd-thresh` is set to 0 (disabling censoring) and `--min-time` is set to 0 (no longer limiting the run duration), don't warn users about `--min-time` being disabled.