### PR TITLE
Load spheres for anatomical workflow from TemplateFlow and BIDS derivatives

### DIFF
--- a/xcp_d/interfaces/bids.py
+++ b/xcp_d/interfaces/bids.py
@@ -172,18 +172,24 @@ class CollectRegistrationFiles(SimpleInterface):
 
             # TODO: Collect from templateflow once it's uploaded.
             # MCRIBS: tpl-fsaverage_hemi-?_den-41k_desc-reg_sphere.surf.gii
+            # What about tpl-fsaverage_hemi-L_den-41k_sphere.surf.gii from TemplateFlow?
             self._results["source_sphere"] = os.path.join(
                 self.inputs.segmentation_dir,
                 "templates_fsLR",
                 f"tpl-fsaverage_hemi-{hemisphere}_den-41k_desc-reg_sphere.surf.gii",
             )
 
-            # TODO: Collect from templateflow once it's uploaded.
             # MCRIBS: tpl-dHCP_space-fsaverage_hemi-?_den-41k_desc-reg_sphere.surf.gii
-            self._results["sphere_to_sphere"] = os.path.join(
-                self.inputs.segmentation_dir,
-                "templates_fsLR",
-                f"tpl-dHCP_space-fsaverage_hemi-{hemisphere}_den-41k_desc-reg_sphere.surf.gii",
+            self._results["sphere_to_sphere"] = str(
+                get_template(
+                    template="dhcpAsym",
+                    cohort="42",
+                    space="fsaverage",
+                    hemi=hemisphere,
+                    density="41k",
+                    desc="reg",
+                    suffix="sphere",
+                ),
             )
 
             # TODO: Collect from templateflow once it's uploaded.

--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -231,6 +231,7 @@ class _TSVConnectOutputSpec(TraitedSpec):
 def correlate_timeseries(timeseries, temporal_mask):
     """Correlate timeseries stored in a TSV file."""
     timeseries_df = pd.read_table(timeseries)
+    correlations_exact = {}
     if isdefined(temporal_mask):
         censoring_df = pd.read_table(temporal_mask)
 
@@ -243,7 +244,6 @@ def correlate_timeseries(timeseries, temporal_mask):
         censored_censoring_df = censoring_df.loc[censoring_df["framewise_displacement"] == 0]
         censored_censoring_df.reset_index(drop=True, inplace=True)
         exact_columns = [c for c in censoring_df.columns if c.startswith("exact_")]
-        correlations_exact = {}
         for exact_column in exact_columns:
             exact_timeseries_df = timeseries_df.loc[censored_censoring_df[exact_column] == 0]
             exact_correlations_df = exact_timeseries_df.corr()

--- a/xcp_d/tests/conftest.py
+++ b/xcp_d/tests/conftest.py
@@ -148,38 +148,44 @@ def pnc_data(datasets):
     )
     files["brain_mask_file"] = os.path.join(
         func_dir,
-        "sub-1648798153_task-rest_space-MNI152NLin2009cAsym_res-2_desc-brain_mask.nii.gz",
+        "sub-1648798153_ses-PNC1_task-rest_space-MNI152NLin2009cAsym_res-2_desc-brain_mask.nii.gz",
     )
     files["confounds_file"] = os.path.join(
         func_dir,
-        "sub-1648798153_task-rest_desc-confounds_timeseries.tsv",
+        "sub-1648798153_ses-PNC1_task-rest_desc-confounds_timeseries.tsv",
     )
     files["confounds_json"] = os.path.join(
         func_dir,
-        "sub-1648798153_task-rest_desc-confounds_timeseries.json",
+        "sub-1648798153_ses-PNC1_task-rest_desc-confounds_timeseries.json",
     )
     files["anat_to_template_xfm"] = os.path.join(
         anat_dir,
-        "sub-1648798153_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5",
+        "sub-1648798153_ses-PNC1_acq-refaced_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5",
     )
     files["template_to_anat_xfm"] = os.path.join(
         anat_dir,
-        "sub-1648798153_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5",
+        "sub-1648798153_ses-PNC1_acq-refaced_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5",
     )
     files["boldref"] = os.path.join(
         func_dir,
-        "sub-1648798153_task-rest_space-MNI152NLin2009cAsym_res-2_boldref.nii.gz",
+        "sub-1648798153_ses-PNC1_task-rest_space-MNI152NLin2009cAsym_res-2_boldref.nii.gz",
     )
     files["boldref_t1w"] = os.path.join(
         func_dir,
-        "sub-1648798153_task-rest_space-T1w_boldref.nii.gz",
+        "sub-1648798153_ses-PNC1_task-rest_space-T1w_boldref.nii.gz",
     )
