### PR TITLE
Implement "none" mode

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -35,6 +35,9 @@ based on recommended processing pipelines for different studies.
 XCP-D can be run in one of three modes: ``linc``, ``abcd``, or ``hbcd``.
 Each mode is designed by a different group, and has different requirements.
 
+Users may also run XCP-D in ``none`` mode, in which case almost all of the parameters must be
+defined by the user.
+
 
 linc Mode
 =========

--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -1032,6 +1032,7 @@ def _validate_parameters(opts, build_log, parser):
 
         if opts.fd_thresh == "auto":
             error_messages.append("'--fd-thresh' is required for 'none' mode.")
+            opts.fd_thresh = 0  # just to satisfy later checks, not to actually use
 
         if opts.file_format == "auto":
             error_messages.append("'--file-format' is required for 'none' mode.")

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -43,7 +43,7 @@ def test_ds001419_nifti(data_dir, output_dir, working_dir):
         dataset_dir,
         out_dir,
         "participant",
-        "--mode=linc",
+        "--mode=none",
         f"-w={work_dir}",
         f"--bids-filter-file={filter_file}",
         "--nuisance-regressors=aroma_gsr",
@@ -55,6 +55,10 @@ def test_ds001419_nifti(data_dir, output_dir, working_dir):
         "--skip-parcellation",
         "--min-time=100",
         "--combine-runs",
+        "--output-type=censored",
+        "--combine-runs=n",
+        "--linc-qc=y",
+        "--abcc-qc=n",
     ]
     _run_and_generate(
         test_name=test_name,

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -56,7 +56,7 @@ def test_ds001419_nifti(data_dir, output_dir, working_dir):
         "--min-time=100",
         "--combine-runs",
         "--output-type=censored",
-        "--combine-runs=n",
+        "--combine-runs=y",
         "--linc-qc=y",
         "--abcc-qc=n",
         "--despike=n",

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -59,6 +59,10 @@ def test_ds001419_nifti(data_dir, output_dir, working_dir):
         "--combine-runs=n",
         "--linc-qc=y",
         "--abcc-qc=n",
+        "--despike=n",
+        "--file-format=nifti",
+        "--input-type=fmriprep",
+        "--warp-surfaces-native2std=n",
     ]
     _run_and_generate(
         test_name=test_name,

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -397,8 +397,8 @@ def test_validate_parameters_none_mode(base_opts, base_parser, capsys):
     opts.input_type = "fmriprep"
     opts.linc_qc = False
     opts.motion_filter_type = "none"
-    opts.nuisance_regressors = "36P"
     opts.output_type = "censored"
+    opts.params = "36P"
     opts.process_surfaces = False
     opts = parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)
 

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -388,14 +388,14 @@ def test_validate_parameters_none_mode(base_opts, base_parser, capsys):
     assert "'--nuisance-regressors' is required for 'none' mode." in stderr
     assert "'--warp-surfaces-native2std' (y or n) is required for 'none' mode." in stderr
 
-    opts.abcc_qc = "n"
-    opts.combine_runs = "n"
-    opts.despike = "n"
+    opts.abcc_qc = False
+    opts.combine_runs = False
+    opts.despike = False
     opts.fd_thresh = 0
     opts.file_format = "nifti"
     opts.input_type = "fmriprep"
-    opts.linc_qc = "n"
-    opts.motion_filter_type = "none"
+    opts.linc_qc = False
+    opts.motion_filter_type = None
     opts = parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)
 
 

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -386,6 +386,7 @@ def test_validate_parameters_none_mode(base_opts, base_parser, capsys):
     assert "'--linc-qc' (y or n) is required for 'none' mode." in stderr
     assert "'--motion-filter-type' is required for 'none' mode." in stderr
     assert "'--nuisance-regressors' is required for 'none' mode." in stderr
+    assert "'--output-type' is required for 'none' mode." in stderr
     assert "'--warp-surfaces-native2std' (y or n) is required for 'none' mode." in stderr
 
     opts.abcc_qc = False
@@ -395,7 +396,10 @@ def test_validate_parameters_none_mode(base_opts, base_parser, capsys):
     opts.file_format = "nifti"
     opts.input_type = "fmriprep"
     opts.linc_qc = False
-    opts.motion_filter_type = None
+    opts.motion_filter_type = "none"
+    opts.nuisance_regressors = "36P"
+    opts.output_type = "censored"
+    opts.process_surfaces = False
     opts = parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)
 
 

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -367,24 +367,38 @@ def test_validate_parameters_hbcd_mode(base_opts, base_parser, capsys):
     assert "'--motion-filter-type' is required for" in stderr
 
 
