### PR TITLE
Fix exit code bug in `cli.run.main()`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,8 @@ jobs:
             - .coverage.ds001419_nifti
       - store_artifacts:
           path: /src/xcp_d/.circleci/out/test_ds001419_nifti/
+    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
+    resource_class: large
 
   ds001419_cifti:
     <<: *dockersetup

--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -693,10 +693,6 @@ def parse_args(args=None, namespace=None):
     import logging
 
     parser = _build_parser()
-    config.loggers.cli.warning("args")
-    config.loggers.cli.warning(args)
-    config.loggers.cli.warning("namespace")
-    config.loggers.cli.warning(namespace)
 
     opts = parser.parse_args(args, namespace)
     if opts.config_file:

--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -693,7 +693,6 @@ def parse_args(args=None, namespace=None):
     import logging
 
     parser = _build_parser()
-
     opts = parser.parse_args(args, namespace)
     if opts.config_file:
         skip = {} if opts.reports_only else {"execution": ("run_uuid",)}

--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -693,6 +693,11 @@ def parse_args(args=None, namespace=None):
     import logging
 
     parser = _build_parser()
+    config.loggers.cli.warning("args")
+    config.loggers.cli.warning(args)
+    config.loggers.cli.warning("namespace")
+    config.loggers.cli.warning(namespace)
+
     opts = parser.parse_args(args, namespace)
     if opts.config_file:
         skip = {} if opts.reports_only else {"execution": ("run_uuid",)}

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -153,14 +153,6 @@ def main():
                 f"boilerplate text found in {boiler_file}.",
             )
 
-        if config.workflow.run_reconall:
-            from niworkflows.utils.misc import _copy_any
-            from templateflow import api
-
-            dseg_tsv = str(api.get("fsaverage", suffix="dseg", extension=[".tsv"]))
-            _copy_any(dseg_tsv, str(config.execution.xcp_d_dir / "desc-aseg_dseg.tsv"))
-            _copy_any(dseg_tsv, str(config.execution.xcp_d_dir / "desc-aparcaseg_dseg.tsv"))
-
         errno = 0
 
     finally:

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -23,7 +23,7 @@ def main():
         write_dataset_description,
     )
 
-    parse_args()
+    parse_args(args=sys.argv[1:])
 
     if "pdb" in config.execution.debug:
         from xcp_d.utils.debug import setup_exceptionhook

--- a/xcp_d/tests/data/config.toml
+++ b/xcp_d/tests/data/config.toml
@@ -57,9 +57,9 @@ dcan_qc = false
 [nipype]
 crashfile_format = "txt"
 get_linked_libs = false
-memory_gb = 32
-nprocs = 8
-omp_nthreads = 8
+memory_gb = 48
+nprocs = 2
+omp_nthreads = 2
 plugin = "MultiProc"
 resource_monitor = false
 stop_on_first_crash = false

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -360,7 +360,7 @@ def _run_and_generate(test_name, parameters, input_type):
 
     argv = ["xcp-d"] + parameters
     with patch.object(sys, "argv", argv):
-        run()
+        run.main()
 
     output_list_file = os.path.join(get_test_data_path(), f"{test_name}_outputs.txt")
     check_generated_files(config.execution.xcp_d_dir, output_list_file)

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -356,6 +356,7 @@ def _run_and_generate(test_name, parameters, input_type):
 
     parameters.append("--clean-workdir")
     parameters.append("--stop-on-first-crash")
+    parameters.append("--notrack")
     parameters.append("-vv")
 
     argv = ["xcp-d"] + parameters

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -11,6 +11,10 @@ import pytest
 from nipype import logging
 
 from xcp_d.cli import combineqc, run
+from xcp_d.cli.parser import parse_args
+from xcp_d.cli.workflow import build_boilerplate, build_workflow
+from xcp_d.data import load as load_data
+from xcp_d.interfaces.report_core import generate_reports
 from xcp_d.tests.utils import (
     check_affines,
     check_generated_files,
@@ -18,6 +22,7 @@ from xcp_d.tests.utils import (
     get_test_data_path,
     list_files,
 )
+from xcp_d.utils.bids import write_atlas_dataset_description, write_dataset_description
 
 LOGGER = logging.getLogger("nipype.utils")
 
@@ -252,6 +257,7 @@ def test_pnc_cifti_t2wonly(data_dir, output_dir, working_dir):
         test_name=test_name,
         parameters=parameters,
         input_type="cifti",
+        test_main=True,
     )
 
 
@@ -351,7 +357,7 @@ def test_nibabies(data_dir, output_dir, working_dir):
     )
 
 
-def _run_and_generate(test_name, parameters, input_type):
+def _run_and_generate(test_name, parameters, input_type, test_main=False):
     from xcp_d import config
 
     parameters.append("--clean-workdir")
@@ -359,12 +365,35 @@ def _run_and_generate(test_name, parameters, input_type):
     parameters.append("--notrack")
     parameters.append("-vv")
 
-    argv = ["xcp-d"] + parameters
-    with patch.object(sys, "argv", argv):
-        with pytest.raises(SystemExit) as e:
-            run.main()
+    if test_main:
+        # This runs, but for some reason doesn't count toward coverage.
+        argv = ["xcp-d"] + parameters
+        with patch.object(sys, "argv", argv):
+            with pytest.raises(SystemExit) as e:
+                run.main()
 
