### PR TITLE
Fix band-pass filter settings in Config

### DIFF
--- a/.versions.json
+++ b/.versions.json
@@ -27,7 +27,7 @@
 		"0.6.1": "Temporal filtering may have reintroduced variance from nuisance regression.",
 		"0.6.2": "Temporal filtering may have reintroduced variance from nuisance regression.",
 		"0.6.3": "Temporal filtering may have reintroduced variance from nuisance regression.",
-		"0.7.1": "Temporal filtering parameters not retained in workflow.",
-		"0.7.2": "Temporal filtering parameters not retained in workflow."
+		"0.7.1": "Band-pass filter parameters hardcoded to 0.01 - 0.1.",
+		"0.7.2": "Band-pass filter parameters hardcoded to 0.01 - 0.1."
 	}
 }

--- a/.versions.json
+++ b/.versions.json
@@ -26,6 +26,8 @@
 		"0.6.0": "Temporal filtering may have reintroduced variance from nuisance regression.",
 		"0.6.1": "Temporal filtering may have reintroduced variance from nuisance regression.",
 		"0.6.2": "Temporal filtering may have reintroduced variance from nuisance regression.",
-		"0.6.3": "Temporal filtering may have reintroduced variance from nuisance regression."
+		"0.6.3": "Temporal filtering may have reintroduced variance from nuisance regression.",
+		"0.7.1": "Temporal filtering parameters not retained in workflow.",
+		"0.7.2": "Temporal filtering parameters not retained in workflow."
 	}
 }

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -4,6 +4,8 @@
 
 This is a patch release fixing small bugs in 0.7.1.
 
+**There is a known bug with the band-pass filter settings in this release. Upper and lower band-pass values were hardcoded to 0.01 - 0.1.**
+
 ### 🎉 Exciting New Features
 
 * Make `GeneratedBy` in preprocessing derivatives' `dataset_description.json` optional by @tsalo in https://github.com/PennLINC/xcp_d/pull/1151
@@ -23,6 +25,8 @@ This is a patch release fixing small bugs in 0.7.1.
 ## 0.7.1
 
 This release prepares for the XCP-D manuscript.
+
+**There is a known bug with the band-pass filter settings in this release. Upper and lower band-pass values were hardcoded to 0.01 - 0.1.**
 
 ### 🛠 Breaking Changes
 
@@ -243,7 +247,6 @@ The 0.5.1 fixes some bugs for the XCP-D manuscript.
 ## 0.5.0
 
 The 0.5.0 release prepares for the XCP-D manuscript, so I plan to not introduce any backwards-incompatible changes between this release and 1.0.0 (the official paper release).
-<!-- Release notes generated using configuration in .github/release.yml at main -->
 
 ### 🛠 Breaking Changes
 

--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -462,6 +462,7 @@ The default is 240 (4 minutes).
         "--lower_bpf",
         action="store",
         default=0.01,
