### PR TITLE
Add third config to BIDSLayout that defines cohort entity

### DIFF
--- a/xcp_d/config.py
+++ b/xcp_d/config.py
@@ -472,7 +472,7 @@ class execution(_Config):
                 validate=False,
                 ignore=ignore_patterns,
             )
-            xcp_d_config = load_data("xcp_d_bids_config.json")
+            xcp_d_config = load_data("xcp_d_bids_config2.json")
             cls._layout = BIDSLayout(
                 str(cls.fmri_dir),
                 database_path=_db_path,

--- a/xcp_d/config.py
+++ b/xcp_d/config.py
@@ -114,6 +114,7 @@ finally:
     from templateflow import __version__ as _tf_ver
 
     from xcp_d import __version__
+    from xcp_d.data import load as load_data
 
 if not hasattr(sys, "_is_pytest_session"):
     sys._is_pytest_session = False  # Trick to avoid sklearn's FutureWarnings
@@ -471,12 +472,13 @@ class execution(_Config):
                 validate=False,
                 ignore=ignore_patterns,
             )
+            xcp_d_config = load_data("xcp_d_bids_config.json")
             cls._layout = BIDSLayout(
                 str(cls.fmri_dir),
                 database_path=_db_path,
                 reset_database=cls.bids_database_dir is None,
                 indexer=_indexer,
-                config=["bids", "derivatives"],
+                config=["bids", "derivatives", xcp_d_config],
             )
             cls.bids_database_dir = _db_path
 

--- a/xcp_d/data/xcp_d_bids_config2.json
+++ b/xcp_d/data/xcp_d_bids_config2.json
@@ -1,0 +1,49 @@
+{
+  "name": "xcp_d",
+  "entities": [
+    {
+      "name": "cohort",
+      "pattern": "(?:^|_)cohort-([0-9]+)",
+      "dtype": "int"
+    },
+    {
+      "name": "statistic",
+      "pattern": "(?:^|_)stat-([a-zA-Z0-9]+)"
+    },
+    {
+      "name": "segmentation",
+      "pattern": "seg-([a-zA-Z0-9]+)"
+    }
+  ],
+  "default_path_patterns": [
+    "[desc-{desc}]_{suffix<qc>}{extension<.json>|.json}",
+    "atlases/atlas-{atlas}/atlas-{atlas}[_space-{space}][_cohort-{cohort}][_res-{res}][_desc-{desc}]_{suffix<dseg>}{extension<.nii|.nii.gz|.tsv|.json>|.nii.gz}",
+    "atlases/atlas-{atlas}/atlas-{atlas}[_space-{space}][_cohort-{cohort}][_den-{den}][_desc-{desc}]_{suffix<dseg>}{extension<.dlabel.nii|.tsv|.json>|.dlabel.nii}",
+    "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_res-{res}][_desc-{desc}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2starmap|FLAIR|FLASH|PDmap|PD|PDT2|dseg|inplaneT[12]|angio>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+    "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}]_from-{from}_to-{to}_mode-{mode<image|points>|image}_{suffix<xfm>|xfm}{extension<.txt|.h5>}",
+    "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_den-{den}]_hemi-{hemi<L|R>}[_desc-{desc}]_{suffix<wm|smoothwm|white|pial|midthickness|inflated|vinflated|sphere|flat>}{extension<.surf.gii|.json>|.surf.gii}",
+    "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_den-{den}][_desc-{desc}]_{suffix<sulc|curv|thickness|myelinw>}{extension<.dscalar.nii|.json>|.dscalar.nii}",
+    "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_res-{res}]_desc-{desc}_{suffix<mask>|mask}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+    "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_res-{res}]_label-{label}[_desc-{desc}]_{suffix<probseg>|probseg}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}][_res-{res}][_desc-{desc}]_{suffix<bold|sbref|boldref>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_res-{res}]_stat-{statistic}[_desc-{desc}]_{suffix<boldmap>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}]_from-{from}_to-{to}_mode-{mode<image|points>|image}_{suffix<xfm>}{extension<.txt|.h5>}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_res-{res}]_desc-{desc}_{suffix<mask>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}]_stat-{statistic}[_desc-{desc}]_{suffix<relmat>}{extension<.tsv|.json>|.tsv}",
+    "sub-{subject}[/ses-{session}]/{datatype<anat|func>|func}/sub-{subject}[_ses-{session}][_task-{task}][_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_res-{res}][_den-{den}]_stat-{statistic}[_desc-{desc}]_{suffix<bold|morph>}{extension<.tsv|.json>|.tsv}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_desc-{desc}]_{suffix<design>|design}{extension<.tsv|.json>|.tsv}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_res-{res}][_den-{den}]_stat-{statistic}[_desc-{desc}]_{suffix<timeseries>}{extension<.tsv|.json>|.tsv}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_desc-{desc}]_{suffix<motion|outliers>}{extension<.json|.tsv>|.tsv}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}][_res-{res}][_den-{den}][_desc-{desc}]_{suffix<qc>}{extension<.tsv|.json>|.tsv}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_desc-{desc}]_{suffix<qc>}{extension<.hdf5>|.hdf5}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}][_den-{den}][_hemi-{hemi<L|R>}][_desc-{desc}]_{suffix<bold>}{extension<.dtseries.nii|.json>}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}][_den-{den}][_hemi-{hemi<L|R>}]_stat-{statistic}[_desc-{desc}]_{suffix<boldmap>}{extension<.dscalar.nii|.json>}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_den-{den}][_hemi-{hemi<L|R>}]_stat-{statistic}[_desc-{desc}]_{suffix<timeseries>}{extension<.ptseries.nii|.json>}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}]_seg-{segmentation}[_den-{den}][_hemi-{hemi<L|R>}]_stat-{statistic}[_desc-{desc}]_{suffix<boldmap>}{extension<.pscalar.nii|.json>}",
+    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}]_seg-{segmentation}[_den-{den}][_hemi-{hemi<L|R>}]_stat-{statistic}[_desc-{desc}]_{suffix<boldmap>}{extension<.pconn.nii|.json>}",
+    "sub-{subject}/{datatype<figures>}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_desc-{desc}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio|dseg|mask|dwi|epiref|fieldmap>}{extension<.html|.svg|.png>}",
+    "sub-{subject}/{datatype<figures>}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}][_space-{space}][_cohort-{cohort}][_seg-{segmentation}][_desc-{desc}]_{suffix<dseg|mask|dwi|epiref|fieldmap>}{extension<.html|.svg|.png>}",
+    "sub-{subject}/{datatype<figures>}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_cohort-{cohort}][_desc-{desc}]_{suffix<bold|motion>}{extension<.html|.svg|.png>}",
+    "sub-{subject}/{datatype<figures>}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_desc-{desc}]_{suffix<design>|design}{extension<.html|.svg|.png>}"
+  ]
+}

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -92,7 +92,7 @@ def test_collect_data_nibabies(datasets):
         config=["bids", "derivatives", xcp_d_config],
     )
     cohort_files = layout.get(subject="01", cohort="1", space="MNIInfant", suffix="boldref")