-def test_validate_parameters_hbcd_mode(base_opts, base_parser, capsys):
-    """Test parser._validate_parameters with hbcd mode."""
+def test_validate_parameters_none_mode(base_opts, base_parser, capsys):
+    """Test parser._validate_parameters with none mode."""
     opts = deepcopy(base_opts)
     opts.mode = "none"
 
-    # hbcd mode does use abcc_qc but doesn't use linc_qc
+    with pytest.raises(SystemExit, match="2"):
+        parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)
+
+    stderr = capsys.readouterr().err
+    assert "'--abcc-qc' (y or n) is required for 'none' mode." in stderr
+    assert "'--combine-runs' (y or n) is required for 'none' mode." in stderr
+    assert "'--despike' (y or n) is required for 'none' mode." in stderr
+    assert "'--fd-thresh' is required for 'none' mode." in stderr
+    assert "'--file-format' is required for 'none' mode." in stderr
+    assert "'--input-type' is required for 'none' mode." in stderr
+    assert "'--linc-qc' (y or n) is required for 'none' mode." in stderr
+    assert "'--motion-filter-type' is required for 'none' mode." in stderr
+    assert "'--nuisance-regressors' is required for 'none' mode." in stderr
+    assert "'--warp-surfaces-native2std' (y or n) is required for 'none' mode." in stderr
+
     opts = parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)
 
-    assert opts.abcc_qc is True
-    assert opts.combine_runs is True
+    assert opts.abcc_qc == "auto"
+    assert opts.combine_runs == "auto"
     assert opts.dcan_correlation_lengths == []
-    assert opts.despike is True
-    assert opts.fd_thresh == 0.3
-    assert opts.file_format == "cifti"
-    assert opts.input_type == "nibabies"
-    assert opts.linc_qc is True
+    assert opts.despike == "auto"
+    assert opts.fd_thresh == "auto"
+    assert opts.file_format == "auto"
+    assert opts.input_type == "auto"
+    assert opts.linc_qc == "auto"
     assert opts.output_correlations is False
-    assert opts.process_surfaces is True
+    assert opts.process_surfaces == "auto"
 
     opts.dcan_correlation_lengths = ["300", "all"]
     opts = parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -387,31 +387,15 @@ def test_validate_parameters_none_mode(base_opts, base_parser, capsys):
     assert "'--nuisance-regressors' is required for 'none' mode." in stderr
     assert "'--warp-surfaces-native2std' (y or n) is required for 'none' mode." in stderr
 
+    opts.abcc_qc = "n"
+    opts.combine_runs = "n"
+    opts.despike = "n"
+    opts.fd_thresh = 0
+    opts.file_format = "nifti"
+    opts.input_type = "fmriprep"
+    opts.linc_qc = "n"
+    opts.motion_filter_type = "none"
     opts = parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)
-
-    assert opts.abcc_qc == "auto"
-    assert opts.combine_runs == "auto"
-    assert opts.dcan_correlation_lengths == []
-    assert opts.despike == "auto"
-    assert opts.fd_thresh == "auto"
-    assert opts.file_format == "auto"
-    assert opts.input_type == "auto"
-    assert opts.linc_qc == "auto"
-    assert opts.output_correlations is False
-    assert opts.process_surfaces == "auto"
-
-    opts.dcan_correlation_lengths = ["300", "all"]
-    opts = parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)
-    assert opts.dcan_correlation_lengths == ["300"]
-    assert opts.output_correlations is True
-
-    # --motion-filter-type is required
-    opts.motion_filter_type = None
-    with pytest.raises(SystemExit, match="2"):
-        parser._validate_parameters(deepcopy(opts), build_log, parser=base_parser)
-
-    stderr = capsys.readouterr().err
-    assert "'--motion-filter-type' is required for" in stderr
 
 
 def test_validate_parameters_other_mode(base_opts, base_parser, capsys):

--- a/xcp_d/tests/test_cli_run.py
+++ b/xcp_d/tests/test_cli_run.py
@@ -51,6 +51,7 @@ def base_opts():
         "abcc_qc": "auto",
         "linc_qc": "auto",
         "combine_runs": "auto",
+        "output_type": "auto",
     }
     opts = FakeOptions(**opts_dict)
     return opts


### PR DESCRIPTION
Closes #1227.

## Changes proposed in this pull request

- Create a "none" `--mode` option, in which all of the parameters that are automatically set by other modes must be defined manually.
- Add `--output-type` parameter to control whether denoised data and time series are written as censored or interpolated. This was previously automatically determined based on the mode, but with "none" mode users need to define it explicitly.
