### PR TITLE
Modify metadata and boilerplate to reflect updated motion filter parameters

### DIFF
--- a/xcp_d/interfaces/censoring.py
+++ b/xcp_d/interfaces/censoring.py
@@ -530,7 +530,7 @@ class GenerateConfounds(SimpleInterface):
             if self.inputs.motion_filter_type == "lp":
                 filters = col_metadata.get("SoftwareFilters", {})
                 filters["Butterworth low-pass filter"] = {
-                    "cutoff": band_stop_max_adjusted / 60,
+                    "cutoff": band_stop_min_adjusted / 60,
                     "order": self.inputs.motion_filter_order,
                     "cutoff units": "Hz",
                     "function": "scipy.signal.filtfilt",
@@ -541,8 +541,8 @@ class GenerateConfounds(SimpleInterface):
                 filters = col_metadata.get("SoftwareFilters", {})
                 filters["IIR notch digital filter"] = {
                     "cutoff": [
-                        band_stop_min_adjusted / 60,
                         band_stop_max_adjusted / 60,
+                        band_stop_min_adjusted / 60,
                     ],
                     "order": self.inputs.motion_filter_order,
                     "cutoff units": "Hz",

--- a/xcp_d/interfaces/censoring.py
+++ b/xcp_d/interfaces/censoring.py
@@ -557,8 +557,10 @@ class GenerateConfounds(SimpleInterface):
         if confounds_df is not None:
             # Update confounds metadata with modified motion metadata
             for col in motion_df.columns.tolist():
-                if col in confounds_metadata.keys():
-                    confounds_metadata[col] = motion_metadata[col]
+                if col in confounds_df.columns:
+                    base_metadata = confounds_metadata.get(col, {})
+                    base_metadata.update(motion_metadata[col])
+                    confounds_metadata[col] = base_metadata
 
             # Orthogonalize full nuisance regressors w.r.t. any signal regressors
             signal_columns = [c for c in confounds_df.columns if c.startswith("signal__")]

--- a/xcp_d/interfaces/censoring.py
+++ b/xcp_d/interfaces/censoring.py
@@ -14,7 +14,12 @@ from nipype.interfaces.base import (
     traits,
 )
 
-from xcp_d.utils.confounds import _infer_dummy_scans, load_confound_matrix, load_motion
+from xcp_d.utils.confounds import (
+    _infer_dummy_scans,
+    _modify_motion_filter,
+    load_confound_matrix,
+    load_motion,
+)
 from xcp_d.utils.filemanip import fname_presuffix
 from xcp_d.utils.modified_data import _drop_dummy_scans, compute_fd
 
@@ -452,13 +457,20 @@ class GenerateConfounds(SimpleInterface):
 
     def _run_interface(self, runtime):
         fmriprep_confounds_df = pd.read_table(self.inputs.fmriprep_confounds_file)
+        band_stop_min_adjusted, band_stop_max_adjusted, _ = _modify_motion_filter(
+            motion_filter_type=self.inputs.motion_filter_type,
+            band_stop_min=self.inputs.band_stop_min,
+            band_stop_max=self.inputs.band_stop_max,
+            TR=self.inputs.TR,
+        )
+
         motion_df = load_motion(
             fmriprep_confounds_df.copy(),
             TR=self.inputs.TR,
             motion_filter_type=self.inputs.motion_filter_type,
             motion_filter_order=self.inputs.motion_filter_order,
-            band_stop_min=self.inputs.band_stop_min,
-            band_stop_max=self.inputs.band_stop_max,
+            band_stop_min=band_stop_min_adjusted,
+            band_stop_max=band_stop_max_adjusted,
         )
 
         # Add in framewise displacement
@@ -504,7 +516,50 @@ class GenerateConfounds(SimpleInterface):
             custom_confounds=self.inputs.custom_confounds_file,
         )
 
+        # Compile motion metadata from confounds metadata, adding in filtering info
+        motion_metadata = {}
+        for col in motion_df.columns.tolist():
+            col_metadata = confounds_metadata.get(col, {})
+            if col == "framewise_displacement":
+                col_metadata["Description"] = (
+                    "Framewise displacement calculated according to Power et al. (2012)."
+                )
+                col_metadata["Units"] = "mm"
+                col_metadata["HeadRadius"] = self.inputs.head_radius
+
+            if self.inputs.motion_filter_type == "lp":
+                filters = col_metadata.get("SoftwareFilters", {})
+                filters["Butterworth low-pass filter"] = {
+                    "cutoff": band_stop_max_adjusted / 60,
+                    "order": self.inputs.motion_filter_order,
+                    "cutoff units": "Hz",
+                    "function": "scipy.signal.filtfilt",
+                }
+                col_metadata["SoftwareFilters"] = filters
+
+            elif self.inputs.motion_filter_type == "notch":
+                filters = col_metadata.get("SoftwareFilters", {})
+                filters["IIR notch digital filter"] = {
+                    "cutoff": [
+                        band_stop_min_adjusted / 60,
+                        band_stop_max_adjusted / 60,
+                    ],
+                    "order": self.inputs.motion_filter_order,
+                    "cutoff units": "Hz",
+                    "function": "scipy.signal.filtfilt",
+                }
+                col_metadata["SoftwareFilters"] = filters
+
+            motion_metadata[col] = col_metadata
+
+        self._results["motion_metadata"] = motion_metadata
+
         if confounds_df is not None:
+            # Update confounds metadata with modified motion metadata
+            for col in motion_df.columns.tolist():
+                if col in confounds_metadata.keys():
+                    confounds_metadata[col] = motion_metadata[col]
+
             # Orthogonalize full nuisance regressors w.r.t. any signal regressors
             signal_columns = [c for c in confounds_df.columns if c.startswith("signal__")]
             if signal_columns:
@@ -589,28 +644,6 @@ class GenerateConfounds(SimpleInterface):
             header=True,
             sep="\t",
         )
