### PR TITLE
Make collect_data work for T1w+T2w nibabies derivatives

### DIFF
--- a/xcp_d/data/io_spec.yaml
+++ b/xcp_d/data/io_spec.yaml
@@ -11,7 +11,10 @@ queries:
             datatype: anat
             desc: null
             extension: .nii.gz
-            space: null
+            space:
+            - T1w
+            - T2w
+            - null
             suffix: dseg
         # transform from native anatomical (T1w or T2w) space to same standard space as BOLD
         # "to" entity will be set later
@@ -33,7 +36,9 @@ queries:
             datatype: anat
             desc: preproc
             extension: .nii.gz
-            space: null
+            space:
+            - null
+            - T2w
             suffix: T1w
         # native T2w-space or T1w-space, preprocessed T2w file
         t2w:


### PR DESCRIPTION
Closes none, but addresses a bug reported by @erikglee.

Here's the issue: With T1w+T2w derivatives in Nibabies, the `anat_dseg` file may have `space-T2w` instead of no space entity like we expect. 

Fixing this led us down the rabbit hole, as the T1w and T2w produced by Nibabies are in different spaces (native T1w and native T2w, respectively). XCP-D assumes that they would be in the same space, so the same anatomical-to-template transform could be applied to both. Unfortunately, that's not the case with Nibabies derivatives. Also, there is no T1w-to-T2w transform that we could use to get them in the same space (not that I'd want to do that, since it would be an extra transform to apply).

The only things this should affect are the executive summary brainsprite and figures where templates are overlaid on top of the anatomical images.

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
