### PR TITLE
Replace pkgrf with load_data

### DIFF
--- a/xcp_d/_warnings.py
+++ b/xcp_d/_warnings.py
@@ -1,4 +1,5 @@
 """Manipulate Python warnings."""
+
 import logging
 import warnings
 

--- a/xcp_d/config.py
+++ b/xcp_d/config.py
@@ -472,7 +472,7 @@ class execution(_Config):
                 validate=False,
                 ignore=ignore_patterns,
             )
-            xcp_d_config = load_data("xcp_d_bids_config2.json")
+            xcp_d_config = str(load_data("xcp_d_bids_config2.json"))
             cls._layout = BIDSLayout(
                 str(cls.fmri_dir),
                 database_path=_db_path,

--- a/xcp_d/ingression/abcdbids.py
+++ b/xcp_d/ingression/abcdbids.py
@@ -168,7 +168,7 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
     copy_dictionary = {}
 
     # The identity xform is used in place of any actual ones.
-    identity_xfm = load_data("transform/itkIdentityTransform.txt")
+    identity_xfm = str(load_data("transform/itkIdentityTransform.txt"))
     copy_dictionary[identity_xfm] = []
     morph_dict_all_ses = {}
 

--- a/xcp_d/ingression/abcdbids.py
+++ b/xcp_d/ingression/abcdbids.py
@@ -12,8 +12,8 @@ import re
 import nibabel as nb
 import pandas as pd
 from nipype import logging
-from pkg_resources import resource_filename as pkgrf
 
+from xcp_d.data import load as load_data
 from xcp_d.ingression.utils import (
     collect_anatomical_files,
     collect_hcp_confounds,
@@ -168,7 +168,7 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
     copy_dictionary = {}
 
     # The identity xform is used in place of any actual ones.
-    identity_xfm = pkgrf("xcp_d", "/data/transform/itkIdentityTransform.txt")
+    identity_xfm = load_data("transform/itkIdentityTransform.txt")
     copy_dictionary[identity_xfm] = []
     morph_dict_all_ses = {}
 

--- a/xcp_d/ingression/hcpya.py
+++ b/xcp_d/ingression/hcpya.py
@@ -195,15 +195,15 @@ def convert_hcp_to_bids_single_subject(in_dir, out_dir, sub_ent):
     os.makedirs(work_dir, exist_ok=True)
 
     # Get masks to be used to extract confounds
-    csf_mask = load_data(f"masks/{volspace_ent}_{RES_ENT}_label-CSF_mask.nii.gz")
-    wm_mask = load_data(f"masks/{volspace_ent}_{RES_ENT}_label-WM_mask.nii.gz")
+    csf_mask = str(load_data(f"masks/{volspace_ent}_{RES_ENT}_label-CSF_mask.nii.gz"))
+    wm_mask = str(load_data(f"masks/{volspace_ent}_{RES_ENT}_label-WM_mask.nii.gz"))
 
     # A dictionary of mappings from HCP derivatives to fMRIPrep derivatives.
     # Values will be lists, to allow one-to-many mappings.
     copy_dictionary = {}
 
     # The identity xform is used in place of any actual ones.
-    identity_xfm = load_data("transform/itkIdentityTransform.txt")
+    identity_xfm = str(load_data("transform/itkIdentityTransform.txt"))
     copy_dictionary[identity_xfm] = []
 
     t1w_to_template_fmriprep = os.path.join(

--- a/xcp_d/ingression/hcpya.py
+++ b/xcp_d/ingression/hcpya.py
@@ -13,7 +13,7 @@ import re
 import nibabel as nb
 import pandas as pd
 from nipype import logging
-from pkg_resources import resource_filename as pkgrf
+from xcp_d.data import load as load_data
 
 from xcp_d.ingression.utils import (
     collect_anatomical_files,
@@ -195,15 +195,15 @@ def convert_hcp_to_bids_single_subject(in_dir, out_dir, sub_ent):
     os.makedirs(work_dir, exist_ok=True)
 
     # Get masks to be used to extract confounds
-    csf_mask = pkgrf("xcp_d", f"/data/masks/{volspace_ent}_{RES_ENT}_label-CSF_mask.nii.gz")
-    wm_mask = pkgrf("xcp_d", f"/data/masks/{volspace_ent}_{RES_ENT}_label-WM_mask.nii.gz")
+    csf_mask = load_data(f"masks/{volspace_ent}_{RES_ENT}_label-CSF_mask.nii.gz")
+    wm_mask = load_data(f"masks/{volspace_ent}_{RES_ENT}_label-WM_mask.nii.gz")
 
     # A dictionary of mappings from HCP derivatives to fMRIPrep derivatives.
     # Values will be lists, to allow one-to-many mappings.
     copy_dictionary = {}
 
     # The identity xform is used in place of any actual ones.
-    identity_xfm = pkgrf("xcp_d", "/data/transform/itkIdentityTransform.txt")
+    identity_xfm = load_data("transform/itkIdentityTransform.txt")
     copy_dictionary[identity_xfm] = []
 
     t1w_to_template_fmriprep = os.path.join(

--- a/xcp_d/ingression/hcpya.py
+++ b/xcp_d/ingression/hcpya.py
@@ -13,8 +13,8 @@ import re
 import nibabel as nb
 import pandas as pd
 from nipype import logging
-from xcp_d.data import load as load_data
 
+from xcp_d.data import load as load_data
 from xcp_d.ingression.utils import (
     collect_anatomical_files,
     collect_hcp_confounds,

--- a/xcp_d/ingression/ukbiobank.py
+++ b/xcp_d/ingression/ukbiobank.py
@@ -179,7 +179,7 @@ def convert_ukb_to_bids_single_subject(in_dir, out_dir, sub_id, ses_id):
     # Warp BOLD, T1w, and brainmask to MNI152NLin6Asym
     # We use FSL's MNI152NLin6Asym 2 mm3 template instead of TemplateFlow's version,
     # because FSL uses LAS+ orientation, while TemplateFlow uses RAS+.
-    template_file = load_data("MNI152_T1_2mm.nii.gz")
+    template_file = str(load_data("MNI152_T1_2mm.nii.gz"))
 
     copy_dictionary = {}
 
@@ -267,7 +267,7 @@ def convert_ukb_to_bids_single_subject(in_dir, out_dir, sub_id, ses_id):
     ]
 
     # The identity xform is used in place of any actual ones.
-    identity_xfm = load_data("transform/itkIdentityTransform.txt")
+    identity_xfm = str(load_data("transform/itkIdentityTransform.txt"))
     copy_dictionary[identity_xfm] = []
 
     t1w_to_template_fmriprep = os.path.join(

--- a/xcp_d/ingression/ukbiobank.py
+++ b/xcp_d/ingression/ukbiobank.py
@@ -7,7 +7,7 @@ import os
 import pandas as pd
 from nipype import logging
 from nipype.interfaces.fsl.preprocess import ApplyWarp
-from pkg_resources import resource_filename as pkgrf
+from xcp_d.data import load as load_data
 
 from xcp_d.ingression.utils import (
     collect_ukbiobank_confounds,
@@ -179,7 +179,7 @@ def convert_ukb_to_bids_single_subject(in_dir, out_dir, sub_id, ses_id):
     # Warp BOLD, T1w, and brainmask to MNI152NLin6Asym
     # We use FSL's MNI152NLin6Asym 2 mm3 template instead of TemplateFlow's version,
     # because FSL uses LAS+ orientation, while TemplateFlow uses RAS+.
-    template_file = pkgrf("xcp_d", "data/MNI152_T1_2mm.nii.gz")
+    template_file = load_data("MNI152_T1_2mm.nii.gz")
 
     copy_dictionary = {}
 
@@ -267,7 +267,7 @@ def convert_ukb_to_bids_single_subject(in_dir, out_dir, sub_id, ses_id):
     ]
 
     # The identity xform is used in place of any actual ones.
-    identity_xfm = pkgrf("xcp_d", "/data/transform/itkIdentityTransform.txt")
+    identity_xfm = load_data("transform/itkIdentityTransform.txt")
     copy_dictionary[identity_xfm] = []
 
     t1w_to_template_fmriprep = os.path.join(

--- a/xcp_d/ingression/ukbiobank.py
+++ b/xcp_d/ingression/ukbiobank.py
@@ -7,8 +7,8 @@ import os
 import pandas as pd
 from nipype import logging
 from nipype.interfaces.fsl.preprocess import ApplyWarp
-from xcp_d.data import load as load_data
 
+from xcp_d.data import load as load_data
 from xcp_d.ingression.utils import (
     collect_ukbiobank_confounds,
     copy_files_in_dict,

--- a/xcp_d/interfaces/bids.py
+++ b/xcp_d/interfaces/bids.py
@@ -3,7 +3,6 @@
 import os
 import shutil
 from json import loads
-from pathlib import Path
 
 import nibabel as nb
 import numpy as np
@@ -23,7 +22,7 @@ from xcp_d.data import load as load_data
 from xcp_d.utils.bids import get_entity
 
 # NOTE: Modified for xcpd's purposes
-xcp_d_spec = loads(Path(load_data("xcp_d_bids_config.json")).read_text())
+xcp_d_spec = loads(load_data("xcp_d_bids_config.json").read_text())
 bids_config = Config.load("bids")
 deriv_config = Config.load("derivatives")
 
@@ -138,10 +137,12 @@ class CollectRegistrationFiles(SimpleInterface):
 
             # TODO: Collect from templateflow once it's uploaded.
             # FreeSurfer: fs_?/fs_?-to-fs_LR_fsaverage.?_LR.spherical_std.164k_fs_?.surf.gii
-            self._results["sphere_to_sphere"] = load_data(
-                f"standard_mesh_atlases/fs_{hemisphere}/"
-                f"fs_{hemisphere}-to-fs_LR_fsaverage.{hemisphere}_LR.spherical_std."
-                f"164k_fs_{hemisphere}.surf.gii"
+            self._results["sphere_to_sphere"] = str(
+                load_data(
+                    f"standard_mesh_atlases/fs_{hemisphere}/"
+                    f"fs_{hemisphere}-to-fs_LR_fsaverage.{hemisphere}_LR.spherical_std."
+                    f"164k_fs_{hemisphere}.surf.gii"
+                )
             )
 
             # FreeSurfer: tpl-fsLR_hemi-?_den-32k_sphere.surf.gii

--- a/xcp_d/interfaces/bids.py
+++ b/xcp_d/interfaces/bids.py
@@ -18,8 +18,8 @@ from nipype.interfaces.base import (
     traits,
 )
 from niworkflows.interfaces.bids import DerivativesDataSink as BaseDerivativesDataSink
-from xcp_d.data import load as load_data
 
+from xcp_d.data import load as load_data
 from xcp_d.utils.bids import get_entity
 
 # NOTE: Modified for xcpd's purposes
@@ -102,8 +102,9 @@ class CollectRegistrationFiles(SimpleInterface):
     def _run_interface(self, runtime):
         import os
 
-        from xcp_d.data import load as load_data
         from templateflow.api import get as get_template
+
+        from xcp_d.data import load as load_data
 
         hemisphere = self.inputs.hemisphere
         hstr = f"{hemisphere.lower()}h"

--- a/xcp_d/interfaces/bids.py
+++ b/xcp_d/interfaces/bids.py
@@ -18,12 +18,12 @@ from nipype.interfaces.base import (
     traits,
 )
 from niworkflows.interfaces.bids import DerivativesDataSink as BaseDerivativesDataSink
-from pkg_resources import resource_filename as pkgrf
+from xcp_d.data import load as load_data
 
 from xcp_d.utils.bids import get_entity
 
 # NOTE: Modified for xcpd's purposes
-xcp_d_spec = loads(Path(pkgrf("xcp_d", "data/xcp_d_bids_config.json")).read_text())
+xcp_d_spec = loads(Path(load_data("xcp_d_bids_config.json")).read_text())
 bids_config = Config.load("bids")
 deriv_config = Config.load("derivatives")
 
@@ -102,7 +102,7 @@ class CollectRegistrationFiles(SimpleInterface):
     def _run_interface(self, runtime):
         import os
 
-        from pkg_resources import resource_filename as pkgrf
+        from xcp_d.data import load as load_data
         from templateflow.api import get as get_template
 
         hemisphere = self.inputs.hemisphere
@@ -137,13 +137,10 @@ class CollectRegistrationFiles(SimpleInterface):
 
             # TODO: Collect from templateflow once it's uploaded.
             # FreeSurfer: fs_?/fs_?-to-fs_LR_fsaverage.?_LR.spherical_std.164k_fs_?.surf.gii
-            self._results["sphere_to_sphere"] = pkgrf(
-                "xcp_d",
-                (
-                    f"data/standard_mesh_atlases/fs_{hemisphere}/"
-                    f"fs_{hemisphere}-to-fs_LR_fsaverage.{hemisphere}_LR.spherical_std."
-                    f"164k_fs_{hemisphere}.surf.gii"
-                ),
+            self._results["sphere_to_sphere"] = load_data(
+                f"standard_mesh_atlases/fs_{hemisphere}/"
+                f"fs_{hemisphere}-to-fs_LR_fsaverage.{hemisphere}_LR.spherical_std."
+                f"164k_fs_{hemisphere}.surf.gii"
             )
 
             # FreeSurfer: tpl-fsLR_hemi-?_den-32k_sphere.surf.gii

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -18,7 +18,7 @@ from nipype.interfaces.base import (
     TraitedSpec,
 )
 from PIL import Image
-from pkg_resources import resource_filename as pkgrf
+from xcp_d.data import load as load_data
 
 from xcp_d.utils.filemanip import fname_presuffix
 
@@ -310,7 +310,7 @@ class ExecutiveSummary(object):
                     "LaTeX",
                     f"""<pre>{text}</pre>
 <h3>Bibliography</h3>
-<pre>{Path(pkgrf("xcp_d", "data/boilerplate.bib")).read_text()}</pre>
+<pre>{Path(load_data("boilerplate.bib")).read_text()}</pre>
 """,
                 )
             )
@@ -319,7 +319,7 @@ class ExecutiveSummary(object):
         def include_file(name):
             return Markup(loader.get_source(environment, name)[0])
 
-        template_folder = pkgrf("xcp_d", "/data/executive_summary_templates/")
+        template_folder = load_data("executive_summary_templates/")
         loader = FileSystemLoader(template_folder)
         environment = Environment(loader=loader)
         environment.filters["basename"] = os.path.basename

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -310,7 +310,7 @@ class ExecutiveSummary(object):
                     "LaTeX",
                     f"""<pre>{text}</pre>
 <h3>Bibliography</h3>
-<pre>{Path(load_data("boilerplate.bib")).read_text()}</pre>
+<pre>{load_data("boilerplate.bib").read_text()}</pre>
 """,
                 )
             )
@@ -319,7 +319,7 @@ class ExecutiveSummary(object):
         def include_file(name):
             return Markup(loader.get_source(environment, name)[0])
 
-        template_folder = load_data("executive_summary_templates/")
+        template_folder = str(load_data("executive_summary_templates/"))
         loader = FileSystemLoader(template_folder)
         environment = Environment(loader=loader)
         environment.filters["basename"] = os.path.basename

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -18,8 +18,8 @@ from nipype.interfaces.base import (
     TraitedSpec,
 )
 from PIL import Image
-from xcp_d.data import load as load_data
 
+from xcp_d.data import load as load_data
 from xcp_d.utils.filemanip import fname_presuffix
 
 

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -377,7 +377,7 @@ def _run_and_generate(test_name, parameters, input_type):
         subject_list=config.execution.participant_label,
         output_dir=config.execution.xcp_d_dir,
         run_uuid=config.execution.run_uuid,
-        config=load_data("reports-spec.yml"),
+        config=str(load_data("reports-spec.yml")),
         packagename="xcp_d",
     )
 

--- a/xcp_d/tests/test_smoothing.py
+++ b/xcp_d/tests/test_smoothing.py
@@ -7,7 +7,7 @@ import tempfile
 import numpy as np
 from nipype.interfaces.workbench import CiftiSmooth
 from nipype.pipeline import engine as pe
-from pkg_resources import resource_filename as pkgrf
+from xcp_d.data import load as load_data
 
 from xcp_d.interfaces.nilearn import Smooth
 from xcp_d.utils.utils import fwhm2sigma
@@ -81,13 +81,11 @@ def test_smoothing_cifti(ds001419_data, tmp_path_factory, sigma_lx=fwhm2sigma(6)
     tmpdir = tmp_path_factory.mktemp("test_smoothing_cifti")
     in_file = ds001419_data["cifti_file"]
     # pull out atlases for each hemisphere
-    right_surf = pkgrf(
-        "xcp_d",
-        "data/ciftiatlas/Q1-Q6_RelatedParcellation210.R.midthickness_32k_fs_LR.surf.gii",
+    right_surf = load_data(
+        "ciftiatlas/Q1-Q6_RelatedParcellation210.R.midthickness_32k_fs_LR.surf.gii",
     )
-    left_surf = pkgrf(
-        "xcp_d",
-        "data/ciftiatlas/Q1-Q6_RelatedParcellation210.L.midthickness_32k_fs_LR.surf.gii",
+    left_surf = load_data(
+        "ciftiatlas/Q1-Q6_RelatedParcellation210.L.midthickness_32k_fs_LR.surf.gii",
     )
 
     # Estimate the smoothness of the unsmoothed file

--- a/xcp_d/tests/test_smoothing.py
+++ b/xcp_d/tests/test_smoothing.py
@@ -7,8 +7,8 @@ import tempfile
 import numpy as np
 from nipype.interfaces.workbench import CiftiSmooth
 from nipype.pipeline import engine as pe
-from xcp_d.data import load as load_data
 
+from xcp_d.data import load as load_data
 from xcp_d.interfaces.nilearn import Smooth
 from xcp_d.utils.utils import fwhm2sigma
 

--- a/xcp_d/tests/test_smoothing.py
+++ b/xcp_d/tests/test_smoothing.py
@@ -81,11 +81,15 @@ def test_smoothing_cifti(ds001419_data, tmp_path_factory, sigma_lx=fwhm2sigma(6)
     tmpdir = tmp_path_factory.mktemp("test_smoothing_cifti")
     in_file = ds001419_data["cifti_file"]
     # pull out atlases for each hemisphere
-    right_surf = load_data(
-        "ciftiatlas/Q1-Q6_RelatedParcellation210.R.midthickness_32k_fs_LR.surf.gii",
+    right_surf = str(
+        load_data(
+            "ciftiatlas/Q1-Q6_RelatedParcellation210.R.midthickness_32k_fs_LR.surf.gii",
+        )
     )
-    left_surf = load_data(
-        "ciftiatlas/Q1-Q6_RelatedParcellation210.L.midthickness_32k_fs_LR.surf.gii",
+    left_surf = str(
+        load_data(
+            "ciftiatlas/Q1-Q6_RelatedParcellation210.L.midthickness_32k_fs_LR.surf.gii",
+        )
     )
 
     # Estimate the smoothness of the unsmoothed file

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -85,7 +85,7 @@ def test_collect_data_ds001419(datasets):
 def test_collect_data_nibabies(datasets):
     """Test the collect_data function."""
     bids_dir = datasets["nibabies"]
-    xcp_d_config = load_data("xcp_d_bids_config2.json")
+    xcp_d_config = str(load_data("xcp_d_bids_config2.json"))
     layout = BIDSLayout(
         bids_dir,
         validate=False,

--- a/xcp_d/tests/test_utils_execsummary.py
+++ b/xcp_d/tests/test_utils_execsummary.py
@@ -3,7 +3,7 @@
 import os
 
 import matplotlib.pyplot as plt
-from pkg_resources import resource_filename as pkgrf
+from xcp_d.data import load as load_data
 
 from xcp_d.tests.utils import chdir
 from xcp_d.utils import execsummary
@@ -33,9 +33,8 @@ def test_modify_brainsprite_scene_template(tmp_path_factory):
     """Test modify_brainsprite_scene_template."""
     tmpdir = tmp_path_factory.mktemp("test_modify_brainsprite_scene_template")
 
-    brainsprite_scene_template = pkgrf(
-        "xcp_d",
-        "data/executive_summary_scenes/brainsprite_template.scene.gz",
+    brainsprite_scene_template = load_data(
+        "executive_summary_scenes/brainsprite_template.scene.gz",
     )
 
     with chdir(tmpdir):
@@ -56,7 +55,7 @@ def test_modify_pngs_scene_template(tmp_path_factory):
     """Test modify_pngs_scene_template."""
     tmpdir = tmp_path_factory.mktemp("test_modify_pngs_scene_template")
 
-    pngs_scene_template = pkgrf("xcp_d", "data/executive_summary_scenes/pngs_template.scene.gz")
+    pngs_scene_template = load_data("executive_summary_scenes/pngs_template.scene.gz")
 
     with chdir(tmpdir):
         scene_file = execsummary.modify_pngs_scene_template(

--- a/xcp_d/tests/test_utils_execsummary.py
+++ b/xcp_d/tests/test_utils_execsummary.py
@@ -3,8 +3,8 @@
 import os
 
 import matplotlib.pyplot as plt
-from xcp_d.data import load as load_data
 
+from xcp_d.data import load as load_data
 from xcp_d.tests.utils import chdir
 from xcp_d.utils import execsummary
 

--- a/xcp_d/tests/test_utils_execsummary.py
+++ b/xcp_d/tests/test_utils_execsummary.py
@@ -33,8 +33,10 @@ def test_modify_brainsprite_scene_template(tmp_path_factory):
     """Test modify_brainsprite_scene_template."""
     tmpdir = tmp_path_factory.mktemp("test_modify_brainsprite_scene_template")
 
-    brainsprite_scene_template = load_data(
-        "executive_summary_scenes/brainsprite_template.scene.gz",
+    brainsprite_scene_template = str(
+        load_data(
+            "executive_summary_scenes/brainsprite_template.scene.gz",
+        )
     )
 
     with chdir(tmpdir):
@@ -55,7 +57,7 @@ def test_modify_pngs_scene_template(tmp_path_factory):
     """Test modify_pngs_scene_template."""
     tmpdir = tmp_path_factory.mktemp("test_modify_pngs_scene_template")
 
-    pngs_scene_template = load_data("executive_summary_scenes/pngs_template.scene.gz")
+    pngs_scene_template = str(load_data("executive_summary_scenes/pngs_template.scene.gz"))
 
     with chdir(tmpdir):
         scene_file = execsummary.modify_pngs_scene_template(

--- a/xcp_d/tests/tests.py
+++ b/xcp_d/tests/tests.py
@@ -42,7 +42,7 @@ def mock_config():
     if not _old_fs:
         os.environ["FREESURFER_HOME"] = mkdtemp()
 
-    filename = Path(load_data("../tests/data/config.toml")).resolve()
+    filename = load_data("../tests/data/config.toml").resolve()
     settings = loads(filename.read_text())
     for sectionname, configs in settings.items():
         if sectionname != "environment":

--- a/xcp_d/utils/atlas.py
+++ b/xcp_d/utils/atlas.py
@@ -53,7 +53,7 @@ def select_atlases(atlases, subset):
 
 
 def get_atlas_nifti(atlas):
-    """Select atlas by name from xcp_d/data using pkgrf.
+    """Select atlas by name from xcp_d/data using load_data.
 
     All atlases are in MNI space.
 
@@ -78,7 +78,7 @@ def get_atlas_nifti(atlas):
     """
     from os.path import isfile, join
 
-    from pkg_resources import resource_filename as pkgrf
+    from xcp_d.data import load as load_data
 
     if "4S" in atlas or atlas in ("Glasser", "Gordon"):
         # 1 mm3 atlases
@@ -94,12 +94,9 @@ def get_atlas_nifti(atlas):
         atlas_labels_file = join("/AtlasPack", tsv_fname)
         atlas_metadata_file = f"/AtlasPack/tpl-MNI152NLin6Asym_atlas-{atlas}_dseg.json"
     else:
-        atlas_file = pkgrf("xcp_d", f"data/atlases/{atlas_fname}")
-        atlas_labels_file = pkgrf("xcp_d", f"data/atlases/{tsv_fname}")
-        atlas_metadata_file = pkgrf(
-            "xcp_d",
-            f"data/atlases/tpl-MNI152NLin6Asym_atlas-{atlas}_dseg.json",
-        )
+        atlas_file = load_data(f"atlases/{atlas_fname}")
+        atlas_labels_file = load_data(f"atlases/{tsv_fname}")
+        atlas_metadata_file = load_data(f"atlases/tpl-MNI152NLin6Asym_atlas-{atlas}_dseg.json")
 
     if not (isfile(atlas_file) and isfile(atlas_labels_file) and isfile(atlas_metadata_file)):
         raise FileNotFoundError(
@@ -135,19 +132,16 @@ def get_atlas_cifti(atlas):
     """
     from os.path import isfile
 
-    from pkg_resources import resource_filename as pkgrf
+    from xcp_d.data import load as load_data
 
     if "4S" in atlas:
         atlas_file = f"/AtlasPack/tpl-fsLR_atlas-{atlas}_den-91k_dseg.dlabel.nii"
         atlas_labels_file = f"/AtlasPack/atlas-{atlas}_dseg.tsv"
         atlas_metadata_file = f"/AtlasPack/tpl-fsLR_atlas-{atlas}_dseg.json"
     else:
-        atlas_file = pkgrf(
-            "xcp_d",
-            f"data/atlases/tpl-fsLR_atlas-{atlas}_den-32k_dseg.dlabel.nii",
-        )
-        atlas_labels_file = pkgrf("xcp_d", f"data/atlases/atlas-{atlas}_dseg.tsv")
-        atlas_metadata_file = pkgrf("xcp_d", f"data/atlases/tpl-fsLR_atlas-{atlas}_dseg.json")
+        atlas_file = load_data(f"atlases/tpl-fsLR_atlas-{atlas}_den-32k_dseg.dlabel.nii")
+        atlas_labels_file = load_data(f"atlases/atlas-{atlas}_dseg.tsv")
+        atlas_metadata_file = load_data(f"atlases/tpl-fsLR_atlas-{atlas}_dseg.json")
 
     if not (isfile(atlas_file) and isfile(atlas_labels_file) and isfile(atlas_metadata_file)):
         raise FileNotFoundError(

--- a/xcp_d/utils/atlas.py
+++ b/xcp_d/utils/atlas.py
@@ -94,9 +94,11 @@ def get_atlas_nifti(atlas):
         atlas_labels_file = join("/AtlasPack", tsv_fname)
         atlas_metadata_file = f"/AtlasPack/tpl-MNI152NLin6Asym_atlas-{atlas}_dseg.json"
     else:
-        atlas_file = load_data(f"atlases/{atlas_fname}")
-        atlas_labels_file = load_data(f"atlases/{tsv_fname}")
-        atlas_metadata_file = load_data(f"atlases/tpl-MNI152NLin6Asym_atlas-{atlas}_dseg.json")
+        atlas_file = str(load_data(f"atlases/{atlas_fname}"))
+        atlas_labels_file = str(load_data(f"atlases/{tsv_fname}"))
+        atlas_metadata_file = str(
+            load_data(f"atlases/tpl-MNI152NLin6Asym_atlas-{atlas}_dseg.json")
+        )
 
     if not (isfile(atlas_file) and isfile(atlas_labels_file) and isfile(atlas_metadata_file)):
         raise FileNotFoundError(
@@ -139,9 +141,9 @@ def get_atlas_cifti(atlas):
         atlas_labels_file = f"/AtlasPack/atlas-{atlas}_dseg.tsv"
         atlas_metadata_file = f"/AtlasPack/tpl-fsLR_atlas-{atlas}_dseg.json"
     else:
-        atlas_file = load_data(f"atlases/tpl-fsLR_atlas-{atlas}_den-32k_dseg.dlabel.nii")
-        atlas_labels_file = load_data(f"atlases/atlas-{atlas}_dseg.tsv")
-        atlas_metadata_file = load_data(f"atlases/tpl-fsLR_atlas-{atlas}_dseg.json")
+        atlas_file = str(load_data(f"atlases/tpl-fsLR_atlas-{atlas}_den-32k_dseg.dlabel.nii"))
+        atlas_labels_file = str(load_data(f"atlases/atlas-{atlas}_dseg.tsv"))
+        atlas_metadata_file = str(load_data(f"atlases/tpl-fsLR_atlas-{atlas}_dseg.json"))
 
     if not (isfile(atlas_file) and isfile(atlas_labels_file) and isfile(atlas_metadata_file)):
         raise FileNotFoundError(

--- a/xcp_d/utils/doc.py
+++ b/xcp_d/utils/doc.py
@@ -632,6 +632,7 @@ def download_example_data(out_dir=None, overwrite=False):
     import tarfile
 
     import requests
+
     from xcp_d.data import load as load_data
 
     if not out_dir:

--- a/xcp_d/utils/doc.py
+++ b/xcp_d/utils/doc.py
@@ -632,10 +632,10 @@ def download_example_data(out_dir=None, overwrite=False):
     import tarfile
 
     import requests
-    from pkg_resources import resource_filename as pkgrf
+    from xcp_d.data import load as load_data
 
     if not out_dir:
-        out_dir = pkgrf("xcp_d", "data")
+        out_dir = load_data(".")
 
     out_dir = os.path.abspath(out_dir)
 

--- a/xcp_d/utils/doc.py
+++ b/xcp_d/utils/doc.py
@@ -636,7 +636,7 @@ def download_example_data(out_dir=None, overwrite=False):
     from xcp_d.data import load as load_data
 
     if not out_dir:
-        out_dir = load_data(".")
+        out_dir = str(load_data("."))
 
     out_dir = os.path.abspath(out_dir)
 

--- a/xcp_d/utils/sentry.py
+++ b/xcp_d/utils/sentry.py
@@ -41,8 +41,7 @@ def sentry_setup():
     environment = (
         "dev"
         if (
-            os.getenv("XCP-D_DEV", "").lower in ("1", "on", "yes", "y", "true")
-            or ("+" in release)
+            os.getenv("XCP-D_DEV", "").lower in ("1", "on", "yes", "y", "true") or ("+" in release)
         )
         else "prod"
     )

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -94,8 +94,10 @@ def get_bold2std_and_t1w_xfms(bold_file, template_to_anat_xfm):
 
     elif bold_space == "MNIInfant":
         # MNIInfant --> MNI152NLin2009cAsym
-        MNIInfant_to_MNI152NLin2009cAsym = load_data(
-            "transform/tpl-MNIInfant_from-MNI152NLin2009cAsym_mode-image_xfm.h5",
+        MNIInfant_to_MNI152NLin2009cAsym = str(
+            load_data(
+                "transform/tpl-MNIInfant_from-MNI152NLin2009cAsym_mode-image_xfm.h5",
+            )
         )
         xforms_to_MNI = [MNIInfant_to_MNI152NLin2009cAsym]
         xforms_to_MNI_invert = [False]
@@ -189,8 +191,10 @@ def get_std2bold_xfms(bold_file):
 
     elif bold_space == "MNIInfant":
         # NLin6 --> NLin2009c --> MNIInfant
-        MNI152NLin2009cAsym_to_MNI152Infant = load_data(
-            "transform/tpl-MNIInfant_from-MNI152NLin2009cAsym_mode-image_xfm.h5",
+        MNI152NLin2009cAsym_to_MNI152Infant = str(
+            load_data(
+                "transform/tpl-MNIInfant_from-MNI152NLin2009cAsym_mode-image_xfm.h5",
+            )
         )
         transform_list = [
             MNI152NLin2009cAsym_to_MNI152Infant,

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -54,7 +54,7 @@ def get_bold2std_and_t1w_xfms(bold_file, template_to_anat_xfm):
     Only used for QCReport in init_postprocess_nifti_wf.
     QCReport wants MNI-space data in MNI152NLin2009cAsym.
     """
-    from pkg_resources import resource_filename as pkgrf
+    from xcp_d.data import load as load_data
     from templateflow.api import get as get_template
 
     from xcp_d.utils.bids import get_entity
@@ -94,9 +94,8 @@ def get_bold2std_and_t1w_xfms(bold_file, template_to_anat_xfm):
 
     elif bold_space == "MNIInfant":
         # MNIInfant --> MNI152NLin2009cAsym
-        MNIInfant_to_MNI152NLin2009cAsym = pkgrf(
-            "xcp_d",
-            "data/transform/tpl-MNIInfant_from-MNI152NLin2009cAsym_mode-image_xfm.h5",
+        MNIInfant_to_MNI152NLin2009cAsym = load_data(
+            "transform/tpl-MNIInfant_from-MNI152NLin2009cAsym_mode-image_xfm.h5",
         )
         xforms_to_MNI = [MNIInfant_to_MNI152NLin2009cAsym]
         xforms_to_MNI_invert = [False]
@@ -160,7 +159,7 @@ def get_std2bold_xfms(bold_file):
     """
     import os
 
-    from pkg_resources import resource_filename as pkgrf
+    from xcp_d.data import load as load_data
     from templateflow.api import get as get_template
 
     from xcp_d.utils.bids import get_entity
@@ -190,9 +189,8 @@ def get_std2bold_xfms(bold_file):
 
     elif bold_space == "MNIInfant":
         # NLin6 --> NLin2009c --> MNIInfant
-        MNI152NLin2009cAsym_to_MNI152Infant = pkgrf(
-            "xcp_d",
-            "data/transform/tpl-MNIInfant_from-MNI152NLin2009cAsym_mode-image_xfm.h5",
+        MNI152NLin2009cAsym_to_MNI152Infant = load_data(
+            "transform/tpl-MNIInfant_from-MNI152NLin2009cAsym_mode-image_xfm.h5",
         )
         transform_list = [
             MNI152NLin2009cAsym_to_MNI152Infant,

--- a/xcp_d/utils/utils.py
+++ b/xcp_d/utils/utils.py
@@ -54,9 +54,9 @@ def get_bold2std_and_t1w_xfms(bold_file, template_to_anat_xfm):
     Only used for QCReport in init_postprocess_nifti_wf.
     QCReport wants MNI-space data in MNI152NLin2009cAsym.
     """
-    from xcp_d.data import load as load_data
     from templateflow.api import get as get_template
 
+    from xcp_d.data import load as load_data
     from xcp_d.utils.bids import get_entity
 
     # Extract the space of the BOLD file
@@ -159,9 +159,9 @@ def get_std2bold_xfms(bold_file):
     """
     import os
 
-    from xcp_d.data import load as load_data
     from templateflow.api import get as get_template
 
+    from xcp_d.data import load as load_data
     from xcp_d.utils.bids import get_entity
 
     # Extract the space of the BOLD file

--- a/xcp_d/workflows/connectivity.py
+++ b/xcp_d/workflows/connectivity.py
@@ -88,7 +88,7 @@ def init_load_atlases_wf(name="load_atlases_wf"):
         name="outputnode",
     )
 
-    # get atlases via pkgrf
+    # get atlases via load_data
     atlas_file_grabber = pe.MapNode(
         Function(
             input_names=["atlas"],
@@ -318,7 +318,7 @@ def init_parcellate_surfaces_wf(files_to_parcellate, name="parcellate_surfaces_w
 
         return workflow
 
-    # Get CIFTI atlases via pkgrf
+    # Get CIFTI atlases via load_data
     atlas_file_grabber = pe.MapNode(
         Function(
             input_names=["atlas"],

--- a/xcp_d/workflows/execsummary.py
+++ b/xcp_d/workflows/execsummary.py
@@ -9,7 +9,7 @@ from nipype.interfaces import fsl
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-from pkg_resources import resource_filename as pkgrf
+from xcp_d.data import load as load_data
 
 from xcp_d import config
 from xcp_d.interfaces.bids import DerivativesDataSink
@@ -89,11 +89,10 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
     )
 
     # Load template scene file
-    brainsprite_scene_template = pkgrf(
-        "xcp_d",
-        "data/executive_summary_scenes/brainsprite_template.scene.gz",
+    brainsprite_scene_template = load_data(
+        "executive_summary_scenes/brainsprite_template.scene.gz",
     )
-    pngs_scene_template = pkgrf("xcp_d", "data/executive_summary_scenes/pngs_template.scene.gz")
+    pngs_scene_template = load_data("executive_summary_scenes/pngs_template.scene.gz")
 
     if t1w_available and t2w_available:
         image_types = ["T1", "T2"]

--- a/xcp_d/workflows/execsummary.py
+++ b/xcp_d/workflows/execsummary.py
@@ -9,9 +9,9 @@ from nipype.interfaces import fsl
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-from xcp_d.data import load as load_data
 
 from xcp_d import config
+from xcp_d.data import load as load_data
 from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.execsummary import FormatForBrainSwipes
 from xcp_d.interfaces.nilearn import BinaryMath, ResampleToImage

--- a/xcp_d/workflows/execsummary.py
+++ b/xcp_d/workflows/execsummary.py
@@ -89,10 +89,10 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
     )
 
     # Load template scene file
-    brainsprite_scene_template = load_data(
-        "executive_summary_scenes/brainsprite_template.scene.gz",
+    brainsprite_scene_template = str(
+        load_data("executive_summary_scenes/brainsprite_template.scene.gz")
     )
-    pngs_scene_template = load_data("executive_summary_scenes/pngs_template.scene.gz")
+    pngs_scene_template = str(load_data("executive_summary_scenes/pngs_template.scene.gz"))
 
     if t1w_available and t2w_available:
         image_types = ["T1", "T2"]

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -735,11 +735,16 @@ The denoised BOLD was then smoothed using *Connectome Workbench* with a Gaussian
                 sigma_surf=sigma_lx,  # the size of the surface kernel
                 sigma_vol=sigma_lx,  # the volume of the surface kernel
                 direction="COLUMN",  # which direction to smooth along@
-                right_surf=load_data(  # pull out atlases for each hemisphere
-                    "ciftiatlas/Q1-Q6_RelatedParcellation210.R.midthickness_32k_fs_LR.surf.gii"
+                # pull out atlases for each hemisphere
+                right_surf=str(
+                    load_data(
+                        "ciftiatlas/Q1-Q6_RelatedParcellation210.R.midthickness_32k_fs_LR.surf.gii"
+                    )
                 ),
-                left_surf=load_data(
-                    "ciftiatlas/Q1-Q6_RelatedParcellation210.L.midthickness_32k_fs_LR.surf.gii"
+                left_surf=str(
+                    load_data(
+                        "ciftiatlas/Q1-Q6_RelatedParcellation210.L.midthickness_32k_fs_LR.surf.gii"
+                    )
                 ),
             ),
             name="cifti_smoothing",

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -6,7 +6,7 @@ from nipype.interfaces.workbench.cifti import CiftiSmooth
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from num2words import num2words
-from pkg_resources import resource_filename as pkgrf
+from xcp_d.data import load as load_data
 
 from xcp_d import config
 from xcp_d.interfaces.bids import DerivativesDataSink
@@ -735,19 +735,11 @@ The denoised BOLD was then smoothed using *Connectome Workbench* with a Gaussian
                 sigma_surf=sigma_lx,  # the size of the surface kernel
                 sigma_vol=sigma_lx,  # the volume of the surface kernel
                 direction="COLUMN",  # which direction to smooth along@
-                right_surf=pkgrf(  # pull out atlases for each hemisphere
-                    "xcp_d",
-                    (
-                        "data/ciftiatlas/"
-                        "Q1-Q6_RelatedParcellation210.R.midthickness_32k_fs_LR.surf.gii"
-                    ),
+                right_surf=load_data(  # pull out atlases for each hemisphere
+                    "ciftiatlas/Q1-Q6_RelatedParcellation210.R.midthickness_32k_fs_LR.surf.gii"
                 ),
-                left_surf=pkgrf(
-                    "xcp_d",
-                    (
-                        "data/ciftiatlas/"
-                        "Q1-Q6_RelatedParcellation210.L.midthickness_32k_fs_LR.surf.gii"
-                    ),
+                left_surf=load_data(
+                    "ciftiatlas/Q1-Q6_RelatedParcellation210.L.midthickness_32k_fs_LR.surf.gii"
                 ),
             ),
             name="cifti_smoothing",

--- a/xcp_d/workflows/postprocessing.py
+++ b/xcp_d/workflows/postprocessing.py
@@ -6,9 +6,9 @@ from nipype.interfaces.workbench.cifti import CiftiSmooth
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from num2words import num2words
-from xcp_d.data import load as load_data
 
 from xcp_d import config
+from xcp_d.data import load as load_data
 from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.censoring import (
     Censor,


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Stop loading internal resources with `pkg_resources` (which is deprecated) and start using `xcp_d.data.load`.