### PR TITLE
Add "subject" to native-space surface query

### DIFF
--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -418,6 +418,7 @@ def collect_mesh_data(layout, participant_label):
         for hemisphere in ["L", "R"]:
             key = f"{hemisphere.lower()}h_{name}"
             queries[key] = {
+                "subject": participant_label,
                 "datatype": "anat",
                 "hemi": hemisphere,
                 "desc": None,


### PR DESCRIPTION
Closes none, but fixes a bug found by @kahinimehta.

## Changes proposed in this pull request

- Include `subject` in the native-space mesh surface query, which should now match the standard-space mesh surface query (which works), except for the space and den entities.