### PR TITLE
Explicitly check for `-p none` and `--custom-confounds`

### DIFF
--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -1090,6 +1090,14 @@ def _validate_parameters(opts, build_log, parser):
             "you must enable cifti processing (--file-format cifti)."
         )
 
+    # Warn if the user combines custom confounds with the 'none' parameter set
+    if opts.params == "none" and opts.custom_confounds:
+        build_log.warning(
+            "Custom confounds were provided, but --nuisance-regressors was set to none. "
+            "Overriding the 'none' value and setting to 'custom'."
+        )
+        opts.params = "custom"
+
     if error_messages:
         error_message_str = "Errors detected in parameter parsing:\n\t- " + "\n\t- ".join(
             error_messages

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -127,8 +127,12 @@ def test_validate_parameters_06(base_opts, base_parser, capsys):
     assert "In order to perform surface normalization" in stderr
 
 
-def test_validate_parameters_07(base_opts, base_parser, caplog):
+def test_validate_parameters_07(base_opts, base_parser, caplog, tmp_path_factory):
     """Test parser._validate_parameters custom confounds + none."""
+    tmpdir = tmp_path_factory.mktemp("test_validate_parameters_07")
+    confounds_file = os.path.join(tmpdir, "confounds.tsv")
+    Path(confounds_file).touch()  # create the file
+
     opts = deepcopy(base_opts)
     opts.params = "none"
     opts.custom_confounds = "something.txt"

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -131,12 +131,12 @@ def test_validate_parameters_06(base_opts, base_parser, capsys):
 def test_validate_parameters_07(base_opts, base_parser, caplog, tmp_path_factory):
     """Test parser._validate_parameters custom confounds + none."""
     tmpdir = tmp_path_factory.mktemp("test_validate_parameters_07")
-    confounds_file = os.path.join(tmpdir, "confounds.tsv")
-    Path(confounds_file).touch()  # create the file
+    confounds_path = Path(os.path.join(tmpdir, "confounds.tsv"))
+    confounds_path.touch()  # create the file
 
     opts = deepcopy(base_opts)
     opts.params = "none"
-    opts.custom_confounds = "something.txt"
+    opts.custom_confounds = confounds_path
 
     opts = parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)
 

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -32,6 +32,7 @@ def base_opts():
         "mode": "linc",
         "file_format": "auto",
         "input_type": "auto",
+        "params": "36P",
         "high_pass": 0.01,
         "low_pass": 0.1,
         "bandpass_filter": True,

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -127,6 +127,18 @@ def test_validate_parameters_06(base_opts, base_parser, capsys):
     assert "In order to perform surface normalization" in stderr
 
 
+def test_validate_parameters_07(base_opts, base_parser, caplog):
+    """Test parser._validate_parameters custom confounds + none."""
+    opts = deepcopy(base_opts)
+    opts.params = "none"
+    opts.custom_confounds = "something.txt"
+
+    opts = parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)
+
+    assert opts.params == "custom"
+    assert "Overriding the 'none' value and setting to 'custom'" in caplog.text
+
+
 def test_validate_parameters_motion_filtering(base_opts, base_parser, caplog, capsys):
     """Test parser._validate_parameters."""
     opts = deepcopy(base_opts)


### PR DESCRIPTION
Closes none, but addresses an issue reported by @juliegrier. Basically, it's currently unclear how XCP-D works if users use `-p none` (no denoising) and `--custom-confounds` (external regressors to be used for denoising). Logically, it makes more sense to automatically change `-p` to `custom` in that scenario than to ignore `--custom-confounds`.

## Changes proposed in this pull request

- If nuisance regressors are set to `none`, but custom confounds are provided, then issue a warning and change the nuisance regressor option to `custom`.