### PR TITLE
Raise error if FS_LICENSE environment variable is not an existing file

### DIFF
--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -745,6 +745,16 @@ def _validate_parameters(opts, build_log):
         else:
             build_log.error(f"Freesurfer license DNE: {opts.fs_license_file}.")
             return_code = 1
+    else:
+        fs_license_file = os.environ.get("FS_LICENSE", "/opt/freesurfer/license.txt")
+        if not Path(fs_license_file).is_file():
+            build_log.error(
+                "A valid FreeSurfer license file is required. "
+                "Set the FS_LICENSE environment variable or use the '--fs-license-file' flag."
+            )
+            return_code = 1
+
+        os.environ["FS_LICENSE"] = str(fs_license_file)
 
     # Check the validity of inputs
     if opts.output_dir == opts.fmri_dir:

--- a/xcp_d/tests/utils.py
+++ b/xcp_d/tests/utils.py
@@ -240,3 +240,34 @@ def list_files(startpath):
             tree += f"{subindent}{f}\n"
 
     return tree
+
+
+@contextmanager
+def modified_environ(*remove, **update):
+    """
+    Temporarily updates the ``os.environ`` dictionary in-place.
+
+    The ``os.environ`` dictionary is updated in-place so that the modification
+    is sure to work in all situations.
+
+    :param remove: Environment variables to remove.
+    :param update: Dictionary of environment variables and values to add/update.
+    """
+    env = os.environ
+    update = update or {}
+    remove = remove or []
+
+    # List of environment variables being updated or removed.
+    stomped = (set(update.keys()) | set(remove)) & set(env.keys())
+    # Environment variables and values to restore on exit.
+    update_after = {k: env[k] for k in stomped}
+    # Environment variables and values to remove on exit.
+    remove_after = frozenset(k for k in update if k not in env)
+
+    try:
+        env.update(update)
+        [env.pop(k, None) for k in remove]
+        yield
+    finally:
+        env.update(update_after)
+        [env.pop(k) for k in remove_after]


### PR DESCRIPTION
Related to #1067.

## Changes proposed in this pull request

- If `--fs-license-file` is not set, then the environment variable `FS_LICENSE` must be defined. This checks that that environment variable is set, and that the variable points to an existing file.
