### PR TITLE
Use `copy_atlas` to write out atlas tsv and json files

### DIFF
--- a/xcp_d/tests/test_utils_atlas.py
+++ b/xcp_d/tests/test_utils_atlas.py
@@ -62,10 +62,40 @@ def test_copy_atlas(tmp_path_factory):
     assert os.path.basename(out_file) == "space-MNI152NLin2009cAsym_atlas-Y_res-2_dseg.nii.gz"
 
     # CIFTI
-    atlas_file, _, _ = atlas.get_atlas_cifti("Gordon")
+    atlas_file, atlas_labels_file, atlas_metadata_file = atlas.get_atlas_cifti("Gordon")
     name_source = "sub-01_task-imagery_run-01_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii"
     out_file = atlas.copy_atlas(
         name_source=name_source, in_file=atlas_file, output_dir=tmpdir, atlas="Y"
     )
     assert os.path.isfile(out_file)
     assert os.path.basename(out_file) == "space-fsLR_atlas-Y_den-91k_dseg.dlabel.nii"
+
+    # TSV
+    name_source = "sub-01_task-imagery_run-01_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii"
+    out_file = atlas.copy_atlas(
+        name_source=name_source, in_file=atlas_labels_file, output_dir=tmpdir, atlas="Y"
+    )
+    assert os.path.isfile(out_file)
+    assert os.path.basename(out_file) == "atlas-Y_dseg.tsv"
+
+    # JSON
+    name_source = "sub-01_task-imagery_run-01_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii"
+    out_file = atlas.copy_atlas(
+        name_source=name_source, in_file=atlas_metadata_file, output_dir=tmpdir, atlas="Y"
+    )
+    assert os.path.isfile(out_file)
+    assert os.path.basename(out_file) == "atlas-Y_dseg.json"
+
+    # Ensure that out_file isn't overwritten if it already exists
+    fake_in_file = os.path.join(tmpdir, "fake.json")
+    with open(fake_in_file, "w") as fo:
+        fo.write("fake")
+
+    out_file = atlas.copy_atlas(
+        name_source=name_source, in_file=fake_in_file, output_dir=tmpdir, atlas="Y"
+    )
+    assert os.path.isfile(out_file)
+    assert os.path.basename(out_file) == "atlas-Y_dseg.json"
+    # The file should not be overwritten, so the contents shouldn't be "fake"
+    with open(out_file, "r") as fo:
+        assert fo.read() != "fake"

--- a/xcp_d/utils/atlas.py
+++ b/xcp_d/utils/atlas.py
@@ -160,6 +160,24 @@ def get_atlas_cifti(atlas):
 def copy_atlas(name_source, in_file, output_dir, atlas):
     """Copy atlas file to output directory.
 
+    Parameters
+    ----------
+    name_source : :obj:`str`
+        The source name of the atlas file.
+    in_file : :obj:`str`
+        The atlas file to copy.
+    output_dir : :obj:`str`
+        The output directory.
+    atlas : :obj:`str`
+        The name of the atlas.
+
+    Returns
+    -------
+    out_file : :obj:`str`
+        The path to the copied atlas file.
+
+    Notes
+    -----
     I can't use DerivativesDataSink because it has a problem with dlabel CIFTI files.
     It gives the following error:
     "AttributeError: 'Cifti2Header' object has no attribute 'set_data_dtype'"
@@ -167,31 +185,38 @@ def copy_atlas(name_source, in_file, output_dir, atlas):
     I can't override the CIFTI atlas's data dtype ahead of time because setting it to int8 or int16
     somehow converts all of the values in the data array to weird floats.
     This could be a version-specific nibabel issue.
+
+    I've also updated this function to handle JSON and TSV files as well.
     """
     import os
     import shutil
 
     from xcp_d.utils.bids import get_entity
 
-    extension = ".nii.gz" if name_source.endswith(".nii.gz") else ".dlabel.nii"
-    space = get_entity(name_source, "space")
-    res = get_entity(name_source, "res")
-    den = get_entity(name_source, "den")
-    cohort = get_entity(name_source, "cohort")
+    if in_file.endswith(".json"):
+        out_basename = f"atlas-{atlas}_dseg.json"
+    elif in_file.endswith(".tsv"):
+        out_basename = f"atlas-{atlas}_dseg.tsv"
+    else:
+        extension = ".nii.gz" if name_source.endswith(".nii.gz") else ".dlabel.nii"
+        space = get_entity(name_source, "space")
+        res = get_entity(name_source, "res")
+        den = get_entity(name_source, "den")
+        cohort = get_entity(name_source, "cohort")
 
