### PR TITLE
Use pytest-env to capture warnings on CI runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ markers = [
     "nibabies: mark integration test for nibabies derivatives",
 ]
 env = [
-    "PYTHONWARNINGS" = "default",
+    "PYTHONWARNINGS = default",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ markers = [
     "nibabies: mark integration test for nibabies derivatives",
 ]
 env = [
-    "PYTHONWARNINGS = default",
+    "RUNNING_PYTEST = 1",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ tests = [
     "pep8-naming",
     "pytest",
     "pytest-cov",
+    "pytest-env",
 ]
 maint = [
     "fuzzywuzzy",
@@ -175,6 +176,9 @@ markers = [
     "pnc_cifti_t2wonly: mark integration test for fMRIPrep derivatives with CIFTI settings and a simulated T2w file",
     "fmriprep_without_freesurfer: mark integration test for fMRIPrep derivatives without FreeSurfer",
     "nibabies: mark integration test for nibabies derivatives",
+]
+env = [
+    "PYTHONWARNINGS" = "default",
 ]
 
 [tool.coverage.run]

--- a/xcp_d/config.py
+++ b/xcp_d/config.py
@@ -117,8 +117,9 @@ finally:
 
 if not hasattr(sys, "_is_pytest_session"):
     sys._is_pytest_session = False  # Trick to avoid sklearn's FutureWarnings
+
 # Disable all warnings in main and children processes only on production versions
-if not any(
+if ("RUNNING_PYTEST" not in os.environ) and not any(
     (
         "+" in __version__,
         __version__.endswith(".dirty"),
@@ -463,7 +464,7 @@ class execution(_Config):
             if cls.participant_label:
                 # Ignore any subjects who aren't the requested ones.
                 ignore_patterns.append(
-                    re.compile(r'sub-(?!' + '|'.join(cls.participant_label) + r')\w+')
+                    re.compile(r"sub-(?!" + "|".join(cls.participant_label) + r")\w+")
                 )
 
             _indexer = BIDSLayoutIndexer(


### PR DESCRIPTION
References #1106 (won't be able to tell if it works until I make a release, I think).

## Changes proposed in this pull request

- Add `pytest-env` to testing dependencies.
- Set environment variable `PYTHONWARNINGS` to "default" in test runs, since it is set to "ignore" for production runs by the Config object.