### PR TITLE
Account for floating point issues in ALFF time array creation

### DIFF
--- a/xcp_d/utils/restingstate.py
+++ b/xcp_d/utils/restingstate.py
@@ -162,7 +162,7 @@ def compute_alff(data_matrix, low_pass, high_pass, TR, sample_mask=None):
             voxel_data_censored -= np.mean(voxel_data_censored)
             voxel_data_censored /= np.std(voxel_data_censored)
 
-            time_arr = np.arange(0, n_volumes * TR, TR)
+            time_arr = np.arange(n_volumes) * TR
             assert sample_mask.size == time_arr.size, f"{sample_mask.size} != {time_arr.size}"
             time_arr = time_arr[sample_mask]
             frequencies_hz = np.linspace(0, 0.5 * fs, (n_volumes // 2) + 1)[1:]


### PR DESCRIPTION
Fixes a bug reported by @erikglee. Basically, `time_arr = np.arange(0, n_volumes * TR, TR)` and `time_arr = np.arange(n_volumes) * TR` _should_ produce the same array, but in some cases `n_volumes * TR` evaluates to `X.00000005` (or something similar), which trickes `np.arange` into putting another value in the array, making it longer than desired. I've switched to the latter approach, which shouldn't be susceptible to the same problem.
