### PR TITLE
Allow ALFF to work with low-pass or high-pass filters

### DIFF
--- a/xcp_d/utils/restingstate.py
+++ b/xcp_d/utils/restingstate.py
@@ -186,6 +186,14 @@ def compute_alff(data_matrix, low_pass, high_pass, TR, sample_mask=None):
         # square root of power spectrum
         power_spectrum_sqrt = np.sqrt(power_spectrum)
         # get the position of the arguments closest to high_pass and low_pass, respectively
+        if high_pass == 0:
+            # If high_pass is 0, then we set it to the minimum frequency
+            high_pass = frequencies_hz[0]
+
+        if low_pass == 0:
+            # If low_pass is 0, then we set it to the maximum frequency
+            low_pass = frequencies_hz[-1]
+
         ff_alff = [
             np.argmin(np.abs(frequencies_hz - high_pass)),
             np.argmin(np.abs(frequencies_hz - low_pass)),


### PR DESCRIPTION
Closes none. I noticed that the integration tests with low-pass set to 0 (pnc_cifti and ds001419_cifti) had ALFF maps/TSVs that were all NaNs.

## Changes proposed in this pull request

- Set high-pass and low-pass values to the frequency range's appropriate extrema if either is disabled (set to 0).