### PR TITLE
Enable linc-qc for abcd and hbcd modes by default

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -57,6 +57,7 @@ which may be overridden by the user:
 -  ``--despike``: Despiking is enabled by default.
 -  ``--fd-thresh 0``: Censoring is disabled by default.
 -  ``--input-type fmriprep``: fMRIPrep outputs are expected as input.
+-  ``--linc-qc``: The LINC QC file will be created by default.
 
 Optional Parameters
 -------------------
@@ -106,6 +107,7 @@ which may be overridden by the user:
 -  ``--input-type fmriprep``: fMRIPrep outputs are expected as input.
 -  ``--combine-runs``: Runs will be concatenated by default.
 -  ``--warp-surfaces-native2std``: Surfaces will be warped to standard space by default.
+-  ``--linc-qc``: The LINC QC file will be created by default.
 
 Required Parameters
 -------------------
@@ -126,8 +128,6 @@ Optional Parameters
    If you would like to create correlation matrices, you must include the ``--create-matrices`` flag.
    The ``--create-matrices`` parameter accepts lengths of time to use for the correlation matrices,
    as well as the special value "all", which uses all of the low-motion data from the run.
--  ``--linc-qc``: By default, XCP-D will not create the LINC QC file when run in the ``abcd`` mode.
-   If you would like to create these files, you must include the ``--linc-qc`` flag.
 
 
 hbcd Mode
@@ -158,6 +158,7 @@ which may be overridden by the user:
 -  ``--input-type nibabies``: Nibabies outputs are expected as input.
 -  ``--combine-runs``: Runs will be concatenated by default.
 -  ``--warp-surfaces-native2std``: Surfaces will be warped to standard space by default.
+-  ``--linc-qc``: The LINC QC file will be created by default.
 
 Required Parameters
 -------------------
@@ -178,8 +179,6 @@ Optional Parameters
    If you would like to create correlation matrices, you must include the ``--create-matrices`` flag.
    The ``--create-matrices`` parameter accepts lengths of time to use for the correlation matrices,
    as well as the special value "all", which uses all of the low-motion data from the run.
--  ``--linc-qc``: By default, XCP-D will not create the LINC QC file when run in the ``hbcd`` mode.
-   If you would like to create these files, you must include the ``--linc-qc`` flag.
 
 
 Major Differences Between Modes