+        dest="high_pass",
         type=float,
         help=(
             "Lower cut-off frequency (Hz) for the Butterworth bandpass filter to be applied to "
@@ -474,6 +475,7 @@ The default is 240 (4 minutes).
         "--upper_bpf",
         action="store",
         default=0.08,
+        dest="low_pass",
         type=float,
         help=(
             "Upper cut-off frequency (Hz) for the Butterworth bandpass filter to be applied to "
@@ -878,17 +880,17 @@ def _validate_parameters(opts, build_log, parser):
         opts.custom_confounds = str(opts.custom_confounds.resolve())
 
     # Bandpass filter parameters
-    if opts.lower_bpf <= 0 and opts.upper_bpf <= 0:
+    if opts.high_pass <= 0 and opts.low_pass <= 0:
         opts.bandpass_filter = False
 
     if (
         opts.bandpass_filter
-        and (opts.lower_bpf >= opts.upper_bpf)
-        and (opts.lower_bpf > 0 and opts.upper_bpf > 0)
+        and (opts.high_pass >= opts.low_pass)
+        and (opts.high_pass > 0 and opts.low_pass > 0)
     ):
         parser.error(
-            f"'--lower-bpf' ({opts.lower_bpf}) must be lower than "
-            f"'--upper-bpf' ({opts.upper_bpf})."
+            f"'--lower-bpf' ({opts.high_pass}) must be lower than "
+            f"'--upper-bpf' ({opts.low_pass})."
         )
     elif not opts.bandpass_filter:
         build_log.warning("Bandpass filtering is disabled. ALFF outputs will not be generated.")

--- a/xcp_d/config.py
+++ b/xcp_d/config.py
@@ -524,15 +524,15 @@ class workflow(_Config):
 
     cifti = False
     """Postprocess CIFTI inputs instead of NIfTIs."""
-    dummy_scans = 0
+    dummy_scans = None
     """Number of label-control volume pairs to delete before CBF computation."""
-    input_type = "fmriprep"
+    input_type = None
     """Postprocessing pipeline type."""
     despike = False
     """Despike the BOLD data before postprocessing."""
-    params = "36P"
+    params = None
     """Nuisance regressors to include in the postprocessing."""
-    smoothing = 6
+    smoothing = None
     """Full-width at half-maximum (FWHM) of the smoothing kernel."""
     combineruns = False
     """Combine runs of the same task."""
@@ -542,23 +542,23 @@ class workflow(_Config):
     """Low cutoff frequency for the band-stop filter."""
     band_stop_max = None
     """High cutoff frequency for the band-stop filter."""
-    motion_filter_order = 4
+    motion_filter_order = None
     """Order of the filter to apply to the motion regressors."""
-    head_radius = 50
+    head_radius = None
     """Radius of the head in mm."""
-    fd_thresh = 0.3
+    fd_thresh = None
     """Framewise displacement threshold for censoring."""
-    min_time = 240
+    min_time = None
     """Post-scrubbing threshold to apply to individual runs in the dataset."""
     bandpass_filter = True
     """Apply a band-pass filter to the data."""
-    high_pass = 0.01
+    high_pass = None
     """Lower bound of the band-pass filter."""
-    low_pass = 0.1
+    low_pass = None
     """Upper bound of the band-pass filter."""
-    bpf_order = 2
+    bpf_order = None
     """Order of the band-pass filter."""
-    min_coverage = 0.5
+    min_coverage = None
     """Coverage threshold to apply to parcels in each atlas."""
     exact_time = []
     """Produce correlation matrices limited to each requested amount of time."""

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -29,8 +29,8 @@ def base_opts():
         "output_dir": Path("out"),
         "work_dir": Path("work"),
         "analysis_level": "participant",
-        "lower_bpf": 0.01,
-        "upper_bpf": 0.1,
+        "high_pass": 0.01,
+        "low_pass": 0.1,
         "bandpass_filter": True,
         "fd_thresh": 0.3,
         "min_time": 100,
@@ -62,8 +62,8 @@ def test_validate_parameters_04(base_opts, base_parser, caplog):
     assert opts.bandpass_filter is True
 
     # Disable bandpass_filter to False indirectly
-    opts.lower_bpf = -1
-    opts.upper_bpf = -1
+    opts.high_pass = -1
+    opts.low_pass = -1
 
     opts = parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)
 
@@ -76,8 +76,8 @@ def test_validate_parameters_05(base_opts, base_parser, capsys):
     opts = deepcopy(base_opts)
 
     # Set upper BPF below lower one
-    opts.lower_bpf = 0.01
-    opts.upper_bpf = 0.001
+    opts.high_pass = 0.01
+    opts.low_pass = 0.001
 
     with pytest.raises(SystemExit, match="2"):
         parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)


### PR DESCRIPTION
Closes #1171.

## Changes proposed in this pull request

- Set destination variables for `--upper-bpf` and `--lower-bpf` parameters so that they are passed along to the Config object as `low_pass` and `high_pass`, respectively.
- Flag versions 0.7.1 and 0.7.2 in the version log, as the bandpass filter parameters selected by the user were not respected in those versions.
- Set default values in the Config object to None when feasible, in order to more readily identify bugs like this in the future.