-    files["t1w"] = os.path.join(anat_dir, "sub-1648798153_desc-preproc_T1w.nii.gz")
+    files["t1w"] = os.path.join(anat_dir, "sub-1648798153_acq-refaced_desc-preproc_T1w.nii.gz")
     files["t1w_mni"] = os.path.join(
         anat_dir,
-        "sub-1648798153_space-MNI152NLin2009cAsym_res-2_desc-preproc_T1w.nii.gz",
+        (
+            "sub-1648798153_ses-PNC1_acq-refaced_space-MNI152NLin2009cAsym_"
+            "res-2_desc-preproc_T1w.nii.gz"
+        ),
     )
-    files["anat_dseg"] = os.path.join(anat_dir, "sub-1648798153_desc-aseg_dseg.nii.gz")
+    files["anat_dseg"] = os.path.join(
+        anat_dir,
+        "sub-1648798153_ses-PNC1_acq-refaced_desc-aseg_dseg.nii.gz",
+    )
 
     return files
 

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -306,28 +306,6 @@ def test_get_tr(ds001419_data):
     assert t_r == 3.0
 
 
-def test_get_freesurfer_dir(datasets):
-    """Test get_freesurfer_dir."""
-    with pytest.raises(NotADirectoryError, match="No FreeSurfer/MCRIBS derivatives found"):
-        xbids.get_freesurfer_dir(".")
-
-    fs_dir, software = xbids.get_freesurfer_dir(datasets["nibabies"])
-    assert os.path.isdir(fs_dir)
-    assert software == "FreeSurfer"
-
-    # Create fake FreeSurfer folder so there are two possible folders and it grabs the closest
-    tmp_fs_dir = os.path.join(datasets["nibabies"], "sourcedata/mcribs")
-    os.makedirs(tmp_fs_dir, exist_ok=True)
-    fs_dir, software = xbids.get_freesurfer_dir(datasets["nibabies"])
-    assert os.path.isdir(fs_dir)
-    assert software == "MCRIBS"
-    os.rmdir(tmp_fs_dir)
-
-    fs_dir, software = xbids.get_freesurfer_dir(datasets["pnc"])
-    assert os.path.isdir(fs_dir)
-    assert software == "FreeSurfer"
-
-
 def test_get_entity(datasets):
     """Test get_entity."""
     fname = os.path.join(datasets["ds001419"], "sub-01", "anat", "sub-01_desc-preproc_T1w.nii.gz")

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -126,13 +126,13 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
     """Test collect_mesh_data."""
     # Dataset without mesh files
     layout = BIDSLayout(datasets["fmriprep_without_freesurfer"], validate=False)
-    mesh_available, standard_space_mesh, _ = xbids.collect_mesh_data(layout, "01")
+    mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(layout, "01")
     assert mesh_available is False
     assert standard_space_mesh is False
 
     # Dataset with native-space mesh files (one file matching each query)
     layout = BIDSLayout(datasets["ds001419"], validate=False)
-    mesh_available, standard_space_mesh, _ = xbids.collect_mesh_data(layout, "01")
+    mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(layout, "01")
     assert mesh_available is True
     assert standard_space_mesh is False
 
@@ -153,7 +153,7 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
         (std_mesh_dir / "sub-01/anat").joinpath(f).touch()
 
     layout = BIDSLayout(std_mesh_dir, validate=False)
-    mesh_available, standard_space_mesh, _ = xbids.collect_mesh_data(layout, "01")
+    mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(layout, "01")
     assert mesh_available is True
     assert standard_space_mesh is True
 

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -126,60 +126,60 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
     """Test collect_mesh_data."""
     # Dataset without mesh files
     layout = BIDSLayout(datasets["fmriprep_without_freesurfer"], validate=False)
