### PR TITLE
Ignore subcortical figures and plot FOV center of reference brains in executive summary

### DIFF
--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -89,14 +89,14 @@ class ExecutiveSummary(object):
         ANAT_REGISTRATION_DESCS = [
             "AtlasOnAnat",
             "AnatOnAtlas",
-            "AtlasOnSubcorticals",
-            "SubcorticalsOnAtlas",
+            # "AtlasOnSubcorticals",
+            # "SubcorticalsOnAtlas",
         ]
         ANAT_REGISTRATION_TITLES = [
             "Atlas On {modality}",  # noqa: FS003
             "{modality} On Atlas",  # noqa: FS003
-            "Atlas On {modality} Subcorticals",  # noqa: FS003
-            "{modality} Subcorticals On Atlas",  # noqa: FS003
+            # "Atlas On {modality} Subcorticals",  # noqa: FS003
+            # "{modality} Subcorticals On Atlas",  # noqa: FS003
         ]
         TASK_REGISTRATION_DESCS = [
             "TaskOnT1w",

--- a/xcp_d/interfaces/plotting.py
+++ b/xcp_d/interfaces/plotting.py
@@ -679,7 +679,15 @@ class AnatomicalPlot(SimpleInterface):
         arr = img.get_fdata()
 
         fig = plt.figure(constrained_layout=False, figsize=(25, 10))
-        plot_anat(img, draw_cross=False, figure=fig, vmin=np.min(arr), vmax=np.max(arr))
+        plot_anat(
+            img,
+            draw_cross=False,
+            figure=fig,
+            vmin=np.min(arr),
+            vmax=np.max(arr),
+            cut_coords=[0, 0, 0],
+            annotate=False,
+        )
         fig.savefig(self._results["out_file"], bbox_inches="tight", pad_inches=None)
         plt.close(fig)
 

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -73,15 +73,17 @@ def load_motion(
         )
 
     # Volterra expansion
-    columns = motion_confounds_df.columns.tolist()
-    for col in columns:
-        new_col = f"{col}_derivative1"
-        motion_confounds_df[new_col] = motion_confounds_df[col].diff()
+    # Ignore pandas SettingWithCopyWarning
+    with pd.option_context("mode.chained_assignment", None):
+        columns = motion_confounds_df.columns.tolist()
+        for col in columns:
+            new_col = f"{col}_derivative1"
+            motion_confounds_df[new_col] = motion_confounds_df[col].diff()
 
-    columns = motion_confounds_df.columns.tolist()
-    for col in columns:
-        new_col = f"{col}_power2"
-        motion_confounds_df[new_col] = motion_confounds_df[col] ** 2
+        columns = motion_confounds_df.columns.tolist()
+        for col in columns:
+            new_col = f"{col}_power2"
+            motion_confounds_df[new_col] = motion_confounds_df[col] ** 2
 
     return motion_confounds_df
 


### PR DESCRIPTION
Closes #1101 and addresses a request for the manuscript.

## Changes proposed in this pull request

- Don't include the not-yet-implemented subcortical figures in the executive summary.
- Set the cut coordinates to (0, 0, 0) (center of FOV) for the BOLD reference images in the executive summary.
- Ignore annoying SettingWithCopyWarnings when calculating motion parameters.