### PR TITLE
Fix query error report in `collect_mesh_data`

### DIFF
--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -966,7 +966,7 @@ def build_workflow(opts, retval):
     run_uuid = f"{strftime('%Y%m%d-%H%M%S')}_{uuid.uuid4()}"
     retval["run_uuid"] = run_uuid
 
-    layout = BIDSLayout(str(opts.fmri_dir), validate=False, derivatives=True)
+    layout = BIDSLayout(str(opts.fmri_dir), validate=False)
     subject_list = collect_participants(layout, participant_label=opts.participant_label)
     retval["subject_list"] = subject_list
 

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -34,7 +34,7 @@ class ExecutiveSummary(object):
         else:
             self.session_id = None
 
-        self.layout = BIDSLayout(xcpd_path, validate=False, derivatives=True)
+        self.layout = BIDSLayout(xcpd_path, validate=False)
 
     def write_html(self, document, filename):
         """Write an html document to a filename.

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 
 import pytest
 from bids.layout import BIDSLayout
@@ -123,17 +124,64 @@ def test_collect_data_nibabies(datasets):
         )
 
 
-def test_collect_mesh_data(datasets):
+def test_collect_mesh_data(datasets, tmp_path_factory):
     """Test collect_mesh_data."""
+    # Dataset without mesh files
     layout = BIDSLayout(datasets["fmriprep_without_freesurfer"], validate=False, derivatives=True)
     mesh_available, standard_space_mesh, _ = xbids.collect_mesh_data(layout, "01")
     assert mesh_available is False
     assert standard_space_mesh is False
 
+    # Dataset with native-space mesh files (one file matching each query)
     layout = BIDSLayout(datasets["ds001419"], validate=False, derivatives=True)
     mesh_available, standard_space_mesh, _ = xbids.collect_mesh_data(layout, "01")
     assert mesh_available is True
     assert standard_space_mesh is False
+
+    # Dataset with standard-space mesh files (one file matching each query)
+    std_mesh_dir = tmp_path_factory.mktemp("standard_mesh")
+    shutil.copyfile(
+        os.path.join(datasets["ds001419"], "dataset_description.json"),
+        std_mesh_dir / "dataset_description.json",
+    )
+    os.makedirs(std_mesh_dir / "sub-01/anat", exist_ok=True)
+    files = [
+        "sub-01_space-fsLR_den-32k_hemi-L_pial.surf.gii",
+        "sub-01_space-fsLR_den-32k_hemi-L_white.surf.gii",
+        "sub-01_space-fsLR_den-32k_hemi-R_pial.surf.gii",
+        "sub-01_space-fsLR_den-32k_hemi-R_white.surf.gii",
+    ]
+    for f in files:
+        (std_mesh_dir / "sub-01/anat").joinpath(f).touch()
+
+    layout = BIDSLayout(std_mesh_dir, validate=False, derivatives=True)
+    mesh_available, standard_space_mesh, _ = xbids.collect_mesh_data(layout, "01")
+    assert mesh_available is True
+    assert standard_space_mesh is True
+
+    # Dataset with multiple files matching each query (raises an error)
+    bad_mesh_dir = tmp_path_factory.mktemp("standard_mesh")
+    shutil.copyfile(
+        os.path.join(datasets["ds001419"], "dataset_description.json"),
+        bad_mesh_dir / "dataset_description.json",
+    )
+    os.makedirs(bad_mesh_dir / "sub-01/anat", exist_ok=True)
+    files = [
+        "sub-01_space-fsLR_den-32k_hemi-L_pial.surf.gii",
+        "sub-01_space-fsLR_den-32k_hemi-L_white.surf.gii",
+        "sub-01_space-fsLR_den-32k_hemi-R_pial.surf.gii",
+        "sub-01_space-fsLR_den-32k_hemi-R_white.surf.gii",
+        "sub-01_acq-test_space-fsLR_den-32k_hemi-L_pial.surf.gii",
+        "sub-01_acq-test_space-fsLR_den-32k_hemi-L_white.surf.gii",
+        "sub-01_acq-test_space-fsLR_den-32k_hemi-R_pial.surf.gii",
+        "sub-01_acq-test_space-fsLR_den-32k_hemi-R_white.surf.gii",
+    ]
+    for f in files:
+        (std_mesh_dir / "sub-01/anat").joinpath(f).touch()
+
+    layout = BIDSLayout(std_mesh_dir, validate=False, derivatives=True)
+    with pytest.raises(ValueError, match="More than one surface found"):
+        xbids.collect_mesh_data(layout, "01")
 
 
 def test_write_dataset_description(datasets, tmp_path_factory, caplog):

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -86,7 +86,6 @@ def test_collect_data_nibabies(datasets):
     layout = BIDSLayout(
         bids_dir,
         validate=False,
-        derivatives=True,
         config=["bids", "derivatives"],
     )
 
@@ -127,13 +126,13 @@ def test_collect_data_nibabies(datasets):
 def test_collect_mesh_data(datasets, tmp_path_factory):
     """Test collect_mesh_data."""
     # Dataset without mesh files
-    layout = BIDSLayout(datasets["fmriprep_without_freesurfer"], validate=False, derivatives=True)
+    layout = BIDSLayout(datasets["fmriprep_without_freesurfer"], validate=False)
     mesh_available, standard_space_mesh, _ = xbids.collect_mesh_data(layout, "01")
     assert mesh_available is False
     assert standard_space_mesh is False
 
     # Dataset with native-space mesh files (one file matching each query)
-    layout = BIDSLayout(datasets["ds001419"], validate=False, derivatives=True)
+    layout = BIDSLayout(datasets["ds001419"], validate=False)
     mesh_available, standard_space_mesh, _ = xbids.collect_mesh_data(layout, "01")
     assert mesh_available is True
     assert standard_space_mesh is False
@@ -154,7 +153,7 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
     for f in files:
         (std_mesh_dir / "sub-01/anat").joinpath(f).touch()
 
-    layout = BIDSLayout(std_mesh_dir, validate=False, derivatives=True)
+    layout = BIDSLayout(std_mesh_dir, validate=False)
     mesh_available, standard_space_mesh, _ = xbids.collect_mesh_data(layout, "01")
     assert mesh_available is True
     assert standard_space_mesh is True
@@ -179,7 +178,7 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
     for f in files:
         (std_mesh_dir / "sub-01/anat").joinpath(f).touch()
 
-    layout = BIDSLayout(std_mesh_dir, validate=False, derivatives=True)
+    layout = BIDSLayout(std_mesh_dir, validate=False)
     with pytest.raises(ValueError, match="More than one surface found"):
         xbids.collect_mesh_data(layout, "01")
 

--- a/xcp_d/tests/utils.py
+++ b/xcp_d/tests/utils.py
@@ -107,8 +107,8 @@ def check_generated_files(out_dir, output_list_file):
 
 def check_affines(data_dir, out_dir, input_type):
     """Confirm affines don't change across XCP-D runs."""