-    mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(layout, "01")
+    mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(layout, "1648798153")
     assert mesh_available is False
     assert standard_space_mesh is False
 
     # Dataset with native-space mesh files (one file matching each query)
-    layout = BIDSLayout(datasets["ds001419"], validate=False)
-    mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(layout, "01")
+    layout = BIDSLayout(datasets["pnc"], validate=False)
+    mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(layout, "1648798153")
     assert mesh_available is True
     assert standard_space_mesh is False
 
     # Dataset with standard-space mesh files (one file matching each query)
     std_mesh_dir = tmp_path_factory.mktemp("standard_mesh")
     shutil.copyfile(
-        os.path.join(datasets["ds001419"], "dataset_description.json"),
+        os.path.join(datasets["pnc"], "dataset_description.json"),
         std_mesh_dir / "dataset_description.json",
     )
-    os.makedirs(std_mesh_dir / "sub-01/anat", exist_ok=True)
+    os.makedirs(std_mesh_dir / "sub-1648798153/ses-PNC1/anat", exist_ok=True)
     files = [
-        "sub-01_space-fsLR_den-32k_hemi-L_pial.surf.gii",
-        "sub-01_space-fsLR_den-32k_hemi-L_white.surf.gii",
-        "sub-01_space-fsLR_den-32k_hemi-R_pial.surf.gii",
-        "sub-01_space-fsLR_den-32k_hemi-R_white.surf.gii",
+        "sub-1648798153_ses-PNC1_space-fsLR_den-32k_hemi-L_pial.surf.gii",
+        "sub-1648798153_ses-PNC1_space-fsLR_den-32k_hemi-L_white.surf.gii",
+        "sub-1648798153_ses-PNC1_space-fsLR_den-32k_hemi-R_pial.surf.gii",
+        "sub-1648798153_ses-PNC1_space-fsLR_den-32k_hemi-R_white.surf.gii",
     ]
     for f in files:
-        (std_mesh_dir / "sub-01/anat").joinpath(f).touch()
+        (std_mesh_dir / "sub-1648798153/ses-PNC1/anat").joinpath(f).touch()
 
     layout = BIDSLayout(std_mesh_dir, validate=False)
-    mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(layout, "01")
+    mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(layout, "1648798153")
     assert mesh_available is True
     assert standard_space_mesh is True
 
     # Dataset with multiple files matching each query (raises an error)
     bad_mesh_dir = tmp_path_factory.mktemp("standard_mesh")
     shutil.copyfile(
-        os.path.join(datasets["ds001419"], "dataset_description.json"),
+        os.path.join(datasets["pnc"], "dataset_description.json"),
         bad_mesh_dir / "dataset_description.json",
     )
-    os.makedirs(bad_mesh_dir / "sub-01/anat", exist_ok=True)
+    os.makedirs(bad_mesh_dir / "sub-1648798153/ses-PNC1/anat", exist_ok=True)
     files = [
-        "sub-01_space-fsLR_den-32k_hemi-L_pial.surf.gii",
-        "sub-01_space-fsLR_den-32k_hemi-L_white.surf.gii",
-        "sub-01_space-fsLR_den-32k_hemi-R_pial.surf.gii",
-        "sub-01_space-fsLR_den-32k_hemi-R_white.surf.gii",
-        "sub-01_acq-test_space-fsLR_den-32k_hemi-L_pial.surf.gii",
-        "sub-01_acq-test_space-fsLR_den-32k_hemi-L_white.surf.gii",
-        "sub-01_acq-test_space-fsLR_den-32k_hemi-R_pial.surf.gii",
-        "sub-01_acq-test_space-fsLR_den-32k_hemi-R_white.surf.gii",
+        "sub-1648798153_ses-PNC1_space-fsLR_den-32k_hemi-L_pial.surf.gii",
+        "sub-1648798153_ses-PNC1_space-fsLR_den-32k_hemi-L_white.surf.gii",
+        "sub-1648798153_ses-PNC1_space-fsLR_den-32k_hemi-R_pial.surf.gii",
+        "sub-1648798153_ses-PNC1_space-fsLR_den-32k_hemi-R_white.surf.gii",
+        "sub-1648798153_ses-PNC1_acq-test_space-fsLR_den-32k_hemi-L_pial.surf.gii",
+        "sub-1648798153_ses-PNC1_acq-test_space-fsLR_den-32k_hemi-L_white.surf.gii",
+        "sub-1648798153_ses-PNC1_acq-test_space-fsLR_den-32k_hemi-R_pial.surf.gii",
+        "sub-1648798153_ses-PNC1_acq-test_space-fsLR_den-32k_hemi-R_white.surf.gii",
     ]
     for f in files:
-        (std_mesh_dir / "sub-01/anat").joinpath(f).touch()
+        (std_mesh_dir / "sub-1648798153/ses-PNC1/anat").joinpath(f).touch()
 
     layout = BIDSLayout(std_mesh_dir, validate=False)
     with pytest.raises(ValueError, match="More than one surface found"):
-        xbids.collect_mesh_data(layout, "01")
+        xbids.collect_mesh_data(layout, "1648798153")
 
 
 def test_write_dataset_description(datasets, tmp_path_factory, caplog):

--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -15,38 +15,48 @@ from xcp_d.workflows import anatomical
 def surface_files(datasets, tmp_path_factory):
     """Collect real and fake surface files to test the anatomical workflow."""
     tmpdir = tmp_path_factory.mktemp("surface_files")
-    anat_dir = os.path.join(datasets["ds001419"], "sub-01", "anat")
+    anat_dir = os.path.join(datasets["pnc"], "sub-1648798153", "ses-PNC1", "anat")
 
     files = {
-        "native_lh_pial": os.path.join(anat_dir, "sub-01_hemi-L_pial.surf.gii"),
-        "native_lh_wm": os.path.join(anat_dir, "sub-01_hemi-L_smoothwm.surf.gii"),
-        "native_rh_pial": os.path.join(anat_dir, "sub-01_hemi-R_pial.surf.gii"),
-        "native_rh_wm": os.path.join(anat_dir, "sub-01_hemi-R_smoothwm.surf.gii"),
+        "native_lh_pial": os.path.join(
+            anat_dir, "sub-1648798153_ses-PNC1_acq-refaced_hemi-L_pial.surf.gii"
+        ),
+        "native_lh_wm": os.path.join(
+            anat_dir, "sub-1648798153_ses-PNC1_acq-refaced_hemi-L_white.surf.gii"
+        ),
+        "native_rh_pial": os.path.join(
+            anat_dir, "sub-1648798153_ses-PNC1_acq-refaced_hemi-R_pial.surf.gii"
+        ),
+        "native_rh_wm": os.path.join(
+            anat_dir, "sub-1648798153_ses-PNC1_acq-refaced_hemi-R_white.surf.gii"
+        ),
     }
     final_files = files.copy()
     for fref, fpath in files.items():
         std_fref = fref.replace("native_", "fsLR_")
         std_fname = os.path.basename(fpath)
-        std_fname = std_fname.replace("sub-01_", "sub-01_space-fsLR_den-32k_")
+        std_fname = std_fname.replace(
+            "sub-1648798153_ses-PNC1_acq-refaced_",
+            "sub-1648798153_ses-PNC1_acq-refaced_space-fsLR_den-32k_",
+        )
         std_fpath = os.path.join(tmpdir, std_fname)
         shutil.copyfile(fpath, std_fpath)
         final_files[std_fref] = std_fpath
 
