### PR TITLE
Allow `space-fsaverage` for sphere files

### DIFF
--- a/xcp_d/data/io_spec.yaml
+++ b/xcp_d/data/io_spec.yaml
@@ -60,13 +60,15 @@ queries:
             extension: .surf.gii
             hemi: L
             suffix: pial
-        # Subject's surface sphere to be used to warp fsnative meshes to fsLR space
+        # Subject's surface sphere to be used to warp fsnative meshes to fsaverage space
         lh_subject_sphere:
             datatype: anat
             desc: reg
             extension: .surf.gii
             hemi: L
-            space: null
+            space:
+            - null
+            - fsaverage
             suffix: sphere
         # White matter surface mesh in fsnative space (fsLR-space mesh will be searched for separately)
         lh_wm_surf:
@@ -84,13 +86,15 @@ queries:
             extension: .surf.gii
             hemi: R
             suffix: pial
-        # Subject's surface sphere to be used to warp fsnative meshes to fsLR space
+        # Subject's surface sphere to be used to warp fsnative meshes to fsaverage space
         rh_subject_sphere:
             datatype: anat
             desc: reg
             extension: .surf.gii
             hemi: R
-            space: null
+            space:
+            - null
+            - fsaverage
             suffix: sphere
         # White matter surface mesh in fsnative space (fsLR-space mesh will be searched for separately)
         rh_wm_surf:


### PR DESCRIPTION
Closes none, but relates to https://github.com/nipreps/fmriprep/commit/ea651967a9427d91124cd7b9238162b409935d4c, https://github.com/nipreps/smriprep/pull/446, and https://github.com/nipreps/nibabies/pull/368. This will probably take effect at Nibabies 24.0.0 and fMRIPrep 24.0.2.

## Changes proposed in this pull request

- Accept either no space entity (old/current versions for fMRIPrep and nibabies) or `space-fsaverage` (upcoming versions of fMRIPrep and nibabies) for surface spheres used in the anatomical workflow.