-    preproc_layout = BIDSLayout(str(data_dir), validate=False, derivatives=False)
-    xcp_layout = BIDSLayout(str(out_dir), validate=False, derivatives=False)
+    preproc_layout = BIDSLayout(str(data_dir), validate=False)
+    xcp_layout = BIDSLayout(str(out_dir), validate=False)
     if input_type == "cifti":  # Get the .dtseries.nii
         denoised_files = xcp_layout.get(
             invalid_filters="allow",

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -395,7 +395,7 @@ def collect_mesh_data(layout, participant_label):
     # Surfaces to use for brainsprite and anatomical workflow
     # The base surfaces can be used to generate the derived surfaces.
     # The base surfaces may be in native or standard space.
-    queries = {
+    base_queries = {
         "pial_surf": "pial",
         "wm_surf": ["smoothwm", "white"],
     }
@@ -405,7 +405,7 @@ def collect_mesh_data(layout, participant_label):
     }
 
     standard_space_mesh = True
-    for name, suffixes in queries.items():
+    for name, suffixes in base_queries.items():
         # First, try to grab the first base surface file in standard space.
         # If it's not available, switch to native T1w-space data.
         for hemisphere in ["L", "R"]:
@@ -432,19 +432,19 @@ def collect_mesh_data(layout, participant_label):
         }
 
     initial_mesh_files = {}
-    for name, suffixes in queries.items():
+    queries = {}
+    for name, suffixes in base_queries.items():
         for hemisphere in ["L", "R"]:
             key = f"{hemisphere.lower()}h_{name}"
-            initial_mesh_files[key] = layout.get(
-                return_type="file",
-                subject=participant_label,
-                datatype="anat",
-                hemi=hemisphere,
-                desc=None,
-                suffix=suffixes,
-                extension=".surf.gii",
+            queries[key] = {
+                "datatype": "anat",
+                "hemi": hemisphere,
+                "desc": None,
+                "suffix": suffixes,
+                "extension": ".surf.gii",
                 **query_extras,
-            )
+            }
+            initial_mesh_files[key] = layout.get(return_type="file", **queries[key])
 
     mesh_files = {}
     mesh_available = True

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -105,7 +105,7 @@ def collect_participants(bids_dir, participant_label=None, strict=False, bids_va
     if isinstance(bids_dir, BIDSLayout):
         layout = bids_dir
     else:
-        layout = BIDSLayout(str(bids_dir), validate=bids_validate, derivatives=True)
+        layout = BIDSLayout(str(bids_dir), validate=bids_validate)
 
     all_participants = set(layout.get_subjects())
 
@@ -181,7 +181,6 @@ def collect_data(
         layout = BIDSLayout(
             str(bids_dir),
             validate=bids_validate,
-            derivatives=True,
             config=["bids", "derivatives"],
         )
 


### PR DESCRIPTION
References #1090.

## Changes proposed in this pull request

- Ensure that the `queries` dictionary has the necessary keys for error reporting in `collect_mesh_data`.
- Drop `derivatives=True` from BIDSLayout inits. This will resolve a number of warnings.