### PR TITLE
Document the apptainer version requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ assignees: ''
 <!--Please fill in the following details-->
 - xcp_d version:
 - Docker version:
-- Singularity version:
+- Apptainer version:
 
 ### What were you trying to do?
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,10 +14,10 @@ There are two ways to install *XCP-D*:
 **********************
 Container Technologies
 **********************
-*XCP-D* is ideally run via a Docker or Singularity container. If you are running *XCP-D* locally,
+*XCP-D* is ideally run via a Docker or Apptainer container. If you are running *XCP-D* locally,
 we suggest Docker_.
 However, for security reasons, many :abbr:`HPCs (High-Performance Computing)` do not allow Docker
-containers, but do allow Singularity_ containers.
+containers, but do allow Apptainer_ containers.
 The improved security for multi-tenant systems comes at the price of some limitations and extra
 steps necessary for execution.
 
@@ -41,17 +41,15 @@ The image can also be found here: https://hub.docker.com/r/pennlinc/xcp_d
 or through a lightweight wrapper that was created for convenience.
 
 
-.. _installation_singularity:
+.. _installation_apptainer:
 
-Singularity Installation
+Apptainer Installation
 ========================
 
-**Singularity version >= 2.5**:
-If the version of Singularity installed on your :abbr:`HPC (High-Performance Computing)` system is
-modern enough, you can create a Singularity image directly on the system using the following
+You can create an Apptainer image directly on the system using the following
 command: ::
 
-    $ singularity build xcp_d-<version>.simg docker://pennlinc/xcp_d:<version>
+    $ apptainer build xcp_d-<version>.simg docker://pennlinc/xcp_d:<version>
 
 where ``<version>`` should be replaced with the desired version of *xcp-d* that you want to
 download.
@@ -65,7 +63,7 @@ Manually Prepared Environment (Python 3.10)
 .. warning::
 
    This method is not recommended! Please use container alternatives
-   in :ref:`run_docker`, and :ref:`run_singularity`.
+   in :ref:`run_docker`, and :ref:`run_apptainer`.
 
 XCP-D requires some `External Dependencies`_.
 These tools must be installed and their binaries available in the system's ``$PATH``.

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -14,7 +14,7 @@
 .. _`Docker`: https://docs.docker.com
 .. _`Docker installation`: https://docs.docker.com/install/
 .. _`Docker Hub`: https://hub.docker.com/r/pennlinc/xcp_d/tags
-.. _Singularity: https://sylabs.io/guides/3.5/user-guide/introduction.html
+.. _Apptainer: https://apptainer.org/
 .. _QSIPrep: https://qsiprep.readthedocs.io
 .. _ASLPrep: https://aslprep.readthedocs.io
 .. _fMRIPrep: https://fmriprep.org

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -233,7 +233,7 @@ A Docker container can be created using the following command:
       /fmriprep /out participant \
       --file-format cifti --despike --head_radius 40 -w /work --smoothing 6
 
-.. _run_singularity:
+.. _run_apptainer:
 
 Apptainer
 =========
@@ -242,20 +242,12 @@ If you are computing on an :abbr:`HPC (High-Performance Computing)`, we recommen
 Apptainer.
 See :ref:`installation_container_technologies` for installation instructions.
 
-.. warning::
-
-   XCP-D (and perhaps other Docker-based Apptainer images) may not work with
-   Apptainer <=2.4.
-   We strongly recommend using Apptainer 3+.
-   For more information, see `this xcp_d issue <https://github.com/PennLINC/xcp_d/issues/793>`_ and
-   `this Apptainer issue <https://github.com/apptainer/singularity/issues/884>`_.
-
 If the data to be preprocessed is also on the HPC or a personal computer, you are ready to run
 *xcp_d*.
 
 .. code-block:: bash
 
-    singularity run --cleanenv xcp_d.sif \
+    apptainer run --cleanenv xcp_d.sif \
         /dset/derivatives/fmriprep  \
         /dset/derivatives/xcp_d \
         --participant-label label
@@ -276,7 +268,7 @@ argument (``--home``) as follows:
 
 .. code-block:: bash
 
-    singularity run -B $HOME:/home/xcp \
+    apptainer run -B $HOME:/home/xcp \
         --home /home/xcp \
         --cleanenv xcp_d.simg \
         <xcp_d arguments>
@@ -403,7 +395,7 @@ for example, ``--nuisance-regressors 36P`` in the call.
 
 .. code-block:: bash
 
-   singularity run --cleanenv -B /my/project/directory:/mnt xcpabcd_latest.simg \
+   apptainer run --cleanenv -B /my/project/directory:/mnt xcpabcd_latest.simg \
       /mnt/input/fmriprep \
       /mnt/output/directory \
       participant \

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -142,7 +142,7 @@ def main():
         boiler_file = config.execution.xcp_d_dir / "logs" / "CITATION.md"
         if boiler_file.exists():
             if config.environment.exec_env in (
-                "singularity",
+                "apptainer",
                 "docker",
             ):
                 boiler_file = Path("<OUTPUT_PATH>") / boiler_file.relative_to(

--- a/xcp_d/config.py
+++ b/xcp_d/config.py
@@ -159,7 +159,7 @@ _exec_env = os.name
 _docker_ver = None
 # special variable set in the container
 if os.getenv("IS_DOCKER_8395080871"):
-    _exec_env = "singularity"
+    _exec_env = "apptainer"
     _cgroup = Path("/proc/1/cgroup")
     if _cgroup.exists() and "docker" in _cgroup.read_text():
         _docker_ver = os.getenv("DOCKER_VERSION_8395080871")


### PR DESCRIPTION
Closes #1230.

## Changes proposed in this pull request

- Finish replacing "Singularity" with "Apptainer" in documentation.
- Drop mention of Singularity version requirements because I don't think we have those same requirements for Apptainer.