-        assert e.value.code == 0
+            assert e.value.code == 0
+    else:
+        parse_args(parameters)
+        config_file = config.execution.work_dir / f"config-{config.execution.run_uuid}.toml"
+        config.loggers.cli.warning(f"Saving config file to {config_file}")
+        config.to_filename(config_file)
+
+        retval = build_workflow(config_file, retval={})
+        xcpd_wf = retval["workflow"]
+        xcpd_wf.run()
+        write_dataset_description(config.execution.fmri_dir, config.execution.xcp_d_dir)
+        if config.execution.atlases:
+            write_atlas_dataset_description(config.execution.xcp_d_dir / "atlases")
+
+        build_boilerplate(str(config_file), xcpd_wf)
+        generate_reports(
+            subject_list=config.execution.participant_label,
+            output_dir=config.execution.xcp_d_dir,
+            run_uuid=config.execution.run_uuid,
+            config=str(load_data("reports-spec.yml")),
+            packagename="xcp_d",
+        )
 
     output_list_file = os.path.join(get_test_data_path(), f"{test_name}_outputs.txt")
     check_generated_files(config.execution.xcp_d_dir, output_list_file)

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -361,7 +361,10 @@ def _run_and_generate(test_name, parameters, input_type):
 
     argv = ["xcp-d"] + parameters
     with patch.object(sys, "argv", argv):
-        run.main()
+        with pytest.raises(SystemExit) as e:
+            run.main()
+
+        assert e.value.code == 0
 
     output_list_file = os.path.join(get_test_data_path(), f"{test_name}_outputs.txt")
     check_generated_files(config.execution.xcp_d_dir, output_list_file)

--- a/xcp_d/utils/debug.py
+++ b/xcp_d/utils/debug.py
@@ -22,7 +22,8 @@
 #
 # STATEMENT OF CHANGES: This file is derived from sources licensed under the Apache-2.0 terms,
 # and uses the following portion of the original code:
-# https://github.com/dandi/dandi-cli/blob/da3b7a726c4a352dfb53a0c6bee59e660de827e6/dandi/utils.py#L49-L82
+# https://github.com/dandi/dandi-cli/blob/da3b7a726c4a352dfb53a0c6bee59e660de827e6/dandi/\
+# utils.py#L49-L82
 #
 #
 # ORIGINAL WORK'S ATTRIBUTION NOTICE:
@@ -41,18 +42,20 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+"""Tools for debugging, from fMRIPrep."""
 import sys
 
 
 def is_interactive():
-    """Return True if all in/outs are tty"""
+    """Return True if all in/outs are tty."""
     # TODO: check on windows if hasattr check would work correctly and add value:
     #
     return sys.stdin.isatty() and sys.stdout.isatty() and sys.stderr.isatty()
 
 
 def setup_exceptionhook(ipython=False):
-    """Overloads default sys.excepthook with our exceptionhook handler.
+    """Overload default sys.excepthook with our exceptionhook handler.
+
     If interactive, our exceptionhook handler will invoke
     pdb.post_mortem; if not interactive, then invokes default handler.
     """

--- a/xcp_d/utils/debug.py
+++ b/xcp_d/utils/debug.py
@@ -1,0 +1,79 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+# STATEMENT OF CHANGES: This file is derived from sources licensed under the Apache-2.0 terms,
+# and uses the following portion of the original code:
+# https://github.com/dandi/dandi-cli/blob/da3b7a726c4a352dfb53a0c6bee59e660de827e6/dandi/utils.py#L49-L82
+#
+#
+# ORIGINAL WORK'S ATTRIBUTION NOTICE:
+#
+#    Copyright DANDI Client Developers
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+import sys
+
+
+def is_interactive():
+    """Return True if all in/outs are tty"""
+    # TODO: check on windows if hasattr check would work correctly and add value:
+    #
+    return sys.stdin.isatty() and sys.stdout.isatty() and sys.stderr.isatty()
+
+
+def setup_exceptionhook(ipython=False):
+    """Overloads default sys.excepthook with our exceptionhook handler.
+    If interactive, our exceptionhook handler will invoke
+    pdb.post_mortem; if not interactive, then invokes default handler.
+    """
+
+    def _pdb_excepthook(type, value, tb):
+        import traceback
+
+        traceback.print_exception(type, value, tb)
+        print()
+        if is_interactive():
+            import pdb
+
+            pdb.post_mortem(tb)
+
+    if ipython:
+        from IPython.core import ultratb
+
+        sys.excepthook = ultratb.FormattedTB(
+            mode="Verbose",
+            # color_scheme='Linux',
+            call_pdb=is_interactive(),
+        )
+    else:
+        sys.excepthook = _pdb_excepthook


### PR DESCRIPTION
Closes none, but addresses a bug reported by @erikglee when running XCP-D on CBRAIN.

## Changes proposed in this pull request

- Fix a bug in which I referenced an attribute of the Config object that doesn't exist. I copied the code from fMRIPrep without noticing the problem. The workflow still successfully ran, but the exit code was 1 (failure) instead of 0 (success) regardless.
- Improve integration tests by using `xcp_d.cli.run.main()` directly.