-    final_files["lh_surface_sphere"] = os.path.join(
+    final_files["lh_subject_sphere"] = os.path.join(
         anat_dir,
-        "sub-01_hemi-L_desc-reg_sphere.surf.gii",
+        "sub-1648798153_ses-PNC1_acq-refaced_hemi-L_desc-reg_sphere.surf.gii",
     )
-    final_files["rh_surface_sphere"] = os.path.join(
+    final_files["rh_subject_sphere"] = os.path.join(
         anat_dir,
-        "sub-01_hemi-R_desc-reg_sphere.surf.gii",
+        "sub-1648798153_ses-PNC1_acq-refaced_hemi-R_desc-reg_sphere.surf.gii",
     )
 
     return final_files
 
 
 def test_warp_surfaces_to_template_wf(
-    datasets,
-    ds001419_data,
+    pnc_data,
     surface_files,
     tmp_path_factory,
 ):
@@ -57,8 +67,8 @@ def test_warp_surfaces_to_template_wf(
     tmpdir = tmp_path_factory.mktemp("test_warp_surfaces_to_template_wf")
 
     wf = anatomical.init_warp_surfaces_to_template_wf(
-        fmri_dir=datasets["ds001419"],
         output_dir=tmpdir,
+        software="FreeSurfer",
         omp_nthreads=1,
     )
 
@@ -66,15 +76,17 @@ def test_warp_surfaces_to_template_wf(
     wf.inputs.inputnode.rh_pial_surf = surface_files["native_rh_pial"]
     wf.inputs.inputnode.lh_wm_surf = surface_files["native_lh_wm"]
     wf.inputs.inputnode.rh_wm_surf = surface_files["native_rh_wm"]
+    wf.inputs.inputnode.lh_subject_sphere = surface_files["lh_subject_sphere"]
+    wf.inputs.inputnode.rh_subject_sphere = surface_files["rh_subject_sphere"]
     # transforms (only used if warp_to_standard is True)
-    wf.inputs.inputnode.anat_to_template_xfm = ds001419_data["anat_to_template_xfm"]
-    wf.inputs.inputnode.template_to_anat_xfm = ds001419_data["template_to_anat_xfm"]
+    wf.inputs.inputnode.anat_to_template_xfm = pnc_data["anat_to_template_xfm"]
+    wf.inputs.inputnode.template_to_anat_xfm = pnc_data["template_to_anat_xfm"]
 
     wf.base_dir = tmpdir
     wf.run()
 
     # All of the possible fsLR surfaces should be available.
-    out_anat_dir = os.path.join(tmpdir, "sub-01", "anat")
+    out_anat_dir = os.path.join(tmpdir, "sub-1648798153", "ses-PNC1", "anat")
     for key, filename in surface_files.items():
         if "fsLR" in key:
             out_fname = os.path.basename(filename)

--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -32,6 +32,15 @@ def surface_files(datasets, tmp_path_factory):
         shutil.copyfile(fpath, std_fpath)
         final_files[std_fref] = std_fpath
 
+    final_files["lh_surface_sphere"] = os.path.join(
+        anat_dir,
+        "sub-01_hemi-L_desc-reg_sphere.surf.gii",
+    )
+    final_files["rh_surface_sphere"] = os.path.join(
+        anat_dir,
+        "sub-01_hemi-R_desc-reg_sphere.surf.gii",
+    )
+
     return final_files
 
 
@@ -47,11 +56,8 @@ def test_warp_surfaces_to_template_wf(
     """
     tmpdir = tmp_path_factory.mktemp("test_warp_surfaces_to_template_wf")
 
-    subject_id = "01"
-
     wf = anatomical.init_warp_surfaces_to_template_wf(
         fmri_dir=datasets["ds001419"],
-        subject_id=subject_id,
         output_dir=tmpdir,
         omp_nthreads=1,
     )

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -482,6 +482,8 @@ def collect_mesh_data(layout, participant_label):
         25,
         f"Collected mesh files:\n{yaml.dump(mesh_files, default_flow_style=False, indent=4)}",
     )
+    if mesh_available:
+        LOGGER.log(25, f"Assuming segmentation was performed with {software}.")
 
     return mesh_available, standard_space_mesh, software, mesh_files
 

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -372,6 +372,8 @@ def collect_mesh_data(layout, participant_label):
         True if surface mesh files (pial and smoothwm) were found. False if they were not.
     standard_space_mesh : :obj:`bool`
         True if standard-space (fsLR) surface mesh files were found. False if they were not.
+    software : {"MCRIBS", "FreeSurfer"}
+        The software used to generate the surfaces.
     mesh_files : :obj:`dict`
         Dictionary of surface file identifiers and their paths.
         If the surface files weren't found, then the paths will be Nones.
@@ -462,12 +464,26 @@ def collect_mesh_data(layout, participant_label):
     mesh_files["lh_subject_sphere"] = mesh_files.get("lh_subject_sphere", None)
     mesh_files["rh_subject_sphere"] = mesh_files.get("rh_subject_sphere", None)
 
+    # Check for *_space-dhcpAsym_desc-reg_sphere.surf.gii
+    # If we find it, we assume segmentation was done with MCRIBS. Otherwise, assume FreeSurfer.
+    dhcp_file = layout.get(
+        return_type="file",
+        datatype="anat",
+        subject=participant_label,
+        hemi="L",
+        space="dhcpAsym",
+        desc="reg",
+        suffix="sphere",
+        extension=".surf.gii",
+    )
+    software = "MCRIBS" if bool(len(dhcp_file)) else "FreeSurfer"
+
     LOGGER.log(
         25,
         f"Collected mesh files:\n{yaml.dump(mesh_files, default_flow_style=False, indent=4)}",
     )
 
-    return mesh_available, standard_space_mesh, mesh_files
+    return mesh_available, standard_space_mesh, software, mesh_files
 
 
 @fill_doc

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -318,7 +318,6 @@ def collect_data(
         queries["anat_to_template_xfm"]["from"] = "T2w"
         # Nibabies may include space-T2w for some derivatives
         queries["anat_dseg"]["space"] = ["T2w", None]
-        queries["anat_brainmask"]["space"] = ["T2w", None]
 
     # Search for the files.
     subj_data = {

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -1,7 +1,7 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Anatomical post-processing workflows."""
-from nipype import Function, logging
+from nipype import logging
 from nipype.interfaces import utility as niu
 from nipype.interfaces.ants import CompositeTransformUtil  # MB
 from nipype.interfaces.freesurfer import MRIsConvert
@@ -28,7 +28,6 @@ from xcp_d.interfaces.workbench import (  # MB,TM
     SurfaceGenerateInflated,
     SurfaceSphereProjectUnproject,
 )
-from xcp_d.utils.bids import get_segmentation_software
 from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.utils import list_to_str
 from xcp_d.workflows.execsummary import (

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -366,7 +366,6 @@ def init_postprocess_surfaces_wf(
     """
     workflow = Workflow(name=name)
 
-    fmri_dir = config.execution.fmri_dir
     abcc_qc = config.workflow.abcc_qc
     process_surfaces = config.workflow.process_surfaces
     output_dir = config.execution.xcp_d_dir
@@ -488,7 +487,6 @@ def init_postprocess_surfaces_wf(
         workflow.__desc__ += " fsnative-space surfaces were then warped to fsLR space."
         # Mesh files are in fsnative and must be warped to fsLR.
         warp_surfaces_to_template_wf = init_warp_surfaces_to_template_wf(
-            fmri_dir=fmri_dir,
             output_dir=output_dir,
             software=software,
             omp_nthreads=omp_nthreads,
@@ -536,7 +534,6 @@ def init_postprocess_surfaces_wf(
 
 @fill_doc
 def init_warp_surfaces_to_template_wf(
-    fmri_dir,
     output_dir,
     software,
     omp_nthreads,
@@ -552,7 +549,6 @@ def init_warp_surfaces_to_template_wf(
             from xcp_d.workflows.anatomical import init_warp_surfaces_to_template_wf
 
             wf = init_warp_surfaces_to_template_wf(
-                fmri_dir=".",
                 output_dir=".",
                 software="FreeSurfer",
                 omp_nthreads=1,
@@ -561,7 +557,6 @@ def init_warp_surfaces_to_template_wf(
 
     Parameters
     ----------
-    %(fmri_dir)s
     %(output_dir)s
     software : {"MCRIBS", "FreeSurfer"}
         The software used to generate the surfaces.

--- a/xcp_d/workflows/anatomical.py
+++ b/xcp_d/workflows/anatomical.py
@@ -287,7 +287,6 @@ resolution.
 
 @fill_doc
 def init_postprocess_surfaces_wf(
-    subject_id,
     mesh_available,
     standard_space_mesh,
     morphometry_files,
@@ -324,7 +323,6 @@ def init_postprocess_surfaces_wf(
 
             with mock_config():
                 wf = init_postprocess_surfaces_wf(
-                    subject_id="01",
                     mesh_available=True,
                     standard_space_mesh=False,
                     morphometry_files=[],
@@ -335,7 +333,6 @@ def init_postprocess_surfaces_wf(
 
     Parameters
     ----------
-    subject_id
     mesh_available : bool
     standard_space_mesh : bool
     morphometry_files : list of str
@@ -489,7 +486,6 @@ def init_postprocess_surfaces_wf(
         # Mesh files are in fsnative and must be warped to fsLR.
         warp_surfaces_to_template_wf = init_warp_surfaces_to_template_wf(
             fmri_dir=fmri_dir,
-            subject_id=subject_id,
             output_dir=output_dir,
             omp_nthreads=omp_nthreads,
             name="warp_surfaces_to_template_wf",
@@ -537,7 +533,6 @@ def init_postprocess_surfaces_wf(
 @fill_doc
 def init_warp_surfaces_to_template_wf(
     fmri_dir,
-    subject_id,
     output_dir,
     omp_nthreads,
     name="warp_surfaces_to_template_wf",
@@ -553,7 +548,6 @@ def init_warp_surfaces_to_template_wf(
 
             wf = init_warp_surfaces_to_template_wf(
                 fmri_dir=".",
-                subject_id="01",
                 output_dir=".",
                 omp_nthreads=1,
                 name="warp_surfaces_to_template_wf",
@@ -562,7 +556,6 @@ def init_warp_surfaces_to_template_wf(
     Parameters
     ----------
     %(fmri_dir)s
-    %(subject_id)s
     %(output_dir)s
     %(omp_nthreads)s
     %(name)s

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -135,7 +135,7 @@ def init_single_subject_wf(subject_id: str):
     t2w_available = subj_data["t2w"] is not None
     anat_mod = "t1w" if t1w_available else "t2w"
 
-    mesh_available, standard_space_mesh, mesh_files = collect_mesh_data(
+    mesh_available, standard_space_mesh, software, mesh_files = collect_mesh_data(
         layout=config.execution.layout,
         participant_label=subject_id,
     )
@@ -314,6 +314,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
             morphometry_files=morph_file_types,
             t1w_available=t1w_available,
             t2w_available=t2w_available,
+            software=software,
         )
 
         workflow.connect([

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -309,7 +309,6 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
         # Run surface post-processing workflow if we want to warp meshes to standard space *or*
         # generate brainsprite.
         postprocess_surfaces_wf = init_postprocess_surfaces_wf(
-            subject_id=subject_id,
             mesh_available=mesh_available,
             standard_space_mesh=standard_space_mesh,
             morphometry_files=morph_file_types,

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -167,6 +167,8 @@ def init_single_subject_wf(subject_id: str):
                 "rh_pial_surf",
                 "lh_wm_surf",
                 "rh_wm_surf",
+                "lh_subject_sphere",
+                "rh_subject_sphere",
                 # morphometry files
                 "sulcal_depth",
                 "sulcal_curv",
@@ -191,6 +193,8 @@ def init_single_subject_wf(subject_id: str):
     inputnode.inputs.rh_pial_surf = mesh_files["rh_pial_surf"]
     inputnode.inputs.lh_wm_surf = mesh_files["lh_wm_surf"]
     inputnode.inputs.rh_wm_surf = mesh_files["rh_wm_surf"]
+    inputnode.inputs.lh_subject_sphere = mesh_files["lh_subject_sphere"]
+    inputnode.inputs.rh_subject_sphere = mesh_files["rh_subject_sphere"]
 
     # optional surface shape files (used by surface-warping workflow)
     inputnode.inputs.sulcal_depth = morphometry_files["sulcal_depth"]
@@ -319,6 +323,8 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
                 ("rh_pial_surf", "inputnode.rh_pial_surf"),
                 ("lh_wm_surf", "inputnode.lh_wm_surf"),
                 ("rh_wm_surf", "inputnode.rh_wm_surf"),
+                ("lh_subject_sphere", "inputnode.lh_subject_sphere"),
+                ("rh_subject_sphere", "inputnode.rh_subject_sphere"),
                 ("anat_to_template_xfm", "inputnode.anat_to_template_xfm"),
                 ("template_to_anat_xfm", "inputnode.template_to_anat_xfm"),
             ]),


### PR DESCRIPTION
Closes none.

This is a breaking change for older versions of fMRIPrep and/or Nibabies, when the sphere file was not written out as a BIDS derivative.

## Changes proposed in this pull request

- Grab the subject's registration sphere from the BIDS derivatives instead of navigating Freesurfer and/or MCRIBS outputs.
- Use templateflow to grab other spheres necessary to warp mesh files to fsLR.