### PR TITLE
Convert coverage values to float32 to address pandas warning

### DIFF
--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -197,7 +197,7 @@ class NiftiParcellate(SimpleInterface):
 
         # Save out the coverage tsv
         coverage_df = pd.DataFrame(
-            data=parcel_coverage,
+            data=np.round(parcel_coverage, 4),
             index=node_labels,
             columns=["coverage"],
         )
@@ -473,7 +473,7 @@ class CiftiParcellate(SimpleInterface):
 
                 # Determine the percentage of vertices with good data
                 parcel_coverage = 1 - (bad_vertices_in_parcel_idx.size / parcel_idx.size)
-                coverage_df.loc[parcel_label, "coverage"] = parcel_coverage
+                coverage_df.loc[parcel_label, "coverage"] = np.round(parcel_coverage, 4)
 
                 if parcel_coverage < min_coverage:
                     # If the parcel has >=50% bad data, replace all of the values with zeros.

--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -197,7 +197,7 @@ class NiftiParcellate(SimpleInterface):
 
         # Save out the coverage tsv
         coverage_df = pd.DataFrame(
-            data=np.round(parcel_coverage, 4),
+            data=parcel_coverage.astype(np.float32),
             index=node_labels,
             columns=["coverage"],
         )
@@ -473,7 +473,7 @@ class CiftiParcellate(SimpleInterface):
 
                 # Determine the percentage of vertices with good data
                 parcel_coverage = 1 - (bad_vertices_in_parcel_idx.size / parcel_idx.size)
-                coverage_df.loc[parcel_label, "coverage"] = np.round(parcel_coverage, 4)
+                coverage_df.loc[parcel_label, "coverage"] = np.float32(parcel_coverage)
 
                 if parcel_coverage < min_coverage:
                     # If the parcel has >=50% bad data, replace all of the values with zeros.


### PR DESCRIPTION
Meant to address the many warnings I'm seeing:

```
xcp_d/tests/test_cli.py::test_ds001419_cifti
  /src/xcp_d/xcp_d/interfaces/connectivity.py:476: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '0.48340796876794123' has dtype incompatible with float32, please explicitly cast to a compatible dtype first.
    coverage_df.loc[parcel_label, "coverage"] = parcel_coverage
```
