### PR TITLE
Look for space entity in T2w-only anatomical inputs

### DIFF
--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -315,6 +315,9 @@ def collect_data(
         LOGGER.warning("T2w found, but no T1w. Enabling T2w-only processing.")
         queries["template_to_anat_xfm"]["to"] = "T2w"
         queries["anat_to_template_xfm"]["from"] = "T2w"
+        # Nibabies may include space-T2w for some derivatives
+        queries["anat_dseg"]["space"] = ["T2w", None]
+        queries["anat_brainmask"]["space"] = ["T2w", None]
 
     # Search for the files.
     subj_data = {


### PR DESCRIPTION
Closes #1199.

## Changes proposed in this pull request

- For T2w-only processing, look for anatomical inputs with either no space entity (current behavior) or space-T2w.