--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -560,8 +560,11 @@ This option is only allowed for the "abcd" and "hbcd" modes.
     g_dcan.add_argument(
         "--linc-qc",
         "--linc_qc",
-        action="store_true",
+        nargs="?",
+        const=None,
         default="auto",
+        choices=["y", "n"],
+        action=parser_utils.YesNoAction,
         dest="linc_qc",
         help="""\
 Run LINC QC.
@@ -574,8 +577,11 @@ This will calculate QC metrics from the LINC pipeline.
     g_linc.add_argument(
         "--abcc-qc",
         "--abcc_qc",
-        action="store_true",
+        nargs="?",
+        const=None,
         default="auto",
+        choices=["y", "n"],
+        action=parser_utils.YesNoAction,
         dest="abcc_qc",
         help="""\
 Run ABCC QC.
@@ -931,7 +937,7 @@ def _validate_parameters(opts, build_log, parser):
 
     # Check parameters based on the mode
     if opts.mode == "abcd":
-        opts.abcc_qc = True
+        opts.abcc_qc = True if (opts.abcc_qc == "auto") else opts.abcc_qc
         opts.combine_runs = True if (opts.combine_runs == "auto") else opts.combine_runs
         opts.dcan_correlation_lengths = (
             [] if opts.dcan_correlation_lengths is None else opts.dcan_correlation_lengths
@@ -940,7 +946,7 @@ def _validate_parameters(opts, build_log, parser):
         opts.fd_thresh = 0.3 if (opts.fd_thresh == "auto") else opts.fd_thresh
         opts.file_format = "cifti" if (opts.file_format == "auto") else opts.file_format
         opts.input_type = "fmriprep" if opts.input_type == "auto" else opts.input_type
-        opts.linc_qc = False if (opts.linc_qc == "auto") else opts.linc_qc
+        opts.linc_qc = True if (opts.linc_qc == "auto") else opts.linc_qc
         if opts.motion_filter_type is None:
             error_messages.append(f"'--motion-filter-type' is required for '{opts.mode}' mode.")
         opts.output_correlations = True if "all" in opts.dcan_correlation_lengths else False
@@ -951,7 +957,7 @@ def _validate_parameters(opts, build_log, parser):
         # Remove "all" from the list of correlation lengths
         opts.dcan_correlation_lengths = [c for c in opts.dcan_correlation_lengths if c != "all"]
     elif opts.mode == "hbcd":
-        opts.abcc_qc = True
+        opts.abcc_qc = True if (opts.abcc_qc == "auto") else opts.abcc_qc
         opts.combine_runs = True if (opts.combine_runs == "auto") else opts.combine_runs
         opts.dcan_correlation_lengths = (
             [] if opts.dcan_correlation_lengths is None else opts.dcan_correlation_lengths
@@ -960,7 +966,7 @@ def _validate_parameters(opts, build_log, parser):
         opts.fd_thresh = 0.3 if (opts.fd_thresh == "auto") else opts.fd_thresh
         opts.file_format = "cifti" if (opts.file_format == "auto") else opts.file_format
         opts.input_type = "nibabies" if opts.input_type == "auto" else opts.input_type
-        opts.linc_qc = False if (opts.linc_qc == "auto") else opts.linc_qc
+        opts.linc_qc = True if (opts.linc_qc == "auto") else opts.linc_qc
         if opts.motion_filter_type is None:
             error_messages.append(f"'--motion-filter-type' is required for '{opts.mode}' mode.")
         opts.output_correlations = True if "all" in opts.dcan_correlation_lengths else False
@@ -977,7 +983,7 @@ def _validate_parameters(opts, build_log, parser):
         opts.fd_thresh = 0 if (opts.fd_thresh == "auto") else opts.fd_thresh
         opts.file_format = "nifti" if (opts.file_format == "auto") else opts.file_format
         opts.input_type = "fmriprep" if opts.input_type == "auto" else opts.input_type
-        opts.linc_qc = True
+        opts.linc_qc = True if (opts.linc_qc == "auto") else opts.linc_qc
         opts.output_correlations = True
         opts.output_interpolated = False
         opts.process_surfaces = False if opts.process_surfaces == "auto" else opts.process_surfaces

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -203,6 +203,7 @@ def test_pnc_cifti(data_dir, output_dir, working_dir):
         "300",
         "480",
         "all",
+        "--linc-qc=n",
     ]
     _run_and_generate(
         test_name=test_name,
@@ -258,6 +259,7 @@ def test_pnc_cifti_t2wonly(data_dir, output_dir, working_dir):
         "--despike=n",
         "--disable-bandpass-filter",
         "--create-matrices=all",
+        "--linc-qc=n",
     ]
     _run_and_generate(
         test_name=test_name,
@@ -431,6 +433,7 @@ def test_nibabies(data_dir, output_dir, working_dir):
         "--fd-thresh=0",
         "--create-matrices=all",
         "--motion-filter-type=none",
+        "--linc-qc=n",
     ]
     _run_and_generate(
         test_name=test_name,

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -297,7 +297,7 @@ def test_validate_parameters_abcd_mode(base_opts, base_parser, capsys):
     assert opts.fd_thresh == 0.3
     assert opts.file_format == "cifti"
     assert opts.input_type == "fmriprep"
-    assert opts.linc_qc is False
+    assert opts.linc_qc is True
     assert opts.output_correlations is False
     assert opts.process_surfaces is True
 
@@ -332,7 +332,7 @@ def test_validate_parameters_hbcd_mode(base_opts, base_parser, capsys):
     assert opts.fd_thresh == 0.3
     assert opts.file_format == "cifti"
     assert opts.input_type == "nibabies"
-    assert opts.linc_qc is False
+    assert opts.linc_qc is True
     assert opts.output_correlations is False
     assert opts.process_surfaces is True
 


### PR DESCRIPTION
Closes none, but addresses a request by Damien Fair.

## Changes proposed in this pull request

- Enable linc-qc for abcd and hbcd modes by default.
- Change `--linc-qc` and `--abcc-qc` to accept `y` or `n` as keywords.