### PR TITLE
Add 0.7.3 to changelog and note filtering bug

### DIFF
--- a/.versions.json
+++ b/.versions.json
@@ -28,6 +28,7 @@
 		"0.6.2": "Temporal filtering may have reintroduced variance from nuisance regression.",
 		"0.6.3": "Temporal filtering may have reintroduced variance from nuisance regression.",
 		"0.7.1": "Band-pass filter parameters hardcoded to 0.01 - 0.1.",
-		"0.7.2": "Band-pass filter parameters hardcoded to 0.01 - 0.1."
+		"0.7.2": "Band-pass filter parameters hardcoded to 0.01 - 0.1.",
+		"0.7.3": "Band-pass filter parameters hardcoded to 0.01 - 0.1."
 	}
 }

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,5 +1,20 @@
 # What's New
 
+## 0.7.3
+
+Small patch release for manuscript's executive summary.
+
+**There is a known bug with the band-pass filter settings in this release. Upper and lower band-pass values were hardcoded to 0.01 - 0.1.**
+
+## What's Changed
+
+### 🐛 Bug Fixes
+
+* Drop concatenated rest-as-run section from executive summary by @tsalo in https://github.com/PennLINC/xcp_d/pull/1156
+
+**Full Changelog**: https://github.com/PennLINC/xcp_d/compare/0.7.2...0.7.3
+
+
 ## 0.7.2
 
 This is a patch release fixing small bugs in 0.7.1.


### PR DESCRIPTION
Closes none, but is related to #1171.

## Changes proposed in this pull request

- Add 0.7.3 to the notes from #1172.