-
-        # Compile metadata to pass along to outputs.
-        motion_metadata = {
-            "framewise_displacement": {
-                "Description": (
-                    "Framewise displacement calculated according to Power et al. (2012)."
-                ),
-                "Units": "mm",
-                "HeadRadius": self.inputs.head_radius,
-            }
-        }
-        if self.inputs.motion_filter_type == "lp":
-            motion_metadata["LowpassFilter"] = self.inputs.band_stop_max
-            motion_metadata["LowpassFilterOrder"] = self.inputs.motion_filter_order
-        elif self.inputs.motion_filter_type == "notch":
-            motion_metadata["BandstopFilter"] = [
-                self.inputs.band_stop_min,
-                self.inputs.band_stop_max,
-            ]
-            motion_metadata["BandstopFilterOrder"] = self.inputs.motion_filter_order
-
-        self._results["motion_metadata"] = motion_metadata
 
         outliers_metadata = {
             "framewise_displacement": {

--- a/xcp_d/tests/test_utils_confounds.py
+++ b/xcp_d/tests/test_utils_confounds.py
@@ -28,8 +28,8 @@ def test_modify_motion_filter():
     with pytest.warns(
         UserWarning,
         match=re.escape(
-            "Low-pass filter frequency is above Nyquist frequency (0.625 Hz), "
-            "so it has been changed (0.7 --> 0.55 Hz)."
+            "Low-pass filter frequency is above Nyquist frequency (37.5 BPM), "
+            "so it has been changed (42 --> 33.0 BPM)."
         ),
     ):
         band_stop_min2, _, is_modified = confounds._modify_motion_filter(
@@ -38,7 +38,7 @@ def test_modify_motion_filter():
             band_stop_min=42,  # 0.7 Hz > (1.25 / 2)
             band_stop_max=None,
         )
-    assert band_stop_min2 == 0.55
+    assert band_stop_min2 == 33.0
     assert is_modified is True
 
     # Now test band-stop filter
@@ -49,8 +49,8 @@ def test_modify_motion_filter():
     with pytest.warns(
         UserWarning,
         match=re.escape(
-            "One or both filter frequencies are above Nyquist frequency (0.625 Hz), "
-            "so they have been changed (0.7 --> 0.55, 0.75 --> 0.5 Hz)."
+            "One or both filter frequencies are above Nyquist frequency (37.5 BPM), "
+            "so they have been changed (42 --> 33.0, 45 --> 30.0 BPM)."
         ),
     ):
         band_stop_min2, band_stop_max2, is_modified = confounds._modify_motion_filter(
@@ -60,8 +60,8 @@ def test_modify_motion_filter():
             band_stop_max=45,  # 0.7 Hz > (1.25 / 2)
         )
 
-    assert band_stop_min2 == 0.55
-    assert band_stop_max2 == 0.5
+    assert band_stop_min2 == 33.0
+    assert band_stop_max2 == 30.0
     assert is_modified is True
 
     # Using a filter type other than notch or lp should raise an exception.

--- a/xcp_d/tests/test_utils_confounds.py
+++ b/xcp_d/tests/test_utils_confounds.py
@@ -22,7 +22,7 @@ def test_modify_motion_filter():
             TR=TR,
         )
     assert band_stop_min2 == band_stop_min
-    assert is_modified is True
+    assert is_modified is False
 
     # Use freq above Nyquist, and function will automatically modify the filter.
     with pytest.warns(
@@ -104,6 +104,7 @@ def test_motion_filtering_lp():
         TR=TR,
         motion_filter_type="lp",
         band_stop_min=band_stop_min,
+        band_stop_max=None,
         motion_filter_order=2,
     )
 

--- a/xcp_d/tests/test_utils_confounds.py
+++ b/xcp_d/tests/test_utils_confounds.py
@@ -64,15 +64,6 @@ def test_modify_motion_filter():
     assert band_stop_max2 == 30.0
     assert is_modified is True
 
-    # Using a filter type other than notch or lp should raise an exception.
-    with pytest.raises(ValueError, match="Motion filter type 'fail' not supported."):
-        confounds._modify_motion_filter(
-            TR=TR,
-            motion_filter_type="fail",
-            band_stop_min=band_stop_min,
-            band_stop_max=band_stop_max,
-        )
-
 
 def test_motion_filtering_lp():
     """Run low-pass filter on toy data, compare to simplified results."""
@@ -110,6 +101,17 @@ def test_motion_filtering_lp():
 
     # What's the difference from the verified data?
     assert np.allclose(np.squeeze(lowpass_data_test), lowpass_data_true)
+
+    # Using a filter type other than notch or lp should raise an exception.
+    with pytest.raises(ValueError, match="Motion filter type 'fail' not supported."):
+        confounds.motion_regression_filter(
+            raw_data,
+            TR=TR,
+            motion_filter_type="fail",
+            band_stop_min=band_stop_min,
+            band_stop_max=None,
+            motion_filter_order=2,
+        )
 
 
 def test_motion_filtering_notch():

--- a/xcp_d/tests/test_utils_confounds.py
+++ b/xcp_d/tests/test_utils_confounds.py
@@ -240,3 +240,11 @@ def test_describe_censoring():
         exact_scans=[],
     )
     assert isinstance(desc, str)