-    cohort_str = f"_cohort-{cohort}" if cohort else ""
-    res_str = f"_res-{res}" if res else ""
-    den_str = f"_den-{den}" if den else ""
-    if extension == ".dlabel.nii":
-        atlas_basename = f"space-{space}_atlas-{atlas}{den_str}{cohort_str}_dseg{extension}"
-    elif extension == ".nii.gz":
-        atlas_basename = f"space-{space}_atlas-{atlas}{res_str}{cohort_str}_dseg{extension}"
+        cohort_str = f"_cohort-{cohort}" if cohort else ""
+        res_str = f"_res-{res}" if res else ""
+        den_str = f"_den-{den}" if den else ""
+        if extension == ".dlabel.nii":
+            out_basename = f"space-{space}_atlas-{atlas}{den_str}{cohort_str}_dseg{extension}"
+        elif extension == ".nii.gz":
+            out_basename = f"space-{space}_atlas-{atlas}{res_str}{cohort_str}_dseg{extension}"
 
     atlas_out_dir = os.path.join(output_dir, f"xcp_d/atlases/atlas-{atlas}")
     os.makedirs(atlas_out_dir, exist_ok=True)
-    out_atlas_file = os.path.join(atlas_out_dir, atlas_basename)
+    out_file = os.path.join(atlas_out_dir, out_basename)
     # Don't copy the file if it exists, to prevent any race conditions between parallel processes.
-    if not os.path.isfile(out_atlas_file):
-        shutil.copyfile(in_file, out_atlas_file)
+    if not os.path.isfile(out_file):
+        shutil.copyfile(in_file, out_file)
 
-    return out_atlas_file
+    return out_file

