### PR TITLE
Update to new build image (v0.0.12)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 .dockersetup:
   &dockersetup
   docker:
-    - image: pennlinc/xcp_d_build:0.0.11
+    - image: pennlinc/xcp_d_build:unstable
   working_directory: /src/xcp_d
 
 runinstall:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 .dockersetup:
   &dockersetup
   docker:
-    - image: pennlinc/xcp_d_build:unstable
+    - image: pennlinc/xcp_d_build:0.0.12
   working_directory: /src/xcp_d
 
 runinstall:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pennlinc/xcp_d_build:unstable
+FROM pennlinc/xcp_d_build:0.0.12
 
 # Install xcp_d
 COPY . /src/xcp_d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pennlinc/xcp_d_build:0.0.11
+FROM pennlinc/xcp_d_build:unstable
 
 # Install xcp_d
 COPY . /src/xcp_d


### PR DESCRIPTION
Closes none, but addresses an odd behavior I'd been noticing where templateflow was downloading templates in my XCP-D runs. This was because the step in the build image where templates are precached was happening _before_ the home directory was redefined, so the ultimate templateflow directory was not where the templates had previously been downloaded!