+
+    # no filter, no censoring, exact-scan
+    desc = confounds.describe_censoring(
+        motion_filter_type=None,
+        fd_thresh=0,
+        exact_scans=[100, 150],
+    )
+    assert isinstance(desc, str)

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -632,7 +632,10 @@ def motion_regression_filter(
         raise ValueError(f"Motion filter type '{motion_filter_type}' not supported.")
 
     band_stop_min_adjusted, band_stop_max_adjusted, _ = _modify_motion_filter(
-        motion_filter_type, band_stop_min, band_stop_max, TR
+        motion_filter_type=motion_filter_type,
+        band_stop_min=band_stop_min,
+        band_stop_max=band_stop_max,
+        TR=TR,
     )
     lowpass_hz_adjusted = band_stop_min_adjusted / 60
 
@@ -681,18 +684,18 @@ def _modify_motion_filter(motion_filter_type, band_stop_min, band_stop_max, TR):
     motion_filter_type : str
         The type of motion filter to apply.
     band_stop_min : float
-        The minimum frequency to stop in the filter, in beats-per-minute.
+        The minimum frequency to stop in the filter, in breaths-per-minute.
     band_stop_max : float
-        The maximum frequency to stop in the filter, in beats-per-minute.
+        The maximum frequency to stop in the filter, in breaths-per-minute.
     TR : float
         The repetition time of the data.
 
     Returns
     -------
     band_stop_min_adjusted : float
-        The adjusted low-pass filter frequency, in beats-per-minute.
+        The adjusted low-pass filter frequency, in breaths-per-minute.
     band_stop_max_adjusted : float
-        The adjusted high-pass filter frequency, in beats-per-minute.
+        The adjusted high-pass filter frequency, in breaths-per-minute.
     is_modified : bool
         Whether the filter parameters were modified.
     """

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -715,8 +715,9 @@ def _modify_motion_filter(motion_filter_type, band_stop_min, band_stop_max, TR):
         )
         band_stop_min_adjusted = lowpass_hz_adjusted * 60  # change Hertz back to BPM
         if band_stop_min_adjusted != band_stop_min:
+            nyquist_bpm = nyquist_frequency * 60
             warnings.warn(
-                f"Low-pass filter frequency is above Nyquist frequency ({nyquist_frequency} Hz), "
+                f"Low-pass filter frequency is above Nyquist frequency ({nyquist_bpm} BPM), "
                 f"so it has been changed ({band_stop_min} --> {band_stop_min_adjusted} BPM)."
             )
             is_modified = True

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -695,6 +695,7 @@ def _modify_motion_filter(motion_filter_type, band_stop_min, band_stop_max, TR):
     """
     sampling_frequency = 1 / TR
     nyquist_frequency = sampling_frequency / 2
+    nyquist_bpm = nyquist_frequency * 60
 
     is_modified = False
     if motion_filter_type == "lp":  # low-pass filter
@@ -715,7 +716,6 @@ def _modify_motion_filter(motion_filter_type, band_stop_min, band_stop_max, TR):
         )
         band_stop_min_adjusted = lowpass_hz_adjusted * 60  # change Hertz back to BPM
         if band_stop_min_adjusted != band_stop_min:
-            nyquist_bpm = nyquist_frequency * 60
             warnings.warn(
                 f"Low-pass filter frequency is above Nyquist frequency ({nyquist_bpm} BPM), "
                 f"so it has been changed ({band_stop_min} --> {band_stop_min_adjusted} BPM)."

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -735,7 +735,7 @@ def _modify_motion_filter(motion_filter_type, band_stop_min, band_stop_max, TR):
         assert band_stop_min is not None
         assert band_stop_max > 0
         assert band_stop_min > 0
-        assert band_stop_min < band_stop_max
+        assert band_stop_min < band_stop_max, f"{band_stop_min} >= {band_stop_max}"
 
         stopband = np.array([band_stop_min, band_stop_max])
         stopband_hz = stopband / 60  # change BPM to Hertz

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -645,7 +645,7 @@ def motion_regression_filter(
         )
         filtered_data = filtfilt(b, a, data, axis=0, padtype="constant", padlen=data.shape[0] - 1)
 
-    elif motion_filter_type == "notch":  # notch filter
+    else:  # notch filter
         highpass_hz = band_stop_max / 60
         stopband_hz = np.array([lowpass_hz, highpass_hz])
         # Convert stopband to a single notch frequency.

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -745,8 +745,7 @@ def _modify_motion_filter(motion_filter_type, band_stop_min, band_stop_max, TR):
         stopband_adjusted = stopband_hz_adjusted * 60  # change Hertz back to BPM
         if not np.array_equal(stopband_adjusted, stopband):
             warnings.warn(
-                "One or both filter frequencies are above Nyquist frequency "
-                f"({nyquist_frequency} Hz), "
+                f"One or both filter frequencies are above Nyquist frequency ({nyquist_bpm} BPM), "
                 "so they have been changed "
                 f"({stopband[0]} --> {stopband_adjusted[0]}, "
                 f"{stopband[1]} --> {stopband_adjusted[1]} BPM)."

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -756,6 +756,8 @@ def _modify_motion_filter(motion_filter_type, band_stop_min, band_stop_max, TR):
             is_modified = True
 
         band_stop_min_adjusted, band_stop_max_adjusted = stopband_adjusted
+    else:
+        band_stop_min_adjusted, band_stop_max_adjusted, is_modified = None, None, False
 
     return band_stop_min_adjusted, band_stop_max_adjusted, is_modified
 

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -253,16 +253,16 @@ def describe_regression(params, custom_confounds_file, motion_filter_type):
 
 
 @fill_doc
-def describe_censoring(
+def describe_motion_parameters(
+    *,
     motion_filter_type,
     motion_filter_order,
     band_stop_min,
     band_stop_max,
     head_radius,
-    fd_thresh,
-    exact_scans,
+    TR,
 ):
-    """Build a text description of the motion parameter filtering and FD censoring process.
+    """Build a text description of the motion parameter filtering and FD calculation process.
 
     Parameters
     ----------
@@ -271,6 +271,79 @@ def describe_censoring(
     %(band_stop_min)s
     %(band_stop_max)s
     %(head_radius)s
+    %(TR)s
+
+    Returns
+    -------
+    desc : :obj:`str`
+        A text description of the motion parameters.
+    """
+    from num2words import num2words
+
+    desc = ""
+    if motion_filter_type:
+        band_stop_min_adjusted, band_stop_max_adjusted, is_modified = _modify_motion_filter(
+            motion_filter_type=motion_filter_type,
+            band_stop_min=band_stop_min,
+            band_stop_max=band_stop_max,
+            TR=TR,
+        )
+        if motion_filter_type == "notch":
+            if is_modified:
+                desc = (
+                    "The six translation and rotation head motion traces were "
+                    f"band-stop filtered to remove signals between {band_stop_min_adjusted} and "
+                    f"{band_stop_max_adjusted} breaths-per-minute "
+                    f"(automatically modified from {band_stop_min} and {band_stop_max} BPM due "
+                    "to Nyquist frequency constraints) using a(n) "
+                    f"{num2words(motion_filter_order, ordinal=True)}-order notch filter, "
+                    "based on @fair2020correction. "
+                )
+            else:
+                desc = (
+                    "The six translation and rotation head motion traces were "
+                    f"band-stop filtered to remove signals between {band_stop_min} and "
+                    f"{band_stop_max} breaths-per-minute using a(n) "
+                    f"{num2words(motion_filter_order, ordinal=True)}-order notch filter, "
+                    "based on @fair2020correction. "
+                )
+        else:  # lp
+            if is_modified:
+                desc = (
+                    "The six translation and rotation head motion traces were "
+                    f"low-pass filtered below {band_stop_min_adjusted} breaths-per-minute "
+                    f"(automatically modified from {band_stop_min} BPM due to Nyquist frequency "
+                    "constraints) using a(n) "
+                    f"{num2words(motion_filter_order, ordinal=True)}-order Butterworth filter, "
+                    "based on @gratton2020removal. "
+                )
+            else:
+                desc = (
+                    "The six translation and rotation head motion traces were "
+                    f"low-pass filtered below {band_stop_min} breaths-per-minute "
+                    "using a(n) "
+                    f"{num2words(motion_filter_order, ordinal=True)}-order Butterworth filter, "
+                    "based on @gratton2020removal. "
+                )
+
+        desc += "The Volterra expansion of these filtered motion parameters was then calculated. "
+
+    desc += (
+        "Framewise displacement was calculated from the "
+        f"{'filtered ' if motion_filter_type else ''}motion parameters using the formula from "
+        f"@power_fd_dvars, with a head radius of {head_radius} mm. "
+    )
+
+    return desc
+
+
+@fill_doc
+def describe_censoring(motion_filter_type, fd_thresh, exact_scans):
+    """Build a text description of the FD censoring process.
+
+    Parameters
+    ----------
+    %(motion_filter_type)s
     %(fd_thresh)s
     %(exact_scans)s
 
@@ -279,52 +352,26 @@ def describe_censoring(
     desc : :obj:`str`
         A text description of the censoring procedure.
     """
-    from num2words import num2words
-
-    filter_str = ""
-    if motion_filter_type:
-        if motion_filter_type == "notch":
-            filter_sub_str = (
-                f"band-stop filtered to remove signals between {band_stop_min} and "
-                f"{band_stop_max} breaths-per-minute using a(n) "
-                f"{num2words(motion_filter_order, ordinal=True)}-order notch filter, "
-                "based on @fair2020correction"
-            )
-        else:  # lp
-            filter_sub_str = (
-                f"low-pass filtered below {band_stop_min} breaths-per-minute using a(n) "
-                f"{num2words(motion_filter_order, ordinal=True)}-order Butterworth filter, "
-                "based on @gratton2020removal"
-            )
-
-        filter_str = (
-            f"the six translation and rotation head motion traces were {filter_sub_str}. Next, "
-        )
-
-    outlier_str = ""
+    desc = ""
     if fd_thresh > 0:
-        outlier_str = (
-            f"In order to identify high-motion outlier volumes, {filter_str}"
-            "framewise displacement was calculated using the formula from @power_fd_dvars, "
-            f"with a head radius of {head_radius} mm. "
+        desc += (
             f"Volumes with {'filtered ' if motion_filter_type else ''}framewise displacement "
             f"greater than {fd_thresh} mm were flagged as high-motion outliers for the sake of "
             "later censoring [@power_fd_dvars]."
         )
 
-    exact_str = ""
     if exact_scans and (fd_thresh > 0):
-        exact_str = (
+        desc += (
             " Additional sets of censoring volumes were randomly selected to produce additional "
             f"correlation matrices limited to {list_to_str(exact_scans)} volumes."
         )
     elif exact_scans:
-        exact_str = (
+        desc += (
             "Volumes were randomly selected for censoring, to produce additional correlation "
             f"matrices limited to {list_to_str(exact_scans)} volumes."
         )
 
-    return outlier_str + exact_str
+    return desc
 
 
 def _get_acompcor_confounds(confounds_file):
@@ -584,31 +631,14 @@ def motion_regression_filter(
     if motion_filter_type not in ("lp", "notch"):
         raise ValueError(f"Motion filter type '{motion_filter_type}' not supported.")
 
+    band_stop_min_adjusted, band_stop_max_adjusted, _ = _modify_motion_filter(
+        motion_filter_type, band_stop_min, band_stop_max, TR
+    )
+    lowpass_hz_adjusted = band_stop_min_adjusted / 60
+
     sampling_frequency = 1 / TR
-    nyquist_frequency = sampling_frequency / 2
 
     if motion_filter_type == "lp":  # low-pass filter
-        # Remove any frequencies above band_stop_min.
-        assert band_stop_min is not None
-        assert band_stop_min > 0
-        if band_stop_max:
-            warnings.warn("The parameter 'band_stop_max' will be ignored.")
-
-        lowpass_hz = band_stop_min / 60  # change BPM to right time unit
-
-        # Adjust frequency in case Nyquist is below cutoff.
-        # This won't have an effect if the data have a fast enough sampling rate.
-        lowpass_hz_adjusted = np.abs(
-            lowpass_hz
-            - (np.floor((lowpass_hz + nyquist_frequency) / sampling_frequency))
-            * sampling_frequency
-        )
-        if lowpass_hz_adjusted != lowpass_hz:
-            warnings.warn(
-                f"Low-pass filter frequency is above Nyquist frequency ({nyquist_frequency} Hz), "
-                f"so it has been changed ({lowpass_hz} --> {lowpass_hz_adjusted} Hz)."
-            )
-
         b, a = butter(
             motion_filter_order / 2,
             lowpass_hz_adjusted,
@@ -619,32 +649,8 @@ def motion_regression_filter(
         filtered_data = filtfilt(b, a, data, axis=0, padtype="constant", padlen=data.shape[0] - 1)
 
     elif motion_filter_type == "notch":  # notch filter
-        # Retain any frequencies *outside* the band_stop_min-band_stop_max range.
-        assert band_stop_max is not None
-        assert band_stop_min is not None
-        assert band_stop_max > 0
-        assert band_stop_min > 0
-        assert band_stop_min < band_stop_max
-
-        stopband = np.array([band_stop_min, band_stop_max])
-        stopband_hz = stopband / 60  # change BPM to Hertz
-
-        # Adjust frequencies in case Nyquist is within/below band.
-        # This won't have an effect if the data have a fast enough sampling rate.
-        stopband_hz_adjusted = np.abs(
-            stopband_hz
-            - (np.floor((stopband_hz + nyquist_frequency) / sampling_frequency))
-            * sampling_frequency
-        )
-        if not np.array_equal(stopband_hz, stopband_hz_adjusted):
-            warnings.warn(
-                "One or both filter frequencies are above Nyquist frequency "
-                f"({nyquist_frequency} Hz), "
-                "so they have been changed "
-                f"({stopband_hz[0]} --> {stopband_hz_adjusted[0]}, "
-                f"{stopband_hz[1]} --> {stopband_hz_adjusted[1]} Hz)."
-            )
-
+        highpass_hz_adjusted = band_stop_max_adjusted / 60
+        stopband_hz_adjusted = np.array([lowpass_hz_adjusted, highpass_hz_adjusted])
         # Convert stopband to a single notch frequency.
         freq_to_remove = np.mean(stopband_hz_adjusted)
         bandwidth = np.abs(np.diff(stopband_hz_adjusted))
@@ -665,6 +671,93 @@ def motion_regression_filter(
             )
 
     return filtered_data
+
+
+def _modify_motion_filter(motion_filter_type, band_stop_min, band_stop_max, TR):
+    """Modify the motion filter parameters based on the TR.
+
+    Parameters
+    ----------
+    motion_filter_type : str
+        The type of motion filter to apply.
+    band_stop_min : float
+        The minimum frequency to stop in the filter, in beats-per-minute.
+    band_stop_max : float
+        The maximum frequency to stop in the filter, in beats-per-minute.
+    TR : float
+        The repetition time of the data.
+
+    Returns
+    -------
+    band_stop_min_adjusted : float
+        The adjusted low-pass filter frequency, in beats-per-minute.
+    band_stop_max_adjusted : float
+        The adjusted high-pass filter frequency, in beats-per-minute.
+    is_modified : bool
+        Whether the filter parameters were modified.
+    """
+    sampling_frequency = 1 / TR
+    nyquist_frequency = sampling_frequency / 2
+
+    is_modified = False
+    if motion_filter_type == "lp":  # low-pass filter
+        # Remove any frequencies above band_stop_min.
+        assert band_stop_min is not None
+        assert band_stop_min > 0
+        if band_stop_max:
+            warnings.warn("The parameter 'band_stop_max' will be ignored.")
+
+        lowpass_hz = band_stop_min / 60  # change BPM to right time unit
+
+        # Adjust frequency in case Nyquist is below cutoff.
+        # This won't have an effect if the data have a fast enough sampling rate.
+        lowpass_hz_adjusted = np.abs(
+            lowpass_hz
+            - (np.floor((lowpass_hz + nyquist_frequency) / sampling_frequency))
+            * sampling_frequency
+        )
+        band_stop_min_adjusted = lowpass_hz_adjusted * 60  # change Hertz back to BPM
+        if band_stop_min_adjusted != band_stop_min:
+            warnings.warn(
+                f"Low-pass filter frequency is above Nyquist frequency ({nyquist_frequency} Hz), "
+                f"so it has been changed ({band_stop_min} --> {band_stop_min_adjusted} BPM)."
+            )
+            is_modified = True
+
+        band_stop_max_adjusted = None
+
+    elif motion_filter_type == "notch":  # notch filter
+        # Retain any frequencies *outside* the band_stop_min-band_stop_max range.
+        assert band_stop_max is not None
+        assert band_stop_min is not None
+        assert band_stop_max > 0
+        assert band_stop_min > 0
+        assert band_stop_min < band_stop_max
+
+        stopband = np.array([band_stop_min, band_stop_max])
+        stopband_hz = stopband / 60  # change BPM to Hertz
+
+        # Adjust frequencies in case Nyquist is within/below band.
+        # This won't have an effect if the data have a fast enough sampling rate.
+        stopband_hz_adjusted = np.abs(
+            stopband_hz
+            - (np.floor((stopband_hz + nyquist_frequency) / sampling_frequency))
+            * sampling_frequency
+        )
+        stopband_adjusted = stopband_hz_adjusted * 60  # change Hertz back to BPM
+        if not np.array_equal(stopband_adjusted, stopband):
+            warnings.warn(
+                "One or both filter frequencies are above Nyquist frequency "
+                f"({nyquist_frequency} Hz), "
+                "so they have been changed "
+                f"({stopband[0]} --> {stopband_adjusted[0]}, "
+                f"{stopband[1]} --> {stopband_adjusted[1]} BPM)."
+            )
+            is_modified = True
+
+        band_stop_min_adjusted, band_stop_max_adjusted = stopband_adjusted
+
+    return band_stop_min_adjusted, band_stop_max_adjusted, is_modified
 
 
 def _infer_dummy_scans(dummy_scans, confounds_file=None):

--- a/xcp_d/utils/modified_data.py
+++ b/xcp_d/utils/modified_data.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 from nipype import logging
 
-from xcp_d.utils.confounds import _infer_dummy_scans, load_motion
+from xcp_d.utils.confounds import _infer_dummy_scans, _modify_motion_filter, load_motion
 from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.filemanip import fname_presuffix
 
@@ -183,13 +183,19 @@ def flag_bad_run(
     fmriprep_confounds_df = fmriprep_confounds_df.drop(np.arange(dummy_scans))
 
     # Calculate filtered FD
+    band_stop_min_adjusted, band_stop_max_adjusted, _ = _modify_motion_filter(
+        motion_filter_type=motion_filter_type,
+        band_stop_min=band_stop_min,
+        band_stop_max=band_stop_max,
+        TR=TR,
+    )
     motion_df = load_motion(
         fmriprep_confounds_df,
         TR=TR,
         motion_filter_type=motion_filter_type,
         motion_filter_order=motion_filter_order,
-        band_stop_min=band_stop_min,
-        band_stop_max=band_stop_max,
+        band_stop_min=band_stop_min_adjusted,
+        band_stop_max=band_stop_max_adjusted,
     )
     fd_arr = compute_fd(confound=motion_df, head_radius=head_radius)
     return np.sum(fd_arr <= fd_thresh) * TR

--- a/xcp_d/workflows/bold.py
+++ b/xcp_d/workflows/bold.py
@@ -190,10 +190,12 @@ def init_postprocess_nifti_wf(
         run_data["confounds"],
     )
 
-    workflow.__desc__ = (
-        f"For each of the {num2words(n_runs)} BOLD runs found per subject "
-        "(across all tasks and sessions), the following post-processing was performed."
-    )
+    workflow.__desc__ = f"""\
+
+For each of the {num2words(n_runs)} BOLD runs found per subject (across all tasks and sessions),
+the following post-processing was performed.
+
+"""
 
     outputnode = pe.Node(
         niu.IdentityInterface(

--- a/xcp_d/workflows/cifti.py
+++ b/xcp_d/workflows/cifti.py
@@ -179,10 +179,12 @@ def init_postprocess_cifti_wf(
 
     workflow = Workflow(name=name)
 
-    workflow.__desc__ = (
-        f"For each of the {num2words(n_runs)} BOLD runs found per subject "
-        "(across all tasks and sessions), the following post-processing was performed."
-    )
+    workflow.__desc__ = f"""\
+
+For each of the {num2words(n_runs)} BOLD runs found per subject (across all tasks and sessions),
+the following post-processing was performed.
+
+"""
 
     outputnode = pe.Node(
         niu.IdentityInterface(

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -590,7 +590,7 @@ approach.
         )
 
     workflow.__desc__ += (
-        "The filtered time series were then denoised using linear regression, "
+        " The filtered time series were then denoised using linear regression, "
         "using only the low-motion volumes. "
     )
 

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -544,6 +544,7 @@ def init_denoise_bold_wf(TR, name="denoise_bold_wf"):
     """
     workflow = Workflow(name=name)
 
+    fd_thresh = config.workflow.fd_thresh
     low_pass = config.workflow.low_pass
     high_pass = config.workflow.high_pass
     bpf_order = config.workflow.bpf_order
@@ -589,7 +590,8 @@ approach.
         )
 
     workflow.__desc__ += (
-        "The filtered time series were then denoised using linear regression."
+        "The filtered time series were then denoised using linear regression, "
+        "using only the low-motion volumes. "
     )
 
     inputnode = pe.Node(

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -558,6 +558,15 @@ def init_denoise_bold_wf(TR, name="denoise_bold_wf"):
 Nuisance regressors were regressed from the BOLD data using a denoising method based on *Nilearn*'s
 approach.
 """
+    if fd_thresh > 0:
+        workflow.__desc__ += (
+            "Any volumes censored earlier in the workflow were first cubic spline interpolated in "
+            "the BOLD data. "
+            "Outlier volumes at the beginning or end of the time series were replaced with the "
+            "closest low-motion volume's values, "
+            "as cubic spline interpolation can produce extreme extrapolations. "
+        )
+
     if bandpass_filter:
         if low_pass > 0 and high_pass > 0:
             btype = "band-pass"
@@ -573,17 +582,15 @@ approach.
             filt_input = f"{low_pass}"
 
         workflow.__desc__ += (
-            "Any volumes censored earlier in the workflow were first cubic spline interpolated in "
-            "the BOLD data. "
-            "Outlier volumes at the beginning or end of the time series were replaced with the "
-            "closest low-motion volume's values, "
-            "as cubic spline interpolation can produce extreme extrapolations. "
-            f"The interpolated timeseries were then {btype} filtered using a(n) "
+            f"The timeseries were {btype} filtered using a(n) "
             f"{num2words(bpf_order, ordinal=True)}-order Butterworth filter, "
             f"in order to retain signals {preposition} {filt_input} Hz. "
             "The same filter was applied to the confounds."
-            "The filtered, interpolated time series were then denoised using linear regression."
         )
+
+    workflow.__desc__ += (
+        "The filtered time series were then denoised using linear regression."
+    )
 
     inputnode = pe.Node(
         niu.IdentityInterface(

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -553,10 +553,11 @@ def init_denoise_bold_wf(TR, name="denoise_bold_wf"):
     mem_gb = config.nipype.memory_gb
     omp_nthreads = config.nipype.omp_nthreads
 
-    workflow.__desc__ = (
-        "Nuisance regressors were regressed from the BOLD data using a denoising method based on "
-        "*Nilearn*'s approach. "
-    )
+    workflow.__desc__ = """\
+
+Nuisance regressors were regressed from the BOLD data using a denoising method based on *Nilearn*'s
+approach.
+"""
     if bandpass_filter:
         if low_pass > 0 and high_pass > 0:
             btype = "band-pass"

--- a/xcp_d/workflows/restingstate.py
+++ b/xcp_d/workflows/restingstate.py
@@ -103,6 +103,7 @@ def init_alff_wf(
         )
 
     workflow.__desc__ = f""" \
+
 The amplitude of low-frequency fluctuation (ALFF) [@alff] was computed by transforming
 the mean-centered, standard deviation-normalized, denoised BOLD time series to the frequency
 domain{periodogram_desc}.


### PR DESCRIPTION
Closes #1113.

## Changes proposed in this pull request

- Move the automatic filter parameter modification out of `utils.confounds.motion_regression_filter` and into its own function (`utils.confounds._modify_motion_filter`).
- Split `utils.confounds.describe_censoring` into `describe_censoring` and `describe_motion_parameters`.
- Call the new function (`_modify_motion_filter`) in `utils.confounds.describe_motion_parameters` so that the boilerplate reflects any changes to the motion filter parameters.
- Call `_modify_motion_filter` in `utils.modified_data.flag_bad_run` as well, since `load_motion` doesn't call it anymore.
- Improve spacing (e.g., spaces between sentences and new paragraphs) in the boilerplate.
- Add motion filter parameters to appropriate metadata files.
- Fix up denoising boilerplate to reflect the updated denoising procedure.