--- a/xcp_d/workflows/connectivity.py
+++ b/xcp_d/workflows/connectivity.py
@@ -238,65 +238,49 @@ def init_load_atlases_wf(
     ])  # fmt:skip
 
     ds_atlas_labels_file = pe.MapNode(
-        DerivativesDataSink(
-            base_directory=output_dir,
-            check_hdr=False,
-            dismiss_entities=[
-                "datatype",
-                "subject",
-                "session",
-                "task",
-                "run",
-                "desc",
-                "space",
-                "res",
-                "den",
-                "cohort",
+        Function(
+            function=copy_atlas,
+            input_names=[
+                "name_source",
+                "in_file",
+                "output_dir",
+                "atlas",
             ],
-            allowed_entities=["atlas"],
-            suffix="dseg",
-            extension=".tsv",
+            output_names=["out_file"],
         ),
         name="ds_atlas_labels_file",
-        iterfield=["atlas", "in_file"],
+        iterfield=["in_file", "atlas"],
         run_without_submitting=True,
     )
+    ds_atlas_labels_file.inputs.output_dir = output_dir
     ds_atlas_labels_file.inputs.atlas = atlases
 
     workflow.connect([
-        (inputnode, ds_atlas_labels_file, [("name_source", "source_file")]),
+        (inputnode, ds_atlas_labels_file, [("name_source", "name_source")]),
         (atlas_file_grabber, ds_atlas_labels_file, [("atlas_labels_file", "in_file")]),
-        (ds_atlas_labels_file, outputnode, [("out_file", "atlas_labels_files")]),
+        (ds_atlas_labels_file, outputnode, [("out_file", "atlas_files")]),
     ])  # fmt:skip
 
     ds_atlas_metadata = pe.MapNode(
-        DerivativesDataSink(
-            base_directory=output_dir,
-            check_hdr=False,
-            dismiss_entities=[
-                "datatype",
-                "subject",
-                "session",
-                "task",
-                "run",
-                "desc",
-                "space",
-                "res",
-                "den",
-                "cohort",
+        Function(
+            function=copy_atlas,
+            input_names=[
+                "name_source",
+                "in_file",
+                "output_dir",
+                "atlas",
             ],
-            allowed_entities=["atlas"],
-            suffix="dseg",
-            extension=".json",
+            output_names=["out_file"],
         ),
         name="ds_atlas_metadata",
-        iterfield=["atlas", "in_file"],
+        iterfield=["in_file", "atlas"],
         run_without_submitting=True,
     )
+    ds_atlas_metadata.inputs.output_dir = output_dir
     ds_atlas_metadata.inputs.atlas = atlases
 
     workflow.connect([
-        (inputnode, ds_atlas_metadata, [("name_source", "source_file")]),
+        (inputnode, ds_atlas_metadata, [("name_source", "name_source")]),
         (atlas_file_grabber, ds_atlas_metadata, [("atlas_metadata_file", "in_file")]),
     ])  # fmt:skip
 

--- a/xcp_d/workflows/connectivity.py
+++ b/xcp_d/workflows/connectivity.py
@@ -258,7 +258,7 @@ def init_load_atlases_wf(
     workflow.connect([
         (inputnode, ds_atlas_labels_file, [("name_source", "name_source")]),
         (atlas_file_grabber, ds_atlas_labels_file, [("atlas_labels_file", "in_file")]),
-        (ds_atlas_labels_file, outputnode, [("out_file", "atlas_files")]),
+        (ds_atlas_labels_file, outputnode, [("out_file", "atlas_labels_files")]),
     ])  # fmt:skip
 
     ds_atlas_metadata = pe.MapNode(

--- a/xcp_d/workflows/connectivity.py
+++ b/xcp_d/workflows/connectivity.py
@@ -127,11 +127,9 @@ def init_load_atlases_wf(
             name="get_transforms_to_bold_space",
         )
 
-        # fmt:off
         workflow.connect([
             (inputnode, get_transforms_to_bold_space, [("name_source", "bold_file")]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
 
         # ApplyTransforms needs a 3D image for the reference image.
         grab_first_volume = pe.Node(
@@ -154,7 +152,6 @@ def init_load_atlases_wf(
             n_procs=omp_nthreads,
         )
 
-        # fmt:off
         workflow.connect([
             (grab_first_volume, warp_atlases_to_bold_space, [("out_file", "reference_image")]),
             (atlas_file_grabber, warp_atlases_to_bold_space, [("atlas_file", "input_image")]),
@@ -162,8 +159,7 @@ def init_load_atlases_wf(
                 ("transformfile", "transforms"),
             ]),
             (warp_atlases_to_bold_space, atlas_buffer, [("output_image", "atlas_file")]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
 
     else:
         # Add empty vertices to atlas for locations in data, but not in atlas
@@ -175,13 +171,11 @@ def init_load_atlases_wf(
             iterfield=["label"],
         )
 
-        # fmt:off
         workflow.connect([
             (inputnode, resample_atlas_to_data, [("bold_file", "template_cifti")]),
             (atlas_file_grabber, resample_atlas_to_data, [("atlas_file", "label")]),
             (resample_atlas_to_data, atlas_buffer, [("cifti_out", "atlas_file")]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
 
         # Change the atlas to a scalar file.
         convert_to_dscalar = pe.MapNode(
@@ -195,11 +189,9 @@ def init_load_atlases_wf(
             n_procs=omp_nthreads,
             iterfield=["data_cifti"],
         )
-        # fmt:off
         workflow.connect([
             (resample_atlas_to_data, convert_to_dscalar, [("cifti_out", "data_cifti")]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
 
         # Convert atlas from dlabel to pscalar format.
         # The pscalar version of the atlas is later used for its ParcelAxis.
@@ -215,13 +207,11 @@ def init_load_atlases_wf(
             iterfield=["in_file", "atlas_label"],
         )
 
-        # fmt:off
         workflow.connect([
             (atlas_file_grabber, parcellate_atlas, [("atlas_file", "atlas_label")]),
             (convert_to_dscalar, parcellate_atlas, [("cifti_out", "in_file")]),
             (parcellate_atlas, outputnode, [("out_file", "parcellated_atlas_files")]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
 
     ds_atlas = pe.MapNode(
         Function(
@@ -241,13 +231,11 @@ def init_load_atlases_wf(
     ds_atlas.inputs.output_dir = output_dir
     ds_atlas.inputs.atlas = atlases
 
-    # fmt:off
     workflow.connect([
         (inputnode, ds_atlas, [("name_source", "name_source")]),
         (atlas_buffer, ds_atlas, [("atlas_file", "in_file")]),
         (ds_atlas, outputnode, [("out_file", "atlas_files")]),
-    ])
-    # fmt:on
+    ])  # fmt:skip
 
     ds_atlas_labels_file = pe.MapNode(
         DerivativesDataSink(
@@ -275,13 +263,11 @@ def init_load_atlases_wf(
     )
     ds_atlas_labels_file.inputs.atlas = atlases
 
-    # fmt:off
     workflow.connect([
         (inputnode, ds_atlas_labels_file, [("name_source", "source_file")]),
         (atlas_file_grabber, ds_atlas_labels_file, [("atlas_labels_file", "in_file")]),
         (ds_atlas_labels_file, outputnode, [("out_file", "atlas_labels_files")]),
-    ])
-    # fmt:on
+    ])  # fmt:skip
 
     ds_atlas_metadata = pe.MapNode(
         DerivativesDataSink(
@@ -309,12 +295,10 @@ def init_load_atlases_wf(
     )
     ds_atlas_metadata.inputs.atlas = atlases
 
-    # fmt:off
     workflow.connect([
         (inputnode, ds_atlas_metadata, [("name_source", "source_file")]),
         (atlas_file_grabber, ds_atlas_metadata, [("atlas_metadata_file", "in_file")]),
-    ])
-    # fmt:on
+    ])  # fmt:skip
 
     return workflow
 


### PR DESCRIPTION
Closes #1064.

## Changes proposed in this pull request

- Switch from using DerivativesDataSink to using `xcp_d.utils.atlas.copy_atlas` for writing out the atlas-specific TSV and JSON files.
- Modify `copy_atlas` to handle TSV and JSON files.
- Update associated test.