### PR TITLE
Use standardized DVARS from Nipype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "nilearn == 0.10.3",  # 0.10.2 raises error with compcor from fMRIPrep 23
     "nipype ~= 1.8.5",
     "niworkflows == 1.10.1",
+    "nitime",  # for DVARS calculation in Nipype
     "num2words",  # for boilerplates
     "numpy ~= 1.19",
     "packaging",  # for version string parsing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,13 @@ requires-python = ">=3.10"
 dependencies = [
     'importlib_resources; python_version < "3.11"',
     "beautifulsoup4",  # to clean up HTML in DCAN executive summary outputs
-    "h5py",  # for DCAN motion file
+    "bids-validator <= 1.14.4",
+    "h5py <= 3.10.0",  # for DCAN motion file
     "indexed_gzip ~= 1.8.7",  # for loading imgs in nibabel
     "jinja2 ~= 3.1.2",  # for executive summary
+    "joblib <= 1.3.2",
     "matplotlib ~= 3.8.2",
-    "networkx ~= 3.3",  # nipype needs networkx, but 3+ isn't compatible with nipype 1.8.5
+    "networkx <= 3.3",  # nipype needs networkx, but 3+ isn't compatible with nipype 1.8.5
     "nibabel >= 3.2.1",
     "nilearn == 0.10.3",  # 0.10.2 raises error with compcor from fMRIPrep 23
     "nipype ~= 1.8.5",
@@ -35,7 +37,7 @@ dependencies = [
     "psutil >= 5.4",  # for sentry
     "pybids ~= 0.16.4",
     "pyyaml",
-    "scikit-learn ~= 1.1",
+    "scikit-learn <= 1.4.1",
     "scipy >= 1.8.0,<=1.12.0",  # nipype needs networkx, which needs scipy > 1.8.0
     "seaborn",  # for plots
     "sentry-sdk ~= 1.44.0",  # for usage reports

--- a/xcp_d/interfaces/plotting.py
+++ b/xcp_d/interfaces/plotting.py
@@ -323,11 +323,6 @@ class QCPlots(SimpleInterface):
             datafile=self.inputs.cleaned_file,
             maskfile=self.inputs.mask_file,
         )
-        if np.any(np.isnan(cleaned_data)):
-            raise ValueError(f"NaNs in the cleaned data: {self.inputs.cleaned_data}")
-
-        if np.any(np.isinf(cleaned_data)):
-            raise ValueError(f"Infs in the cleaned data: {self.inputs.cleaned_data}")
 
         dvars_before_processing = compute_dvars(
             datat=read_ndata(

--- a/xcp_d/interfaces/plotting.py
+++ b/xcp_d/interfaces/plotting.py
@@ -330,18 +330,16 @@ class QCPlots(SimpleInterface):
             raise ValueError(f"Infs in the cleaned data: {self.inputs.cleaned_data}")
 
         dvars_before_processing = compute_dvars(
-            read_ndata(
+            datat=read_ndata(
                 datafile=self.inputs.bold_file,
                 maskfile=self.inputs.mask_file,
             ),
-            intensity_normalization=0,
         )[1]
         dvars_after_processing = compute_dvars(
-            read_ndata(
+            datat=read_ndata(
                 datafile=self.inputs.cleaned_file,
                 maskfile=self.inputs.mask_file,
             ),
-            intensity_normalization=0,
         )[1]
         if preproc_fd_timeseries.size != dvars_before_processing.size:
             raise ValueError(

--- a/xcp_d/interfaces/plotting.py
+++ b/xcp_d/interfaces/plotting.py
@@ -324,13 +324,13 @@ class QCPlots(SimpleInterface):
                 datafile=self.inputs.bold_file,
                 maskfile=self.inputs.mask_file,
             )
-        )
+        )[1]
         dvars_after_processing = compute_dvars(
             read_ndata(
                 datafile=self.inputs.cleaned_file,
                 maskfile=self.inputs.mask_file,
             ),
-        )
+        )[1]
         if preproc_fd_timeseries.size != dvars_before_processing.size:
             raise ValueError(
                 f"FD {preproc_fd_timeseries.size} != DVARS {dvars_before_processing.size}\n"

--- a/xcp_d/interfaces/plotting.py
+++ b/xcp_d/interfaces/plotting.py
@@ -319,6 +319,16 @@ class QCPlots(SimpleInterface):
             use_ext=False,
         )
 
+        cleaned_data = read_ndata(
+            datafile=self.inputs.cleaned_file,
+            maskfile=self.inputs.mask_file,
+        )
+        if np.any(np.isnan(cleaned_data)):
+            raise ValueError(f"NaNs in the cleaned data: {self.inputs.cleaned_data}")
+
+        if np.any(np.isinf(cleaned_data)):
+            raise ValueError(f"Infs in the cleaned data: {self.inputs.cleaned_data}")
+
         dvars_before_processing = compute_dvars(
             read_ndata(
                 datafile=self.inputs.bold_file,

--- a/xcp_d/interfaces/plotting.py
+++ b/xcp_d/interfaces/plotting.py
@@ -319,11 +319,6 @@ class QCPlots(SimpleInterface):
             use_ext=False,
         )
 
-        cleaned_data = read_ndata(
-            datafile=self.inputs.cleaned_file,
-            maskfile=self.inputs.mask_file,
-        )
-
         dvars_before_processing = compute_dvars(
             datat=read_ndata(
                 datafile=self.inputs.bold_file,

--- a/xcp_d/interfaces/plotting.py
+++ b/xcp_d/interfaces/plotting.py
@@ -333,13 +333,15 @@ class QCPlots(SimpleInterface):
             read_ndata(
                 datafile=self.inputs.bold_file,
                 maskfile=self.inputs.mask_file,
-            )
+            ),
+            intensity_normalization=0,
         )[1]
         dvars_after_processing = compute_dvars(
             read_ndata(
                 datafile=self.inputs.cleaned_file,
                 maskfile=self.inputs.mask_file,
             ),
+            intensity_normalization=0,
         )[1]
         if preproc_fd_timeseries.size != dvars_before_processing.size:
             raise ValueError(

--- a/xcp_d/tests/test_utils_qcmetrics.py
+++ b/xcp_d/tests/test_utils_qcmetrics.py
@@ -10,6 +10,6 @@ def test_compute_dvars():
     n_volumes, n_vertices = 100, 10000
     data = np.random.random((n_vertices, n_volumes))
 
-    dvars, std_dvars = qcmetrics.compute_dvars(data)
+    dvars, std_dvars = qcmetrics.compute_dvars(datat=data)
     assert dvars.shape == (n_volumes,)
     assert std_dvars.shape == (n_volumes,)

--- a/xcp_d/tests/test_utils_qcmetrics.py
+++ b/xcp_d/tests/test_utils_qcmetrics.py
@@ -10,5 +10,6 @@ def test_compute_dvars():
     n_volumes, n_vertices = 100, 10000
     data = np.random.random((n_vertices, n_volumes))
 
-    dvars = qcmetrics.compute_dvars(data)
+    dvars, std_dvars = qcmetrics.compute_dvars(data)
     assert dvars.shape == (n_volumes,)
+    assert std_dvars.shape == (n_volumes,)

--- a/xcp_d/utils/plotting.py
+++ b/xcp_d/utils/plotting.py
@@ -537,8 +537,14 @@ def plot_fmri_es(
     if np.any(np.isinf(denoised_interpolated_arr)):
         raise ValueError(f"Infs in the cleaned data: {denoised_interpolated_bold}")
 
-    preprocessed_dvars = compute_dvars(preprocessed_arr)[1]
-    denoised_interpolated_dvars = compute_dvars(denoised_interpolated_arr)[1]
+    preprocessed_dvars = compute_dvars(
+        preprocessed_arr,
+        intensity_normalization=0,
+    )[1]
+    denoised_interpolated_dvars = compute_dvars(
+        denoised_interpolated_arr,
+        intensity_normalization=0,
+    )[1]
 
     if preprocessed_arr.shape != denoised_interpolated_arr.shape:
         raise ValueError(

--- a/xcp_d/utils/plotting.py
+++ b/xcp_d/utils/plotting.py
@@ -532,7 +532,7 @@ def plot_fmri_es(
     denoised_interpolated_arr = read_ndata(datafile=denoised_interpolated_bold, maskfile=mask)
 
     if np.any(np.isnan(denoised_interpolated_arr)):
-            raise ValueError(f"NaNs in the cleaned data: {denoised_interpolated_bold}")
+        raise ValueError(f"NaNs in the cleaned data: {denoised_interpolated_bold}")
 
     if np.any(np.isinf(denoised_interpolated_arr)):
         raise ValueError(f"Infs in the cleaned data: {denoised_interpolated_bold}")

--- a/xcp_d/utils/plotting.py
+++ b/xcp_d/utils/plotting.py
@@ -531,12 +531,6 @@ def plot_fmri_es(
     preprocessed_arr = read_ndata(datafile=preprocessed_bold, maskfile=mask)
     denoised_interpolated_arr = read_ndata(datafile=denoised_interpolated_bold, maskfile=mask)
 
-    if np.any(np.isnan(denoised_interpolated_arr)):
-        raise ValueError(f"NaNs in the cleaned data: {denoised_interpolated_bold}")
-
-    if np.any(np.isinf(denoised_interpolated_arr)):
-        raise ValueError(f"Infs in the cleaned data: {denoised_interpolated_bold}")
-
     preprocessed_dvars = compute_dvars(datat=preprocessed_arr)[1]
     denoised_interpolated_dvars = compute_dvars(datat=denoised_interpolated_arr)[1]
 

--- a/xcp_d/utils/plotting.py
+++ b/xcp_d/utils/plotting.py
@@ -531,6 +531,12 @@ def plot_fmri_es(
     preprocessed_arr = read_ndata(datafile=preprocessed_bold, maskfile=mask)
     denoised_interpolated_arr = read_ndata(datafile=denoised_interpolated_bold, maskfile=mask)
 
+    if np.any(np.isnan(denoised_interpolated_arr)):
+            raise ValueError(f"NaNs in the cleaned data: {denoised_interpolated_bold}")
+
+    if np.any(np.isinf(denoised_interpolated_arr)):
+        raise ValueError(f"Infs in the cleaned data: {denoised_interpolated_bold}")
+
     preprocessed_dvars = compute_dvars(preprocessed_arr)[1]
     denoised_interpolated_dvars = compute_dvars(denoised_interpolated_arr)[1]
 

--- a/xcp_d/utils/plotting.py
+++ b/xcp_d/utils/plotting.py
@@ -537,14 +537,8 @@ def plot_fmri_es(
     if np.any(np.isinf(denoised_interpolated_arr)):
         raise ValueError(f"Infs in the cleaned data: {denoised_interpolated_bold}")
 
-    preprocessed_dvars = compute_dvars(
-        preprocessed_arr,
-        intensity_normalization=0,
-    )[1]
-    denoised_interpolated_dvars = compute_dvars(
-        denoised_interpolated_arr,
-        intensity_normalization=0,
-    )[1]
+    preprocessed_dvars = compute_dvars(datat=preprocessed_arr)[1]
+    denoised_interpolated_dvars = compute_dvars(datat=denoised_interpolated_arr)[1]
 
     if preprocessed_arr.shape != denoised_interpolated_arr.shape:
         raise ValueError(

--- a/xcp_d/utils/plotting.py
+++ b/xcp_d/utils/plotting.py
@@ -531,8 +531,8 @@ def plot_fmri_es(
     preprocessed_arr = read_ndata(datafile=preprocessed_bold, maskfile=mask)
     denoised_interpolated_arr = read_ndata(datafile=denoised_interpolated_bold, maskfile=mask)
 
-    preprocessed_dvars = compute_dvars(preprocessed_arr)
-    denoised_interpolated_dvars = compute_dvars(denoised_interpolated_arr)
+    preprocessed_dvars = compute_dvars(preprocessed_arr)[1]
+    denoised_interpolated_dvars = compute_dvars(denoised_interpolated_arr)[1]
 
     if preprocessed_arr.shape != denoised_interpolated_arr.shape:
         raise ValueError(

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -274,7 +274,11 @@ def compute_dvars(
     # Compute (non-robust) estimate of lag-1 autocorrelation
     temp_data = regress_poly(0, datat, remove_mean=True)[0].astype(np.float32)
     if np.any(np.isnan(temp_data)):
-        raise ValueError("NaNs found in data after detrending")
+        nan_idx = np.where(np.isnan(temp_data))[0]
+        nan_datat = datat[nan_idx, :]
+        raise ValueError(
+            f"NaNs found in data after detrending in {nan_idx.size} voxels: {nan_datat}"
+        )
 
     if np.any(np.isinf(temp_data)):
         raise ValueError("Infs found in data after detrending")

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -244,6 +244,9 @@ def compute_dvars(
     :obj:`numpy.ndarray`
         The calculated DVARS array.
         A (timepoints,) array.
+    :obj:`numpy.ndarray`
+        The calculated standardized DVARS array.
+        A (timepoints,) array.
     """
     from nipype.algorithms.confounds import _AR_est_YW, regress_poly
 

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -258,6 +258,8 @@ def compute_dvars(
 
     if intensity_normalization != 0:
         # Perform 1000 intensity normalization
+        data_median = np.median(datat)
+        LOGGER.warning(f"Data median: {data_median}")
         datat = (datat / np.median(datat)) * intensity_normalization
 
     if np.any(np.isnan(datat)):

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -277,7 +277,7 @@ def compute_dvars(
         nan_idx = np.where(np.any(np.isnan(temp_data), axis=0))[0]
         nan_datat = datat[nan_idx, :]
         raise ValueError(
-            f"NaNs found in data after detrending in {nan_idx.size} voxels"
+            f"NaNs found in data after detrending in {nan_idx.size} voxels: {nan_datat[0, :]}"
         )
 
     if np.any(np.isinf(temp_data)):

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -272,12 +272,14 @@ def compute_dvars(
         func_sd = func_sd[zero_variance_voxels]
 
     # Compute (non-robust) estimate of lag-1 autocorrelation
-    ar1 = np.apply_along_axis(
-        _AR_est_YW,
-        1,
-        regress_poly(0, datat, remove_mean=True)[0].astype(np.float32),
-        1,
-    )
+    temp_data = regress_poly(0, datat, remove_mean=True)[0].astype(np.float32)
+    if np.any(np.isnan(temp_data)):
+        raise ValueError("NaNs found in data after detrending")
+
+    if np.any(np.isinf(temp_data)):
+        raise ValueError("Infs found in data after detrending")
+
+    ar1 = np.apply_along_axis(_AR_est_YW, 1, temp_data, 1)
 
     # Compute (predicted) standard deviation of temporal difference time series
     diff_sdhat = np.squeeze(np.sqrt(((1 - ar1) * 2).tolist())) * func_sd

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -274,7 +274,7 @@ def compute_dvars(
     # Compute (non-robust) estimate of lag-1 autocorrelation
     temp_data = regress_poly(0, datat, remove_mean=True)[0].astype(np.float32)
     if np.any(np.isnan(temp_data)):
-        nan_idx = np.where(np.isnan(temp_data))[0]
+        nan_idx = np.where(np.any(np.isnan(temp_data), axis=0))[0]
         nan_datat = datat[nan_idx, :]
         raise ValueError(
             f"NaNs found in data after detrending in {nan_idx.size} voxels"

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -250,9 +250,21 @@ def compute_dvars(
     """
     from nipype.algorithms.confounds import _AR_est_YW, regress_poly
 
+    if np.any(np.isnan(datat)):
+        raise ValueError("NaNs found in data")
+
+    if np.any(np.isinf(datat)):
+        raise ValueError("Infs found in data")
+
     if intensity_normalization != 0:
         # Perform 1000 intensity normalization
         datat = (datat / np.median(datat)) * intensity_normalization
+
+    if np.any(np.isnan(datat)):
+        raise ValueError("NaNs found in data")
+
+    if np.any(np.isinf(datat)):
+        raise ValueError("Infs found in data")
 
     # Robust standard deviation (we are using "lower" interpolation because this is what FSL does
     try:
@@ -270,6 +282,12 @@ def compute_dvars(
         zero_variance_voxels = func_sd > variance_tol
         datat = datat[zero_variance_voxels, :]
         func_sd = func_sd[zero_variance_voxels]
+
+    if np.any(np.isnan(datat)):
+        raise ValueError("NaNs found in data")
+
+    if np.any(np.isinf(datat)):
+        raise ValueError("Infs found in data")
 
     # Compute (non-robust) estimate of lag-1 autocorrelation
     temp_data = regress_poly(0, datat, remove_mean=True)[0].astype(np.float32)

--- a/xcp_d/utils/qcmetrics.py
+++ b/xcp_d/utils/qcmetrics.py
@@ -277,7 +277,7 @@ def compute_dvars(
         nan_idx = np.where(np.isnan(temp_data))[0]
         nan_datat = datat[nan_idx, :]
         raise ValueError(
-            f"NaNs found in data after detrending in {nan_idx.size} voxels: {nan_datat}"
+            f"NaNs found in data after detrending in {nan_idx.size} voxels"
         )
 
     if np.any(np.isinf(temp_data)):


### PR DESCRIPTION
Closes none, but stems from [this NeuroStars post](https://neurostars.org/t/higher-dvars-in-xcp-d-than-fmriprep/29008).

## Changes proposed in this pull request

- Replace XCP-D's DVARS formula with the one from Nipype/fMRIPrep.
    - I had to remove the intensity-normalization element because it doesn't seem to work appropriately on the denoised data. Basically, the intensity normalization divide by the median value across the brain and across time in the BOLD data, but that median value is very low (~0.01) in the denoised data, which results in infinite values in the denoised DVARS.
- Adopt the "standardized" DVARS from the new function for our QC measures and plots.