-    assert len(cohort_files) > 1
+    assert len(cohort_files) > 0
 
     # NIFTI workflow
     subj_data = xbids.collect_data(

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -85,7 +85,7 @@ def test_collect_data_ds001419(datasets):
 def test_collect_data_nibabies(datasets):
     """Test the collect_data function."""
     bids_dir = datasets["nibabies"]
-    xcp_d_config = load_data("xcp_d_bids_config.json")
+    xcp_d_config = load_data("xcp_d_bids_config2.json")
     layout = BIDSLayout(
         bids_dir,
         validate=False,

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -8,6 +8,7 @@ import pytest
 from bids.layout import BIDSLayout
 
 import xcp_d.utils.bids as xbids
+from xcp_d.data import load as load_data
 
 
 def test_collect_participants(datasets):
@@ -84,11 +85,14 @@ def test_collect_data_ds001419(datasets):
 def test_collect_data_nibabies(datasets):
     """Test the collect_data function."""
     bids_dir = datasets["nibabies"]
+    xcp_d_config = load_data("xcp_d_bids_config.json")
     layout = BIDSLayout(
         bids_dir,
         validate=False,
-        config=["bids", "derivatives"],
+        config=["bids", "derivatives", xcp_d_config],
     )
+    cohort_files = layout.get(subject="01", cohort="1", space="MNIInfant", suffix="boldref")
+    assert len(cohort_files) > 1
 
     # NIFTI workflow
     subj_data = xbids.collect_data(


### PR DESCRIPTION
Closes none. The BIDSLayout with `bids` and `derivatives` configs was not identifying `cohort`, even though I had `invalid_filters="allow"`. I _thought_ that `invalid_filters="allow"` would let BIDSLayout find any entity-formatted strings in filenames, but apparently that's not true.

## Changes proposed in this pull request

- Add a new pybids config file that include `cohort`, but not `datatype` (which conflicts with the existing `datatype` definition).