### PR TITLE
Drop concatenated rest-as-run section from executive summary

### DIFF
--- a/xcp_d/interfaces/concatenation.py
+++ b/xcp_d/interfaces/concatenation.py
@@ -150,7 +150,10 @@ class _FilterOutFailedRunsOutputSpec(TraitedSpec):
         desc="TSV files with filtered motion parameters, used for FD calculation.",
     )
     temporal_mask = traits.List(
-        File(exists=True),
+        traits.Either(
+            File(exists=True),
+            Undefined,
+        ),
         desc="TSV files with high-motion outliers indexed.",
     )
     denoised_interpolated_bold = traits.List(
@@ -262,8 +265,10 @@ class _ConcatenateInputsInputSpec(BaseInterfaceInputSpec):
         desc="TSV files with filtered motion parameters, used for FD calculation.",
     )
     temporal_mask = traits.List(
-        File(exists=True),
-        mandatory=True,
+        traits.Either(
+            File(exists=True),
+            Undefined,
+        ),
         desc="TSV files with high-motion outliers indexed.",
     )
     denoised_interpolated_bold = traits.List(
@@ -314,8 +319,9 @@ class _ConcatenateInputsOutputSpec(TraitedSpec):
         exists=True,
         desc="Concatenated TSV file with filtered motion parameters, used for FD calculation.",
     )
-    temporal_mask = File(
-        exists=True,
+    temporal_mask = traits.Either(
+        File(exists=True),
+        Undefined,
         desc="Concatenated TSV file with high-motion outliers indexed.",
     )
     denoised_interpolated_bold = File(
@@ -365,8 +371,8 @@ class ConcatenateInputs(SimpleInterface):
         }
 
         run_index, n_volumes = [], 0
-        for run_tmask in self.inputs.temporal_mask[:-1]:
-            n_volumes = n_volumes + pd.read_table(run_tmask).shape[0]
+        for run_motion in self.inputs.filtered_motion[:-1]:
+            n_volumes = n_volumes + pd.read_table(run_motion).shape[0]
             run_index.append(n_volumes)
 
         self._results["run_index"] = run_index

--- a/xcp_d/utils/plotting.py
+++ b/xcp_d/utils/plotting.py
@@ -550,7 +550,10 @@ def plot_fmri_es(
     )
 
     fd_regressor = pd.read_table(filtered_motion)["framewise_displacement"].values
-    tmask_arr = pd.read_table(temporal_mask)["framewise_displacement"].values.astype(bool)
+    if temporal_mask:
+        tmask_arr = pd.read_table(temporal_mask)["framewise_displacement"].values.astype(bool)
+    else:
+        tmask_arr = np.zeros(fd_regressor.shape, dtype=bool)
 
     # The mean and standard deviation of the preprocessed data,
     # after mean-centering and detrending.

--- a/xcp_d/workflows/concatenation.py
+++ b/xcp_d/workflows/concatenation.py
@@ -323,7 +323,7 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
             ]),
         ])  # fmt:skip
 
-    if dcan_qc:
+    if dcan_qc and (fd_thresh > 0):
         workflow.connect([
             (clean_name_source, ds_interpolated_filtered_bold, [("name_source", "source_file")]),
             (concatenate_inputs, ds_interpolated_filtered_bold, [

--- a/xcp_d/workflows/concatenation.py
+++ b/xcp_d/workflows/concatenation.py
@@ -203,25 +203,26 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
         ]),
     ])  # fmt:skip
 
-    ds_temporal_mask = pe.Node(
-        DerivativesDataSink(
-            base_directory=output_dir,
-            dismiss_entities=["segmentation", "den", "res", "space", "cohort", "desc"],
-            suffix="outliers",
-            extension=".tsv",
-        ),
-        name="ds_temporal_mask",
-        run_without_submitting=True,
-        mem_gb=1,
-    )
+    if fd_thresh > 0:
+        ds_temporal_mask = pe.Node(
+            DerivativesDataSink(
+                base_directory=output_dir,
+                dismiss_entities=["segmentation", "den", "res", "space", "cohort", "desc"],
+                suffix="outliers",
+                extension=".tsv",
+            ),
+            name="ds_temporal_mask",
+            run_without_submitting=True,
+            mem_gb=1,
+        )
 
-    workflow.connect([
-        (clean_name_source, ds_temporal_mask, [("name_source", "source_file")]),
-        (concatenate_inputs, ds_temporal_mask, [("temporal_mask", "in_file")]),
-        (filter_runs, ds_temporal_mask, [
-            (("temporal_mask", _make_xcpd_uri, output_dir), "Sources"),
-        ]),
-    ])  # fmt:skip
+        workflow.connect([
+            (clean_name_source, ds_temporal_mask, [("name_source", "source_file")]),
+            (concatenate_inputs, ds_temporal_mask, [("temporal_mask", "in_file")]),
+            (filter_runs, ds_temporal_mask, [
+                (("temporal_mask", _make_xcpd_uri, output_dir), "Sources"),
+            ]),
+        ])  # fmt:skip
 
     if cifti:
         ds_censored_filtered_bold = pe.Node(


### PR DESCRIPTION
Closes none, but addresses the following issue identified by @kahinimehta. Basically, when there is a concatenated resting-state run, the executive summary shows it as a regular run in the run-wise BOLD section. However, the only figures available for the concatenated resting-state run (as opposed to a resting-state scan without a run entity) are the carpet plots.

![Screenshot 2024-04-25 at 8 07 20 PM](https://github.com/PennLINC/xcp_d/assets/8228902/b1bad498-4b1a-49fd-8105-59a0790976c8)

## Changes proposed in this pull request

- When compiling the list of files for the BOLD section of the executive summary, if there is a resting-state scan without run or direction entities (indicating that it may be concatenated), check if there are resting-state scans _with_ either run or direction. If there are, then drop the concatenated resting-state scan from the list of files.