### PR TITLE
Fix ConnectPlot

### DIFF
--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -438,8 +438,8 @@ class ConnectPlot(SimpleInterface):
             ax_idx = list(range(ncols))
 
         fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=figsize)
-        if not isinstance(axes, list):
-            axes = [axes]
+        if isinstance(axes, plt.Axes):
+            axes = np.array([axes])
 
         for i_ax, atlas in enumerate(selected_atlases):
             atlas_idx = self.inputs.atlases.index(atlas)

--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -438,6 +438,9 @@ class ConnectPlot(SimpleInterface):
             ax_idx = list(range(ncols))
 
         fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=figsize)
+        if not isinstance(axes, list):
+            axes = [axes]
+
         for i_ax, atlas in enumerate(selected_atlases):
             atlas_idx = self.inputs.atlases.index(atlas)
             atlas_file = self.inputs.correlations_tsv[atlas_idx]

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -56,6 +56,8 @@ def test_ds001419_nifti(data_dir, output_dir, working_dir):
         "--skip-dcan-qc",
         "--random-seed=8675309",
         "--min-time=100",
+        "--atlases",
+        "4S156Parcels",
     ]
     _run_and_generate(
         test_name=test_name,

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -52,7 +52,6 @@ def test_ds001419_nifti(data_dir, output_dir, working_dir):
         "--smoothing=6",
         "--motion-filter-type=lp",
         "--band-stop-min=6",
-        "--skip-parcellation",
         "--skip-dcan-qc",
         "--random-seed=8675309",
         "--min-time=100",

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -52,11 +52,10 @@ def test_ds001419_nifti(data_dir, output_dir, working_dir):
         "--smoothing=6",
         "--motion-filter-type=lp",
         "--band-stop-min=6",
+        "--skip-parcellation",
         "--skip-dcan-qc",
         "--random-seed=8675309",
         "--min-time=100",
-        "--atlases",
-        "4S156Parcels",
     ]
     _run_and_generate(
         test_name=test_name,


### PR DESCRIPTION
Closes #1187.

## Changes proposed in this pull request

- In cases where only one atlas is requested, place the `Axes` object for `ConnectPlot` in a numpy array.
