### PR TITLE
Replace `bids:xcp_d:` BIDS URI with `bids::`

### DIFF
--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -313,10 +313,10 @@ def test_make_xcpd_uri():
     """Test _make_xcpd_uri."""
     out_file = "/path/to/dset/xcp_d/sub-01/func/sub-01_task-rest_bold.nii.gz"
     uri = xbids._make_xcpd_uri(out_file, output_dir="/path/to/dset")
-    assert uri == ["bids:xcp_d:sub-01/func/sub-01_task-rest_bold.nii.gz"]
+    assert uri == ["bids::sub-01/func/sub-01_task-rest_bold.nii.gz"]
 
     xbids._make_xcpd_uri([out_file], output_dir="/path/to/dset")
-    assert uri == ["bids:xcp_d:sub-01/func/sub-01_task-rest_bold.nii.gz"]
+    assert uri == ["bids::sub-01/func/sub-01_task-rest_bold.nii.gz"]
 
 
 def test_make_xcpd_uri_lol():
@@ -336,16 +336,16 @@ def test_make_xcpd_uri_lol():
     uris = xbids._make_xcpd_uri_lol(in_list, output_dir="/path/to/dset/")
     assert uris == [
         [
-            "bids:xcp_d:sub-01/func/sub-01_task-rest_run-1_bold.nii.gz",
-            "bids:xcp_d:sub-01/func/sub-01_task-rest_run-2_bold.nii.gz",
+            "bids::sub-01/func/sub-01_task-rest_run-1_bold.nii.gz",
+            "bids::sub-01/func/sub-01_task-rest_run-2_bold.nii.gz",
         ],
         [
-            "bids:xcp_d:sub-02/func/sub-01_task-rest_run-1_bold.nii.gz",
-            "bids:xcp_d:sub-02/func/sub-01_task-rest_run-2_bold.nii.gz",
+            "bids::sub-02/func/sub-01_task-rest_run-1_bold.nii.gz",
+            "bids::sub-02/func/sub-01_task-rest_run-2_bold.nii.gz",
         ],
         [
-            "bids:xcp_d:sub-03/func/sub-01_task-rest_run-1_bold.nii.gz",
-            "bids:xcp_d:sub-03/func/sub-01_task-rest_run-2_bold.nii.gz",
+            "bids::sub-03/func/sub-01_task-rest_run-1_bold.nii.gz",
+            "bids::sub-03/func/sub-01_task-rest_run-2_bold.nii.gz",
         ],
     ]
 

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -156,11 +156,9 @@ def test_write_dataset_description(datasets, tmp_path_factory, caplog):
         desc = json.load(fo)
 
     assert "'preprocessed' is already a dataset link" not in caplog.text
-    assert "'xcp_d' is already a dataset link" not in caplog.text
     assert "'custom_confounds' is already a dataset link" not in caplog.text
     xbids.write_dataset_description(tmpdir, tmpdir, custom_confounds_folder="/fake/path4")
     assert "'preprocessed' is already a dataset link" in caplog.text
-    assert "'xcp_d' is already a dataset link" in caplog.text
     assert "'custom_confounds' is already a dataset link" in caplog.text
 
     # Now change the version and re-run the function.

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -733,11 +733,6 @@ def write_dataset_description(fmri_dir, xcpd_dir, custom_confounds_folder=None):
 
     dset_desc["DatasetLinks"]["preprocessed"] = str(fmri_dir)
 
-    if "xcp_d" in dset_desc["DatasetLinks"].keys():
-        LOGGER.warning("'xcp_d' is already a dataset link. Overwriting.")
-
-    dset_desc["DatasetLinks"]["xcp_d"] = str(xcpd_dir)
-
     if custom_confounds_folder:
         if "custom_confounds" in dset_desc["DatasetLinks"].keys():
             LOGGER.warning("'custom_confounds' is already a dataset link. Overwriting.")

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -1005,9 +1005,9 @@ def _make_xcpd_uri(out_file, output_dir):
     dataset_path = os.path.join(output_dir, "xcp_d")
 
     if isinstance(out_file, list):
-        return [_make_uri(of, "xcp_d", dataset_path) for of in out_file]
+        return [_make_uri(of, "", dataset_path) for of in out_file]
     else:
-        return [_make_uri(out_file, "xcp_d", dataset_path)]
+        return [_make_uri(out_file, "", dataset_path)]
 
 
 def _make_xcpd_uri_lol(in_list, output_dir):


### PR DESCRIPTION
Closes #1080.

## Changes proposed in this pull request

- Change the internal XCP-D BIDS URI prefix from `bids:xcp_d:` to `bids::`.
- Remove the `xcp_d` DatasetLink from the dataset_description.json. There's no need to include a link from the dataset to itself.