### PR TITLE
Remove n_procs for nodes that do not use multiple cores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,9 +401,9 @@ jobs:
 
   pytests:
     <<: *dockersetup
-    resource_class: medium
+    resource_class: large
     environment:
-      CIRCLE_CPUS: 2
+      CIRCLE_CPUS: 4
     steps:
       - checkout
       - run:
@@ -427,7 +427,13 @@ jobs:
           name: Run pytest on the tests directory
           no_output_timeout: 1h
           command: |
-            pytest --cov-append --cov-report term-missing --cov=xcp_d --data_dir=/src/xcp_d/.circleci/data --output_dir=/src/xcp_d/.circleci/out --working_dir=/src/xcp_d/.circleci/work xcp_d
+            pytest \
+              -n ${CIRCLE_CPUS} \
+              --cov-append --cov-report term-missing --cov=xcp_d \
+              --data_dir=/src/xcp_d/.circleci/data \
+              --output_dir=/src/xcp_d/.circleci/out \
+              --working_dir=/src/xcp_d/.circleci/work \
+              xcp_d
             mkdir /src/coverage
             mv /src/xcp_d/.coverage /src/coverage/.coverage.pytests
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,8 +262,6 @@ jobs:
             - .coverage.ds001419_cifti
       - store_artifacts:
           path: /src/xcp_d/.circleci/out/test_ds001419_cifti/
-    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: large
 
   ukbiobank:
     <<: *dockersetup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
           paths:
             - /src/xcp_d/.circleci/data/ds001419-fmriprep
     # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
+    # Why do we need a big executor for this job?
     resource_class: large
 
   download_data_pnc:
@@ -128,6 +129,9 @@ jobs:
 
   nifti_without_freesurfer:
     <<: *dockersetup
+    resource_class: large
+    environment:
+      CIRCLE_CPUS: 4
     steps:
       - checkout
       - run:
@@ -159,6 +163,9 @@ jobs:
 
   nifti_without_freesurfer_with_main:
     <<: *dockersetup
+    resource_class: medium
+    environment:
+      CIRCLE_CPUS: 2
     steps:
       - checkout
       - run:
@@ -190,6 +197,9 @@ jobs:
 
   ds001419_nifti:
     <<: *dockersetup
+    resource_class: large
+    environment:
+      CIRCLE_CPUS: 4
     steps:
       - checkout
       - run:
@@ -218,11 +228,12 @@ jobs:
             - .coverage.ds001419_nifti
       - store_artifacts:
           path: /src/xcp_d/.circleci/out/test_ds001419_nifti/
-    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: large
 
   ds001419_cifti:
     <<: *dockersetup
+    resource_class: large
+    environment:
+      CIRCLE_CPUS: 4
     steps:
       - checkout
       - run:
@@ -256,6 +267,9 @@ jobs:
 
   ukbiobank:
     <<: *dockersetup
+    resource_class: medium
+    environment:
+      CIRCLE_CPUS: 2
     steps:
       - checkout
       - run:
@@ -287,6 +301,9 @@ jobs:
 
   nibabies:
     <<: *dockersetup
+    resource_class: medium
+    environment:
+      CIRCLE_CPUS: 2
     steps:
       - checkout
       - run:
@@ -318,6 +335,9 @@ jobs:
 
   pnc_cifti:
     <<: *dockersetup
+    resource_class: medium
+    environment:
+      CIRCLE_CPUS: 2
     steps:
       - checkout
       - run:
@@ -349,6 +369,9 @@ jobs:
 
   pnc_cifti_t2wonly:
     <<: *dockersetup
+    resource_class: medium
+    environment:
+      CIRCLE_CPUS: 2
     steps:
       - checkout
       - run:
@@ -380,6 +403,9 @@ jobs:
 
   pytests:
     <<: *dockersetup
+    resource_class: medium
+    environment:
+      CIRCLE_CPUS: 2
     steps:
       - checkout
       - run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ tests = [
     "pep8-naming",
     "pytest",
     "pytest-cov",
+    "pytest-xdist",
     "pytest-env",
 ]
 maint = [

--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -13,12 +13,38 @@ from nipype.interfaces.base import (
     isdefined,
     traits,
 )
-from nipype.interfaces.workbench.base import WBCommand
+from nipype.interfaces.workbench.base import WBCommand as WBCommandBase
 
 from xcp_d.utils.filemanip import fname_presuffix, split_filename
 from xcp_d.utils.write_save import get_cifti_intents
 
 iflogger = logging.getLogger("nipype.interface")
+
+
+class WBCommandInputSpec(CommandLineInputSpec):
+    num_threads = traits.Int(1, usedefault=True, nohash=True, desc="set number of threads")
+
+
+class WBCommand(WBCommandBase):
+
+    @property
+    def num_threads(self):
+        """Get number of threads."""
+        return self.inputs.num_threads
+
+    @num_threads.setter
+    def num_threads(self, value):
+        self.inputs.num_threads = value
+
+    def __init__(self, **inputs):
+        super().__init__(**inputs)
+
+        if hasattr(self.inputs, "num_threads"):
+            self.inputs.on_trait_change(self._nthreads_update, "num_threads")
+
+    def _nthreads_update(self):
+        """Update environment with new number of threads."""
+        self.inputs.environ["OMP_NUM_THREADS"] = "%d" % self.inputs.num_threads
 
 
 class _FixCiftiIntentInputSpec(BaseInterfaceInputSpec):
@@ -73,7 +99,7 @@ class FixCiftiIntent(SimpleInterface):
         return runtime
 
 
-class _ConvertAffineInputSpec(CommandLineInputSpec):
+class _ConvertAffineInputSpec(WBCommandInputSpec):
     """Input specification for ConvertAffine."""
 
     fromwhat = traits.Str(
@@ -82,7 +108,6 @@ class _ConvertAffineInputSpec(CommandLineInputSpec):
         position=0,
         desc="world, itk, or flirt",
     )
-
     in_file = File(
         exists=True,
         mandatory=True,
@@ -90,7 +115,6 @@ class _ConvertAffineInputSpec(CommandLineInputSpec):
         position=1,
         desc="The input file",
     )
-
     towhat = traits.Str(
         mandatory=True,
         argstr="-to-%s",
@@ -120,7 +144,7 @@ class ConvertAffine(WBCommand):
     _cmd = "wb_command -convert-affine"
 
 
-class _ApplyAffineInputSpec(CommandLineInputSpec):
+class _ApplyAffineInputSpec(WBCommandInputSpec):
     """Input specification for ApplyAffine."""
 
     in_file = File(
@@ -130,7 +154,6 @@ class _ApplyAffineInputSpec(CommandLineInputSpec):
         position=0,
         desc="The input file",
     )
-
     affine = File(
         exists=True,
         mandatory=True,
@@ -138,7 +161,6 @@ class _ApplyAffineInputSpec(CommandLineInputSpec):
         position=1,
         desc="The affine file",
     )
-
     out_file = File(
         argstr="%s",
         name_source="in_file",
@@ -181,7 +203,7 @@ class ApplyAffine(WBCommand):
     _cmd = "wb_command -surface-apply-affine"
 
 
-class _ApplyWarpfieldInputSpec(CommandLineInputSpec):
+class _ApplyWarpfieldInputSpec(WBCommandInputSpec):
     """Input specification for ApplyWarpfield."""
 
     in_file = File(
@@ -191,7 +213,6 @@ class _ApplyWarpfieldInputSpec(CommandLineInputSpec):
         position=0,
         desc="The input file",
     )
-
     warpfield = File(
         exists=True,
         mandatory=True,
@@ -199,7 +220,6 @@ class _ApplyWarpfieldInputSpec(CommandLineInputSpec):
         position=1,
         desc="The warpfield file",
     )
-
     out_file = File(
         argstr="%s",
         name_source="in_file",
@@ -207,7 +227,6 @@ class _ApplyWarpfieldInputSpec(CommandLineInputSpec):
         extensions=[".surf.gii", ".shape.gii"],
         position=2,
     )
-
     forward_warp = File(
         argstr="-fnirt %s",
         position=3,
@@ -248,7 +267,7 @@ class ApplyWarpfield(WBCommand):
     _cmd = "wb_command -surface-apply-warpfield"
 
 
-class _SurfaceSphereProjectUnprojectInputSpec(CommandLineInputSpec):
+class _SurfaceSphereProjectUnprojectInputSpec(WBCommandInputSpec):
     """Input specification for SurfaceSphereProjectUnproject."""
 
     in_file = File(
@@ -258,7 +277,6 @@ class _SurfaceSphereProjectUnprojectInputSpec(CommandLineInputSpec):
         position=0,
         desc="a sphere with the desired output mesh",
     )
-
     sphere_project_to = File(
         exists=True,
         mandatory=True,
@@ -266,7 +284,6 @@ class _SurfaceSphereProjectUnprojectInputSpec(CommandLineInputSpec):
         position=1,
         desc="a sphere that aligns with sphere-in",
     )
-
     sphere_unproject_from = File(
         exists=True,
         mandatory=True,
@@ -274,7 +291,6 @@ class _SurfaceSphereProjectUnprojectInputSpec(CommandLineInputSpec):
         position=2,
         desc="deformed to the desired output space",
     )
-
     out_file = File(
         name_source="in_file",
         name_template="%s_deformed.surf.gii",
@@ -342,7 +358,7 @@ class SurfaceSphereProjectUnproject(WBCommand):
     _cmd = "wb_command -surface-sphere-project-unproject"
 
 
-class _ChangeXfmTypeInputSpec(CommandLineInputSpec):
+class _ChangeXfmTypeInputSpec(WBCommandInputSpec):
     in_transform = File(exists=True, argstr="%s", mandatory=True, position=0)
 
 
@@ -371,7 +387,7 @@ class ChangeXfmType(SimpleInterface):
         return runtime
 
 
-class _SurfaceAverageInputSpec(CommandLineInputSpec):
+class _SurfaceAverageInputSpec(WBCommandInputSpec):
     """Input specification for SurfaceAverage."""
 
     surface_in1 = File(
@@ -381,7 +397,6 @@ class _SurfaceAverageInputSpec(CommandLineInputSpec):
         position=1,
         desc="specify a surface to include in the average",
     )
-
     surface_in2 = File(
         exists=True,
         mandatory=True,
@@ -389,7 +404,6 @@ class _SurfaceAverageInputSpec(CommandLineInputSpec):
         position=2,
         desc="specify a surface to include in the average",
     )
-
     out_file = File(
         name_source="surface_in1",
         keep_extension=False,
@@ -437,7 +451,7 @@ class SurfaceAverage(WBCommand):
     _cmd = "wb_command -surface-average"
 
 
-class _SurfaceGenerateInflatedInputSpec(CommandLineInputSpec):
+class _SurfaceGenerateInflatedInputSpec(WBCommandInputSpec):
     """Input specification for SurfaceGenerateInflated."""
 
     anatomical_surface_in = File(
@@ -447,7 +461,6 @@ class _SurfaceGenerateInflatedInputSpec(CommandLineInputSpec):
         position=0,
         desc="the anatomical surface",
     )
-
     inflated_out_file = File(
         name_source="anatomical_surface_in",
         keep_extension=False,
@@ -456,7 +469,6 @@ class _SurfaceGenerateInflatedInputSpec(CommandLineInputSpec):
         position=1,
         desc="output - the output inflated surface",
     )
-
     very_inflated_out_file = File(
         name_source="anatomical_surface_in",
         keep_extension=False,
@@ -465,7 +477,6 @@ class _SurfaceGenerateInflatedInputSpec(CommandLineInputSpec):
         position=2,
         desc="output - the output very inflated surface",
     )
-
     iterations_scale_value = traits.Float(
         mandatory=False,
         argstr="-iterations-scale %f",
@@ -506,7 +517,7 @@ class SurfaceGenerateInflated(WBCommand):
     _cmd = "wb_command -surface-generate-inflated"
 
 
-class _CiftiParcellateWorkbenchInputSpec(CommandLineInputSpec):
+class _CiftiParcellateWorkbenchInputSpec(WBCommandInputSpec):
     """Input specification for the CiftiParcellateWorkbench command."""
 
     in_file = File(
@@ -648,7 +659,7 @@ class CiftiParcellateWorkbench(WBCommand):
     _cmd = "wb_command -cifti-parcellate"
 
 
-class _CiftiSurfaceResampleInputSpec(CommandLineInputSpec):
+class _CiftiSurfaceResampleInputSpec(WBCommandInputSpec):
     """Input specification for the CiftiSurfaceResample command.
 
     Resamples a surface file, given two spherical surfaces that are in register.
@@ -669,14 +680,12 @@ class _CiftiSurfaceResampleInputSpec(CommandLineInputSpec):
         position=0,
         desc="the surface file to resample",
     )
-
     current_sphere = File(
         exists=True,
         position=1,
         argstr="%s",
         desc="a sphere surface with the mesh that the input surface is currently on",
     )
-
     new_sphere = File(
         exists=True,
         position=2,
@@ -726,7 +735,7 @@ class CiftiSurfaceResample(WBCommand):
     _cmd = "wb_command -surface-resample"
 
 
-class _CiftiSeparateMetricInputSpec(CommandLineInputSpec):
+class _CiftiSeparateMetricInputSpec(WBCommandInputSpec):
     """Input specification for the CiftiSeparateMetric command."""
 
     in_file = File(
@@ -791,7 +800,7 @@ class CiftiSeparateMetric(WBCommand):
     _cmd = "wb_command  -cifti-separate "
 
 
-class _CiftiSeparateVolumeAllInputSpec(CommandLineInputSpec):
+class _CiftiSeparateVolumeAllInputSpec(WBCommandInputSpec):
     """Input specification for the CiftiSeparateVolumeAll command."""
 
     in_file = File(
@@ -859,7 +868,7 @@ class CiftiSeparateVolumeAll(WBCommand):
     _cmd = "wb_command  -cifti-separate "
 
 
-class _CiftiCreateDenseScalarInputSpec(CommandLineInputSpec):
+class _CiftiCreateDenseScalarInputSpec(WBCommandInputSpec):
     """Input specification for the CiftiSeparateVolumeAll command."""
 
     out_file = File(
@@ -951,7 +960,7 @@ class CiftiCreateDenseScalar(WBCommand):
         return outputs
 
 
-class _ShowSceneInputSpec(CommandLineInputSpec):
+class _ShowSceneInputSpec(WBCommandInputSpec):
     scene_file = File(
         exists=True,
         mandatory=True,
@@ -1075,7 +1084,7 @@ class ShowScene(WBCommand):
         )
 
 
-class _CiftiConvertInputSpec(CommandLineInputSpec):
+class _CiftiConvertInputSpec(WBCommandInputSpec):
     """Input specification for the CiftiConvert command."""
 
     target = traits.Enum(
@@ -1157,7 +1166,7 @@ class CiftiConvert(WBCommand):
         return outputs
 
 
-class _CiftiCreateDenseFromTemplateInputSpec(CommandLineInputSpec):
+class _CiftiCreateDenseFromTemplateInputSpec(WBCommandInputSpec):
     """Input specification for the CiftiCreateDenseFromTemplate command."""
 
     template_cifti = File(
@@ -1276,7 +1285,7 @@ class CiftiCreateDenseFromTemplate(WBCommand):
         return outputs
 
 
-class _CiftiMathInputSpec(CommandLineInputSpec):
+class _CiftiMathInputSpec(WBCommandInputSpec):
     """Input specification for the CiftiMath command."""
 
     data = File(
@@ -1337,7 +1346,7 @@ class CiftiMath(WBCommand):
     _cmd = "wb_command -cifti-math"
 
 
-class _CiftiCorrelationInputSpec(CommandLineInputSpec):
+class _CiftiCorrelationInputSpec(WBCommandInputSpec):
     """Input specification for the CiftiCorrelation command."""
 
     in_file = File(
@@ -1382,3 +1391,149 @@ class CiftiCorrelation(WBCommand):
     input_spec = _CiftiCorrelationInputSpec
     output_spec = _CiftiCorrelationOutputSpec
     _cmd = "wb_command -cifti-correlation"
+
+
+class _CiftiSmoothInputSpec(WBCommandInputSpec):
+    in_file = File(
+        exists=True,
+        mandatory=True,
+        argstr="%s",
+        position=0,
+        desc="The input CIFTI file",
+    )
+    sigma_surf = traits.Float(
+        mandatory=True,
+        argstr="%s",
+        position=1,
+        desc="the sigma for the gaussian surface smoothing kernel, in mm",
+    )
+    sigma_vol = traits.Float(
+        mandatory=True,
+        argstr="%s",
+        position=2,
+        desc="the sigma for the gaussian volume smoothing kernel, in mm",
+    )
+    direction = traits.Enum(
+        "ROW",
+        "COLUMN",
+        mandatory=True,
+        argstr="%s",
+        position=3,
+        desc="which dimension to smooth along, ROW or COLUMN",
+    )
+    out_file = File(
+        name_source=["in_file"],
+        name_template="smoothed_%s.nii",
+        keep_extension=True,
+        argstr="%s",
+        position=4,
+        desc="The output CIFTI",
+    )
+    left_surf = File(
+        exists=True,
+        mandatory=True,
+        position=5,
+        argstr="-left-surface %s",
+        desc="Specify the left surface to use",
+    )
+    left_corrected_areas = File(
+        exists=True,
+        position=6,
+        argstr="-left-corrected-areas %s",
+        desc="vertex areas (as a metric) to use instead of computing them from "
+        "the left surface.",
+    )
+    right_surf = File(
+        exists=True,
+        mandatory=True,
+        position=7,
+        argstr="-right-surface %s",
+        desc="Specify the right surface to use",
+    )
+    right_corrected_areas = File(
+        exists=True,
+        position=8,
+        argstr="-right-corrected-areas %s",
+        desc="vertex areas (as a metric) to use instead of computing them from "
+        "the right surface",
+    )
+    cerebellum_surf = File(
+        exists=True,
+        position=9,
+        argstr="-cerebellum-surface %s",
+        desc="specify the cerebellum surface to use",
+    )
+    cerebellum_corrected_areas = File(
+        exists=True,
+        position=10,
+        requires=["cerebellum_surf"],
+        argstr="cerebellum-corrected-areas %s",
+        desc="vertex areas (as a metric) to use instead of computing them from "
+        "the cerebellum surface",
+    )
+    cifti_roi = File(
+        exists=True,
+        position=11,
+        argstr="-cifti-roi %s",
+        desc="CIFTI file for ROI smoothing",
+    )
+    fix_zeros_vol = traits.Bool(
+        position=12,
+        argstr="-fix-zeros-volume",
+        desc="treat values of zero in the volume as missing data",
+    )
+    fix_zeros_surf = traits.Bool(
+        position=13,
+        argstr="-fix-zeros-surface",
+        desc="treat values of zero on the surface as missing data",
+    )
+    merged_volume = traits.Bool(
+        position=14,
+        argstr="-merged-volume",
+        desc="smooth across subcortical structure boundaries",
+    )
+
+
+class _CiftiSmoothOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc="output CIFTI file")
+
+
+class CiftiSmooth(WBCommand):
+    """Smooth a CIFTI file.
+
+    The input cifti file must have a brain models mapping on the chosen
+    dimension, columns for .dtseries, and either for .dconn.  By default,
+    data in different structures is smoothed independently (i.e., "parcel
+    constrained" smoothing), so volume structures that touch do not smooth
+    across this boundary.  Specify ``merged_volume`` to ignore these
+    boundaries. Surface smoothing uses the ``GEO_GAUSS_AREA`` smoothing method.
+
+    The ``*_corrected_areas`` options are intended for when it is unavoidable
+    to smooth on group average surfaces, it is only an approximate correction
+    for the reduction of structure in a group average surface.  It is better
+    to smooth the data on individuals before averaging, when feasible.
+
+    The ``fix_zeros_*`` options will treat values of zero as lack of data, and
+    not use that value when generating the smoothed values, but will fill
+    zeros with extrapolated values.  The ROI should have a brain models
+    mapping along columns, exactly matching the mapping of the chosen
+    direction in the input file.  Data outside the ROI is ignored.
+
+    >>> from xcp_d.interfaces.workbench import CiftiSmooth
+    >>> smooth = CiftiSmooth()
+    >>> smooth.inputs.in_file = 'sub-01_task-rest.dtseries.nii'
+    >>> smooth.inputs.sigma_surf = 4
+    >>> smooth.inputs.sigma_vol = 4
+    >>> smooth.inputs.direction = 'COLUMN'
+    >>> smooth.inputs.right_surf = 'sub-01.R.midthickness.32k_fs_LR.surf.gii'
+    >>> smooth.inputs.left_surf = 'sub-01.L.midthickness.32k_fs_LR.surf.gii'
+    >>> smooth.cmdline
+    'wb_command -cifti-smoothing sub-01_task-rest.dtseries.nii 4.0 4.0 COLUMN \
+    smoothed_sub-01_task-rest.dtseries.nii \
+    -left-surface sub-01.L.midthickness.32k_fs_LR.surf.gii \
+    -right-surface sub-01.R.midthickness.32k_fs_LR.surf.gii'
+    """
+
+    input_spec = _CiftiSmoothInputSpec
+    output_spec = _CiftiSmoothOutputSpec
+    _cmd = "wb_command -cifti-smoothing"

--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -21,11 +21,15 @@ from xcp_d.utils.write_save import get_cifti_intents
 iflogger = logging.getLogger("nipype.interface")
 
 
-class WBCommandInputSpec(CommandLineInputSpec):
+class _WBCommandInputSpec(CommandLineInputSpec):
     num_threads = traits.Int(1, usedefault=True, nohash=True, desc="set number of threads")
 
 
 class WBCommand(WBCommandBase):
+    """A base interface for wb_command.
+
+    This inherits from Nipype's WBCommand interface, but adds a num_threads input.
+    """
 
     @property
     def num_threads(self):
@@ -44,7 +48,7 @@ class WBCommand(WBCommandBase):
 
     def _nthreads_update(self):
         """Update environment with new number of threads."""
-        self.inputs.environ["OMP_NUM_THREADS"] = "%d" % self.inputs.num_threads
+        self.inputs.environ["OMP_NUM_THREADS"] = str(self.inputs.num_threads)
 
 
 class _FixCiftiIntentInputSpec(BaseInterfaceInputSpec):
@@ -99,7 +103,7 @@ class FixCiftiIntent(SimpleInterface):
         return runtime
 
 
-class _ConvertAffineInputSpec(WBCommandInputSpec):
+class _ConvertAffineInputSpec(_WBCommandInputSpec):
     """Input specification for ConvertAffine."""
 
     fromwhat = traits.Str(
@@ -144,7 +148,7 @@ class ConvertAffine(WBCommand):
     _cmd = "wb_command -convert-affine"
 
 
-class _ApplyAffineInputSpec(WBCommandInputSpec):
+class _ApplyAffineInputSpec(_WBCommandInputSpec):
     """Input specification for ApplyAffine."""
 
     in_file = File(
@@ -203,7 +207,7 @@ class ApplyAffine(WBCommand):
     _cmd = "wb_command -surface-apply-affine"
 
 
-class _ApplyWarpfieldInputSpec(WBCommandInputSpec):
+class _ApplyWarpfieldInputSpec(_WBCommandInputSpec):
     """Input specification for ApplyWarpfield."""
 
     in_file = File(
@@ -267,7 +271,7 @@ class ApplyWarpfield(WBCommand):
     _cmd = "wb_command -surface-apply-warpfield"
 
 
-class _SurfaceSphereProjectUnprojectInputSpec(WBCommandInputSpec):
+class _SurfaceSphereProjectUnprojectInputSpec(_WBCommandInputSpec):
     """Input specification for SurfaceSphereProjectUnproject."""
 
     in_file = File(
@@ -358,7 +362,7 @@ class SurfaceSphereProjectUnproject(WBCommand):
     _cmd = "wb_command -surface-sphere-project-unproject"
 
 
-class _ChangeXfmTypeInputSpec(WBCommandInputSpec):
+class _ChangeXfmTypeInputSpec(_WBCommandInputSpec):
     in_transform = File(exists=True, argstr="%s", mandatory=True, position=0)
 
 
@@ -387,7 +391,7 @@ class ChangeXfmType(SimpleInterface):
         return runtime
 
 
-class _SurfaceAverageInputSpec(WBCommandInputSpec):
+class _SurfaceAverageInputSpec(_WBCommandInputSpec):
     """Input specification for SurfaceAverage."""
 
     surface_in1 = File(
@@ -451,7 +455,7 @@ class SurfaceAverage(WBCommand):
     _cmd = "wb_command -surface-average"
 
 
-class _SurfaceGenerateInflatedInputSpec(WBCommandInputSpec):
+class _SurfaceGenerateInflatedInputSpec(_WBCommandInputSpec):
     """Input specification for SurfaceGenerateInflated."""
 
     anatomical_surface_in = File(
@@ -517,7 +521,7 @@ class SurfaceGenerateInflated(WBCommand):
     _cmd = "wb_command -surface-generate-inflated"
 
 
-class _CiftiParcellateWorkbenchInputSpec(WBCommandInputSpec):
+class _CiftiParcellateWorkbenchInputSpec(_WBCommandInputSpec):
     """Input specification for the CiftiParcellateWorkbench command."""
 
     in_file = File(
@@ -659,7 +663,7 @@ class CiftiParcellateWorkbench(WBCommand):
     _cmd = "wb_command -cifti-parcellate"
 
 
-class _CiftiSurfaceResampleInputSpec(WBCommandInputSpec):
+class _CiftiSurfaceResampleInputSpec(_WBCommandInputSpec):
     """Input specification for the CiftiSurfaceResample command.
 
     Resamples a surface file, given two spherical surfaces that are in register.
@@ -735,7 +739,7 @@ class CiftiSurfaceResample(WBCommand):
     _cmd = "wb_command -surface-resample"
 
 
-class _CiftiSeparateMetricInputSpec(WBCommandInputSpec):
+class _CiftiSeparateMetricInputSpec(_WBCommandInputSpec):
     """Input specification for the CiftiSeparateMetric command."""
 
     in_file = File(
@@ -800,7 +804,7 @@ class CiftiSeparateMetric(WBCommand):
     _cmd = "wb_command  -cifti-separate "
 
 
-class _CiftiSeparateVolumeAllInputSpec(WBCommandInputSpec):
+class _CiftiSeparateVolumeAllInputSpec(_WBCommandInputSpec):
     """Input specification for the CiftiSeparateVolumeAll command."""
 
     in_file = File(
@@ -868,7 +872,7 @@ class CiftiSeparateVolumeAll(WBCommand):
     _cmd = "wb_command  -cifti-separate "
 
 
-class _CiftiCreateDenseScalarInputSpec(WBCommandInputSpec):
+class _CiftiCreateDenseScalarInputSpec(_WBCommandInputSpec):
     """Input specification for the CiftiSeparateVolumeAll command."""
 
     out_file = File(
@@ -960,7 +964,7 @@ class CiftiCreateDenseScalar(WBCommand):
         return outputs
 
 
-class _ShowSceneInputSpec(WBCommandInputSpec):
+class _ShowSceneInputSpec(_WBCommandInputSpec):
     scene_file = File(
         exists=True,
         mandatory=True,
@@ -1084,7 +1088,7 @@ class ShowScene(WBCommand):
         )
 
 
-class _CiftiConvertInputSpec(WBCommandInputSpec):
+class _CiftiConvertInputSpec(_WBCommandInputSpec):
     """Input specification for the CiftiConvert command."""
 
     target = traits.Enum(
@@ -1166,7 +1170,7 @@ class CiftiConvert(WBCommand):
         return outputs
 
 
-class _CiftiCreateDenseFromTemplateInputSpec(WBCommandInputSpec):
+class _CiftiCreateDenseFromTemplateInputSpec(_WBCommandInputSpec):
     """Input specification for the CiftiCreateDenseFromTemplate command."""
 
     template_cifti = File(
@@ -1285,7 +1289,7 @@ class CiftiCreateDenseFromTemplate(WBCommand):
         return outputs
 
 
-class _CiftiMathInputSpec(WBCommandInputSpec):
+class _CiftiMathInputSpec(_WBCommandInputSpec):
     """Input specification for the CiftiMath command."""
 
     data = File(
@@ -1346,7 +1350,7 @@ class CiftiMath(WBCommand):
     _cmd = "wb_command -cifti-math"
 
 
-class _CiftiCorrelationInputSpec(WBCommandInputSpec):
+class _CiftiCorrelationInputSpec(_WBCommandInputSpec):
     """Input specification for the CiftiCorrelation command."""
 
     in_file = File(
@@ -1393,7 +1397,7 @@ class CiftiCorrelation(WBCommand):
     _cmd = "wb_command -cifti-correlation"
 
 
-class _CiftiSmoothInputSpec(WBCommandInputSpec):
+class _CiftiSmoothInputSpec(_WBCommandInputSpec):
     in_file = File(
         exists=True,
         mandatory=True,

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -474,7 +474,7 @@ def _run_and_generate(test_name, parameters, input_type, test_main=False):
 
         retval = build_workflow(config_file, retval={})
         xcpd_wf = retval["workflow"]
-        xcpd_wf.run()
+        xcpd_wf.run(**config.nipype.get_plugin())
         write_dataset_description(config.execution.fmri_dir, config.execution.xcp_d_dir)
         if config.execution.atlases:
             write_atlas_dataset_description(config.execution.xcp_d_dir / "atlases")

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -451,7 +451,7 @@ def _run_and_generate(test_name, parameters, input_type, test_main=False):
     parameters.append("--clean-workdir")
     parameters.append("--stop-on-first-crash")
     parameters.append("--notrack")
-    parameters.append("-v")
+    parameters.append("-vv")
 
     # Add concurrency options if they're not already specified
     parameters = update_resources(parameters)

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -18,6 +18,7 @@ from xcp_d.tests.utils import (
     check_affines,
     check_generated_files,
     download_test_data,
+    update_resources,
     get_test_data_path,
     list_files,
 )
@@ -91,8 +92,6 @@ def test_ds001419_cifti(data_dir, output_dir, working_dir):
         "participant",
         "--mode=abcd",
         f"-w={work_dir}",
-        "--nthreads=2",
-        "--omp-nthreads=2",
         f"--bids-filter-file={filter_file}",
         "--nuisance-regressors=acompcor_gsr",
         "--warp_surfaces_native2std=n",
@@ -141,8 +140,6 @@ def test_ukbiobank(data_dir, output_dir, working_dir):
         "--warp-surfaces-native2std=n",
         "--combine-runs=n",
         f"-w={work_dir}",
-        "--nthreads=2",
-        "--omp-nthreads=2",
         "--input-type=ukb",
         "--nuisance-regressors=gsr_only",
         "--dummy-scans=4",
@@ -191,8 +188,6 @@ def test_pnc_cifti(data_dir, output_dir, working_dir):
         "participant",
         "--mode=abcd",
         f"-w={work_dir}",
-        "--nthreads=2",
-        "--omp-nthreads=2",
         f"--bids-filter-file={filter_file}",
         "--min-time=60",
         "--nuisance-regressors=acompcor_gsr",
@@ -251,8 +246,6 @@ def test_pnc_cifti_t2wonly(data_dir, output_dir, working_dir):
         "participant",
         "--mode=abcd",
         f"-w={work_dir}",
-        "--nthreads=2",
-        "--omp-nthreads=2",
         f"--bids-filter-file={filter_file}",
         "--nuisance-regressors=none",
         "--head_radius=40",
@@ -459,6 +452,9 @@ def _run_and_generate(test_name, parameters, input_type, test_main=False):
     parameters.append("--stop-on-first-crash")
     parameters.append("--notrack")
     parameters.append("-v")
+
+    # Add concurrency options if they're not already specified
+    parameters = update_resources(parameters)
 
     if test_main:
         # This runs, but for some reason doesn't count toward coverage.

--- a/xcp_d/tests/test_smoothing.py
+++ b/xcp_d/tests/test_smoothing.py
@@ -5,11 +5,11 @@ import re
 import tempfile
 
 import numpy as np
-from nipype.interfaces.workbench import CiftiSmooth
 from nipype.pipeline import engine as pe
 from templateflow.api import get as get_template
 
 from xcp_d.interfaces.nilearn import Smooth
+from xcp_d.interfaces.workbench import CiftiSmooth
 from xcp_d.utils.utils import fwhm2sigma
 
 

--- a/xcp_d/tests/test_smoothing.py
+++ b/xcp_d/tests/test_smoothing.py
@@ -123,8 +123,10 @@ def test_smoothing_cifti(ds001419_data, tmp_path_factory, sigma_lx=fwhm2sigma(6)
             direction="COLUMN",  # which direction to smooth along@
             right_surf=right_surf,
             left_surf=left_surf,
+            num_threads=1,
         ),
         name="cifti_smoothing",
+        n_procs=1,
     )
     smooth_data.inputs.in_file = in_file
     smooth_data.base_dir = tmpdir

--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -67,10 +67,7 @@ def test_warp_surfaces_to_template_wf(
     tmpdir = tmp_path_factory.mktemp("test_warp_surfaces_to_template_wf")
 
     with mock_config():
-        config.execution.xcp_d_dir = tmpdir
-        config.workflow.input_type = "fmriprep"
         config.nipype.omp_nthreads = 1
-        config.nipype.mem_gb = 0.1
 
         wf = anatomical.surface.init_warp_surfaces_to_template_wf(
             output_dir=tmpdir,

--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -66,24 +66,30 @@ def test_warp_surfaces_to_template_wf(
     """
     tmpdir = tmp_path_factory.mktemp("test_warp_surfaces_to_template_wf")
 
-    wf = anatomical.surface.init_warp_surfaces_to_template_wf(
-        output_dir=tmpdir,
-        software="FreeSurfer",
-        omp_nthreads=1,
-    )
+    with mock_config():
+        config.execution.xcp_d_dir = tmpdir
+        config.workflow.input_type = "fmriprep"
+        config.nipype.omp_nthreads = 1
+        config.nipype.mem_gb = 0.1
 
-    wf.inputs.inputnode.lh_pial_surf = surface_files["native_lh_pial"]
-    wf.inputs.inputnode.rh_pial_surf = surface_files["native_rh_pial"]
-    wf.inputs.inputnode.lh_wm_surf = surface_files["native_lh_wm"]
-    wf.inputs.inputnode.rh_wm_surf = surface_files["native_rh_wm"]
-    wf.inputs.inputnode.lh_subject_sphere = surface_files["lh_subject_sphere"]
-    wf.inputs.inputnode.rh_subject_sphere = surface_files["rh_subject_sphere"]
-    # transforms (only used if warp_to_standard is True)
-    wf.inputs.inputnode.anat_to_template_xfm = pnc_data["anat_to_template_xfm"]
-    wf.inputs.inputnode.template_to_anat_xfm = pnc_data["template_to_anat_xfm"]
+        wf = anatomical.surface.init_warp_surfaces_to_template_wf(
+            output_dir=tmpdir,
+            software="FreeSurfer",
+            omp_nthreads=1,
+        )
 
-    wf.base_dir = tmpdir
-    wf.run()
+        wf.inputs.inputnode.lh_pial_surf = surface_files["native_lh_pial"]
+        wf.inputs.inputnode.rh_pial_surf = surface_files["native_rh_pial"]
+        wf.inputs.inputnode.lh_wm_surf = surface_files["native_lh_wm"]
+        wf.inputs.inputnode.rh_wm_surf = surface_files["native_rh_wm"]
+        wf.inputs.inputnode.lh_subject_sphere = surface_files["lh_subject_sphere"]
+        wf.inputs.inputnode.rh_subject_sphere = surface_files["rh_subject_sphere"]
+        # transforms (only used if warp_to_standard is True)
+        wf.inputs.inputnode.anat_to_template_xfm = pnc_data["anat_to_template_xfm"]
+        wf.inputs.inputnode.template_to_anat_xfm = pnc_data["template_to_anat_xfm"]
+
+        wf.base_dir = tmpdir
+        wf.run()
 
     # All of the possible fsLR surfaces should be available.
     out_anat_dir = os.path.join(tmpdir, "sub-1648798153", "ses-PNC1", "anat")

--- a/xcp_d/workflows/anatomical/parcellation.py
+++ b/xcp_d/workflows/anatomical/parcellation.py
@@ -104,9 +104,13 @@ def init_parcellate_surfaces_wf(files_to_parcellate, name="parcellate_surfaces_w
 
     for file_to_parcellate in files_to_parcellate:
         resample_atlas_to_surface = pe.MapNode(
-            CiftiCreateDenseFromTemplate(out_file="resampled_atlas.dlabel.nii"),
+            CiftiCreateDenseFromTemplate(
+                out_file="resampled_atlas.dlabel.nii",
+                num_threads=config.nipype.omp_nthreads,
+            ),
             name=f"resample_atlas_to_{file_to_parcellate}",
             iterfield=["label"],
+            n_procs=config.nipype.omp_nthreads,
         )
         workflow.connect([
             (inputnode, resample_atlas_to_surface, [(file_to_parcellate, "template_cifti")]),

--- a/xcp_d/workflows/anatomical/plotting.py
+++ b/xcp_d/workflows/anatomical/plotting.py
@@ -150,10 +150,12 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
                 scene_name_or_number=1,
                 image_width=900,
                 image_height=800,
+                num_threads=config.nipype.omp_nthreads,
             ),
             name=f"create_framewise_pngs_{image_type}",
             iterfield=["scene_file"],
             mem_gb=1,
+            n_procs=config.nipype.omp_nthreads,
         )
         workflow.connect([
             (modify_brainsprite_template_scene, create_framewise_pngs, [

--- a/xcp_d/workflows/anatomical/plotting.py
+++ b/xcp_d/workflows/anatomical/plotting.py
@@ -68,7 +68,6 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
     workflow = Workflow(name=name)
 
     output_dir = config.execution.xcp_d_dir
-    omp_nthreads = config.nipype.omp_nthreads
 
     inputnode = pe.Node(
         niu.IdentityInterface(
@@ -108,7 +107,6 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
             ),
             name=f"get_number_of_frames_{image_type}",
             mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-            omp_nthreads=omp_nthreads,
         )
         workflow.connect([
             (inputnode, get_number_of_frames, [(inputnode_anat_name, "anat_file")]),
@@ -132,7 +130,6 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
             name=f"modify_brainsprite_template_scene_{image_type}",
             iterfield=["slice_number"],
             mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-            omp_nthreads=omp_nthreads,
         )
         modify_brainsprite_template_scene.inputs.scene_template = brainsprite_scene_template
         workflow.connect([
@@ -157,7 +154,6 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
             name=f"create_framewise_pngs_{image_type}",
             iterfield=["scene_file"],
             mem_gb=1,
-            omp_nthreads=omp_nthreads,
         )
         workflow.connect([
             (modify_brainsprite_template_scene, create_framewise_pngs, [
@@ -174,7 +170,6 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
             ),
             name=f"make_mosaic_{image_type}",
             mem_gb=1,
-            omp_nthreads=omp_nthreads,
         )
 
         workflow.connect([(create_framewise_pngs, make_mosaic_node, [("out_file", "png_files")])])
@@ -211,7 +206,6 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
             ),
             name=f"modify_pngs_template_scene_{image_type}",
             mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-            omp_nthreads=omp_nthreads,
         )
         modify_pngs_template_scene.inputs.scene_template = pngs_scene_template
         workflow.connect([
@@ -238,7 +232,6 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
             name=f"create_scenewise_pngs_{image_type}",
             iterfield=["scene_name_or_number"],
             mem_gb=1,
-            omp_nthreads=omp_nthreads,
         )
         workflow.connect([
             (modify_pngs_template_scene, create_scenewise_pngs, [("out_file", "scene_file")]),

--- a/xcp_d/workflows/anatomical/surface.py
+++ b/xcp_d/workflows/anatomical/surface.py
@@ -387,7 +387,6 @@ def init_warp_surfaces_to_template_wf(
     # First, we create the Connectome WorkBench-compatible transform files.
     update_xfm_wf = init_ants_xfm_to_fsl_wf(
         mem_gb=1,
-        omp_nthreads=omp_nthreads,
         name="update_xfm_wf",
     )
     workflow.connect([
@@ -611,7 +610,7 @@ def init_generate_hcp_surfaces_wf(name="generate_hcp_surfaces_wf"):
 
 
 @fill_doc
-def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
+def init_ants_xfm_to_fsl_wf(mem_gb, name="ants_xfm_to_fsl_wf"):
     """Modify ANTS-style fMRIPrep transforms to work with Connectome Workbench/FSL FNIRT.
 
     XXX: Does this only work if the template is MNI152NLin6Asym?
@@ -625,14 +624,12 @@ def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
 
             wf = init_ants_xfm_to_fsl_wf(
                 mem_gb=0.1,
-                omp_nthreads=1,
                 name="ants_xfm_to_fsl_wf",
             )
 
     Parameters
     ----------
     %(mem_gb)s
-    %(omp_nthreads)s
     %(name)s
         Default is "ants_xfm_to_fsl_wf".
 

--- a/xcp_d/workflows/anatomical/surface.py
+++ b/xcp_d/workflows/anatomical/surface.py
@@ -510,7 +510,6 @@ def init_generate_hcp_surfaces_wf(name="generate_hcp_surfaces_wf"):
     workflow = Workflow(name=name)
 
     output_dir = config.execution.xcp_d_dir
-    omp_nthreads = config.nipype.omp_nthreads
 
     inputnode = pe.Node(
         niu.IdentityInterface(
@@ -532,7 +531,6 @@ def init_generate_hcp_surfaces_wf(name="generate_hcp_surfaces_wf"):
         SurfaceAverage(),
         name="generate_midthickness",
         mem_gb=2,
-        n_procs=omp_nthreads,
     )
     workflow.connect([
         (inputnode, generate_midthickness, [
@@ -565,7 +563,6 @@ def init_generate_hcp_surfaces_wf(name="generate_hcp_surfaces_wf"):
     inflate_surface = pe.Node(
         SurfaceGenerateInflated(iterations_scale_value=0.75),
         mem_gb=2,
-        omp_nthreads=omp_nthreads,
         name="inflate_surface",
     )
     workflow.connect([
@@ -679,7 +676,6 @@ def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
         ),
         name="disassemble_h5",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     workflow.connect([(inputnode, disassemble_h5, [("anat_to_template_xfm", "in_file")])])
 
@@ -693,7 +689,6 @@ def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
         ),
         name="disassemble_h5_inv",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     workflow.connect([(inputnode, disassemble_h5_inv, [("template_to_anat_xfm", "in_file")])])
 
@@ -726,7 +721,6 @@ def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
         ),
         name="get_xyz_components",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     get_inv_xyz_components = pe.Node(
         C3d(
@@ -736,7 +730,6 @@ def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
         ),
         name="get_inv_xyz_components",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     workflow.connect([
         (disassemble_h5, get_xyz_components, [("displacement_field", "in_file")]),
@@ -748,13 +741,11 @@ def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
         niu.Select(index=[0]),
         name="select_x_component",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     select_inv_x_component = pe.Node(
         niu.Select(index=[0]),
         name="select_inv_x_component",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
 
     # Select y-component
@@ -762,13 +753,11 @@ def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
         niu.Select(index=[1]),
         name="select_y_component",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     select_inv_y_component = pe.Node(
         niu.Select(index=[1]),
         name="select_inv_y_component",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
 
     # Select z-component
@@ -776,13 +765,11 @@ def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
         niu.Select(index=[2]),
         name="select_z_component",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     select_inv_z_component = pe.Node(
         niu.Select(index=[2]),
         name="select_inv_z_component",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     workflow.connect([
         (get_xyz_components, select_x_component, [("out_files", "inlist")]),
@@ -800,13 +787,11 @@ def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
         BinaryMath(expression="img * -1"),
         name="reverse_y_component",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     reverse_inv_y_component = pe.Node(
         BinaryMath(expression="img * -1"),
         name="reverse_inv_y_component",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     workflow.connect([
         (select_y_component, reverse_y_component, [("out", "in_file")]),
@@ -818,13 +803,11 @@ def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
         niu.Merge(3),
         name="collect_new_components",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     collect_new_inv_components = pe.Node(
         niu.Merge(3),
         name="collect_new_inv_components",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     workflow.connect([
         (select_x_component, collect_new_components, [("out", "in1")]),
@@ -840,13 +823,11 @@ def init_ants_xfm_to_fsl_wf(mem_gb, omp_nthreads, name="ants_xfm_to_fsl_wf"):
         Merge(),
         name="remerge_warpfield",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     remerge_inv_warpfield = pe.Node(
         Merge(),
         name="remerge_inv_warpfield",
         mem_gb=mem_gb,
-        n_procs=omp_nthreads,
     )
     workflow.connect([
         (collect_new_components, remerge_warpfield, [("out", "in_files")]),

--- a/xcp_d/workflows/anatomical/volume.py
+++ b/xcp_d/workflows/anatomical/volume.py
@@ -78,7 +78,6 @@ def init_postprocess_anat_wf(
     workflow = Workflow(name=name)
     output_dir = config.execution.xcp_d_dir
     input_type = config.workflow.input_type
-    omp_nthreads = config.nipype.omp_nthreads
 
     inputnode = pe.Node(
         niu.IdentityInterface(
@@ -168,7 +167,6 @@ resolution.
                 ),
                 name="warp_t1w_to_template",
                 mem_gb=2,
-                n_procs=omp_nthreads,
             )
             workflow.connect([
                 (inputnode, warp_t1w_to_template, [
@@ -189,7 +187,6 @@ resolution.
                 ),
                 name="warp_t2w_to_template",
                 mem_gb=2,
-                n_procs=omp_nthreads,
             )
             workflow.connect([
                 (inputnode, warp_t2w_to_template, [

--- a/xcp_d/workflows/anatomical/volume.py
+++ b/xcp_d/workflows/anatomical/volume.py
@@ -160,13 +160,14 @@ resolution.
             # Warp the native T1w-space T1w, T1w segmentation, and T2w files to standard space.
             warp_t1w_to_template = pe.Node(
                 ApplyTransforms(
-                    num_threads=2,
                     interpolation="LanczosWindowedSinc",
                     input_image_type=3,
                     dimension=3,
+                    num_threads=config.nipype.omp_nthreads,
                 ),
                 name="warp_t1w_to_template",
                 mem_gb=2,
+                n_procs=config.nipype.omp_nthreads,
             )
             workflow.connect([
                 (inputnode, warp_t1w_to_template, [
@@ -180,13 +181,14 @@ resolution.
         if t2w_available:
             warp_t2w_to_template = pe.Node(
                 ApplyTransforms(
-                    num_threads=2,
                     interpolation="LanczosWindowedSinc",
                     input_image_type=3,
                     dimension=3,
+                    num_threads=config.nipype.omp_nthreads,
                 ),
                 name="warp_t2w_to_template",
                 mem_gb=2,
+                n_procs=config.nipype.omp_nthreads,
             )
             workflow.connect([
                 (inputnode, warp_t2w_to_template, [

--- a/xcp_d/workflows/bold/cifti.py
+++ b/xcp_d/workflows/bold/cifti.py
@@ -138,7 +138,6 @@ def init_postprocess_cifti_wf(
     dummy_scans = config.workflow.dummy_scans
     despike = config.workflow.despike
     atlases = config.execution.atlases
-    omp_nthreads = config.nipype.omp_nthreads
 
     TR = run_data["bold_metadata"]["RepetitionTime"]
 
@@ -217,7 +216,6 @@ the following post-processing was performed.
         ConvertTo32(),
         name="downcast_data",
         mem_gb=mem_gbx["timeseries"],
-        n_procs=omp_nthreads,
     )
 
     workflow.connect([

--- a/xcp_d/workflows/bold/connectivity.py
+++ b/xcp_d/workflows/bold/connectivity.py
@@ -420,9 +420,10 @@ or were set to zero (when the parcel had <{min_coverage * 100}% coverage).
     if config.workflow.output_correlations:
         # Correlate the parcellated data
         correlate_bold = pe.MapNode(
-            CiftiCorrelation(),
+            CiftiCorrelation(num_threads=config.nipype.omp_nthreads),
             name="correlate_bold",
             iterfield=["in_file"],
+            n_procs=config.nipype.omp_nthreads,
         )
         workflow.connect([
             (parcellated_bold_buffer, correlate_bold, [("parcellated_cifti", "in_file")]),

--- a/xcp_d/workflows/bold/metrics.py
+++ b/xcp_d/workflows/bold/metrics.py
@@ -145,7 +145,6 @@ series to retain the original scaling.
         ComputeALFF(TR=TR, low_pass=low_pass, high_pass=high_pass),
         mem_gb=mem_gb["resampled"],
         name="alff_compt",
-        n_procs=omp_nthreads,
     )
     workflow.connect([
         (inputnode, alff_compt, [
@@ -201,7 +200,6 @@ series to retain the original scaling.
             smooth_data = pe.Node(
                 Smooth(fwhm=smoothing),
                 name="niftismoothing",
-                n_procs=omp_nthreads,
             )
             workflow.connect([
                 (alff_compt, smooth_data, [("alff", "in_file")]),
@@ -241,7 +239,6 @@ series to retain the original scaling.
                 FixCiftiIntent(),
                 name="fix_cifti_intent",
                 mem_gb=mem_gb["resampled"],
-                n_procs=omp_nthreads,
             )
             workflow.connect([
                 (alff_compt, smooth_data, [("alff", "in_file")]),
@@ -330,19 +327,16 @@ For the subcortical, volumetric data, ReHo was computed with neighborhood voxels
         CiftiSeparateMetric(metric="CORTEX_LEFT", direction="COLUMN"),
         name="separate_lh",
         mem_gb=mem_gb["resampled"],
-        n_procs=omp_nthreads,
     )
     rh_surf = pe.Node(
         CiftiSeparateMetric(metric="CORTEX_RIGHT", direction="COLUMN"),
         name="separate_rh",
         mem_gb=mem_gb["resampled"],
-        n_procs=omp_nthreads,
     )
     subcortical_nifti = pe.Node(
         CiftiSeparateVolumeAll(direction="COLUMN"),
         name="separate_subcortical",
         mem_gb=mem_gb["resampled"],
-        n_procs=omp_nthreads,
     )
 
     # Calculate the reho by hemipshere
@@ -350,19 +344,16 @@ For the subcortical, volumetric data, ReHo was computed with neighborhood voxels
         SurfaceReHo(surf_hemi="L"),
         name="reho_lh",
         mem_gb=mem_gb["resampled"],
-        n_procs=omp_nthreads,
     )
     rh_reho = pe.Node(
         SurfaceReHo(surf_hemi="R"),
         name="reho_rh",
         mem_gb=mem_gb["resampled"],
-        n_procs=omp_nthreads,
     )
     subcortical_reho = pe.Node(
         ReHoNamePatch(neighborhood="vertices"),
         name="reho_subcortical",
         mem_gb=mem_gb["resampled"],
-        n_procs=omp_nthreads,
     )
 
     # Merge the surfaces and subcortical structures back into a CIFTI

--- a/xcp_d/workflows/bold/metrics.py
+++ b/xcp_d/workflows/bold/metrics.py
@@ -3,7 +3,6 @@
 """Workflows for calculating BOLD metrics (ALFF and ReHo)."""
 
 from nipype.interfaces import utility as niu
-from nipype.interfaces.workbench.cifti import CiftiSmooth
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from templateflow.api import get as get_template
@@ -17,6 +16,7 @@ from xcp_d.interfaces.workbench import (
     CiftiCreateDenseFromTemplate,
     CiftiSeparateMetric,
     CiftiSeparateVolumeAll,
+    CiftiSmooth,
     FixCiftiIntent,
 )
 from xcp_d.utils.doc import fill_doc

--- a/xcp_d/workflows/bold/metrics.py
+++ b/xcp_d/workflows/bold/metrics.py
@@ -101,7 +101,6 @@ def init_alff_wf(
     fd_thresh = config.workflow.fd_thresh
     smoothing = config.workflow.smoothing
     file_format = config.workflow.file_format
-    omp_nthreads = config.nipype.omp_nthreads
 
     periodogram_desc = ""
     if fd_thresh > 0:

--- a/xcp_d/workflows/bold/metrics.py
+++ b/xcp_d/workflows/bold/metrics.py
@@ -227,10 +227,11 @@ series to retain the original scaling.
                     direction="COLUMN",
                     right_surf=rh_midthickness,
                     left_surf=lh_midthickness,
+                    num_threads=config.nipype.omp_nthreads,
                 ),
                 name="ciftismoothing",
                 mem_gb=mem_gb["resampled"],
-                n_procs=1,
+                n_procs=config.nipype.omp_nthreads,
             )
 
             # Always check the intent code in CiftiSmooth's output file
@@ -322,19 +323,33 @@ For the subcortical, volumetric data, ReHo was computed with neighborhood voxels
 
     # Extract left and right hemispheres via Connectome Workbench
     lh_surf = pe.Node(
-        CiftiSeparateMetric(metric="CORTEX_LEFT", direction="COLUMN"),
+        CiftiSeparateMetric(
+            metric="CORTEX_LEFT",
+            direction="COLUMN",
+            num_threads=config.nipype.omp_nthreads,
+        ),
         name="separate_lh",
         mem_gb=mem_gb["resampled"],
+        n_procs=config.nipype.omp_nthreads,
     )
     rh_surf = pe.Node(
-        CiftiSeparateMetric(metric="CORTEX_RIGHT", direction="COLUMN"),
+        CiftiSeparateMetric(
+            metric="CORTEX_RIGHT",
+            direction="COLUMN",
+            num_threads=config.nipype.omp_nthreads,
+        ),
         name="separate_rh",
         mem_gb=mem_gb["resampled"],
+        n_procs=config.nipype.omp_nthreads,
     )
     subcortical_nifti = pe.Node(
-        CiftiSeparateVolumeAll(direction="COLUMN"),
+        CiftiSeparateVolumeAll(
+            direction="COLUMN",
+            num_threads=config.nipype.omp_nthreads,
+        ),
         name="separate_subcortical",
         mem_gb=mem_gb["resampled"],
+        n_procs=config.nipype.omp_nthreads,
     )
 
     # Calculate the reho by hemipshere
@@ -356,10 +371,14 @@ For the subcortical, volumetric data, ReHo was computed with neighborhood voxels
 
     # Merge the surfaces and subcortical structures back into a CIFTI
     merge_cifti = pe.Node(
-        CiftiCreateDenseFromTemplate(from_cropped=True, out_file="reho.dscalar.nii"),
+        CiftiCreateDenseFromTemplate(
+            from_cropped=True,
+            out_file="reho.dscalar.nii",
+            num_threads=config.nipype.omp_nthreads,
+        ),
         name="merge_cifti",
         mem_gb=mem_gb["resampled"],
-        n_procs=1,
+        n_procs=config.nipype.omp_nthreads,
     )
     reho_plot = pe.Node(
         PlotDenseCifti(base_desc="reho"),

--- a/xcp_d/workflows/bold/metrics.py
+++ b/xcp_d/workflows/bold/metrics.py
@@ -231,7 +231,7 @@ series to retain the original scaling.
                 ),
                 name="ciftismoothing",
                 mem_gb=mem_gb["resampled"],
-                n_procs=omp_nthreads,
+                n_procs=1,
             )
 
             # Always check the intent code in CiftiSmooth's output file
@@ -311,7 +311,6 @@ For the subcortical, volumetric data, ReHo was computed with neighborhood voxels
 """
 
     output_dir = config.execution.xcp_d_dir
-    omp_nthreads = config.nipype.omp_nthreads
 
     inputnode = pe.Node(
         niu.IdentityInterface(fields=["denoised_bold", "lh_midthickness", "rh_midthickness"]),
@@ -361,7 +360,7 @@ For the subcortical, volumetric data, ReHo was computed with neighborhood voxels
         CiftiCreateDenseFromTemplate(from_cropped=True, out_file="reho.dscalar.nii"),
         name="merge_cifti",
         mem_gb=mem_gb["resampled"],
-        n_procs=omp_nthreads,
+        n_procs=1,
     )
     reho_plot = pe.Node(
         PlotDenseCifti(base_desc="reho"),
@@ -451,7 +450,6 @@ def init_reho_nifti_wf(name_source, mem_gb, name="reho_nifti_wf"):
     workflow = Workflow(name=name)
 
     output_dir = config.execution.xcp_d_dir
-    omp_nthreads = config.nipype.omp_nthreads
 
     workflow.__desc__ = """
 Regional homogeneity (ReHo) [@jiang2016regional] was computed with neighborhood voxels using
@@ -469,7 +467,7 @@ Regional homogeneity (ReHo) [@jiang2016regional] was computed with neighborhood 
         ReHoNamePatch(neighborhood="vertices"),
         name="reho_3d",
         mem_gb=mem_gb["resampled"],
-        n_procs=omp_nthreads,
+        n_procs=1,
     )
     # Get the svg
     reho_plot = pe.Node(

--- a/xcp_d/workflows/bold/nifti.py
+++ b/xcp_d/workflows/bold/nifti.py
@@ -148,7 +148,6 @@ def init_postprocess_nifti_wf(
     dummy_scans = config.workflow.dummy_scans
     despike = config.workflow.despike
     atlases = config.execution.atlases
-    omp_nthreads = config.nipype.omp_nthreads
 
     TR = run_data["bold_metadata"]["RepetitionTime"]
 
@@ -227,7 +226,6 @@ the following post-processing was performed.
         ConvertTo32(),
         name="downcast_data",
         mem_gb=mem_gbx["timeseries"],
-        n_procs=omp_nthreads,
     )
 
     workflow.connect([

--- a/xcp_d/workflows/bold/plotting.py
+++ b/xcp_d/workflows/bold/plotting.py
@@ -87,7 +87,6 @@ def init_qc_report_wf(
     workflow = Workflow(name=name)
 
     output_dir = config.execution.xcp_d_dir
-    omp_nthreads = config.nipype.omp_nthreads
 
     inputnode = pe.Node(
         niu.IdentityInterface(
@@ -161,7 +160,6 @@ def init_qc_report_wf(
                 interpolation="NearestNeighbor",
             ),
             name="warp_boldmask_to_t1w",
-            n_procs=omp_nthreads,
             mem_gb=1,
         )
         workflow.connect([
@@ -182,7 +180,6 @@ def init_qc_report_wf(
                 interpolation="NearestNeighbor",
             ),
             name="warp_boldmask_to_mni",
-            n_procs=omp_nthreads,
             mem_gb=1,
         )
         workflow.connect([
@@ -200,7 +197,6 @@ def init_qc_report_wf(
                 interpolation="NearestNeighbor",
             ),
             name="warp_anatmask_to_t1w",
-            n_procs=omp_nthreads,
             mem_gb=1,
         )
         workflow.connect([
@@ -269,7 +265,6 @@ def init_qc_report_wf(
                 interpolation="GenericLabel",
             ),
             name="warp_dseg_to_bold",
-            n_procs=omp_nthreads,
             mem_gb=3,
         )
         workflow.connect([
@@ -286,7 +281,6 @@ def init_qc_report_wf(
             ),
             name="make_linc_qc",
             mem_gb=2,
-            n_procs=omp_nthreads,
         )
         workflow.connect([
             (inputnode, make_linc_qc, [
@@ -331,7 +325,6 @@ def init_qc_report_wf(
             QCPlots(TR=TR, head_radius=head_radius),
             name="make_qc_plots_nipreps",
             mem_gb=2,
-            n_procs=omp_nthreads,
         )
         workflow.connect([
             (inputnode, make_qc_plots_nipreps, [
@@ -411,7 +404,6 @@ def init_qc_report_wf(
             ABCCQC(TR=TR),
             name="make_abcc_qc",
             mem_gb=2,
-            n_procs=omp_nthreads,
         )
         workflow.connect([(inputnode, make_abcc_qc, [("filtered_motion", "filtered_motion")])])
 
@@ -436,7 +428,6 @@ def init_qc_report_wf(
             QCPlotsES(TR=TR, standardize=config.workflow.params == "none"),
             name="make_qc_plots_es",
             mem_gb=2,
-            n_procs=omp_nthreads,
         )
         workflow.connect([
             (inputnode, make_qc_plots_es, [

--- a/xcp_d/workflows/bold/plotting.py
+++ b/xcp_d/workflows/bold/plotting.py
@@ -158,9 +158,11 @@ def init_qc_report_wf(
             ApplyTransforms(
                 dimension=3,
                 interpolation="NearestNeighbor",
+                num_threads=config.nipype.omp_nthreads,
             ),
             name="warp_boldmask_to_t1w",
             mem_gb=1,
+            n_procs=config.nipype.omp_nthreads,
         )
         workflow.connect([
             (inputnode, warp_boldmask_to_t1w, [
@@ -178,9 +180,11 @@ def init_qc_report_wf(
                 dimension=3,
                 reference_image=nlin2009casym_brain_mask,
                 interpolation="NearestNeighbor",
+                num_threads=config.nipype.omp_nthreads,
             ),
             name="warp_boldmask_to_mni",
             mem_gb=1,
+            n_procs=config.nipype.omp_nthreads,
         )
         workflow.connect([
             (inputnode, warp_boldmask_to_mni, [("bold_mask", "input_image")]),
@@ -195,9 +199,11 @@ def init_qc_report_wf(
             ApplyTransforms(
                 dimension=3,
                 interpolation="NearestNeighbor",
+                num_threads=config.nipype.omp_nthreads,
             ),
             name="warp_anatmask_to_t1w",
             mem_gb=1,
+            n_procs=config.nipype.omp_nthreads,
         )
         workflow.connect([
             (inputnode, warp_anatmask_to_t1w, [
@@ -263,9 +269,11 @@ def init_qc_report_wf(
                 dimension=3,
                 input_image=dseg_file,
                 interpolation="GenericLabel",
+                num_threads=config.nipype.omp_nthreads,
             ),
             name="warp_dseg_to_bold",
             mem_gb=3,
+            n_procs=config.nipype.omp_nthreads,
         )
         workflow.connect([
             (inputnode, warp_dseg_to_bold, [("boldref", "reference_image")]),

--- a/xcp_d/workflows/bold/postprocessing.py
+++ b/xcp_d/workflows/bold/postprocessing.py
@@ -3,7 +3,6 @@
 """Workflows for post-processing BOLD data."""
 
 from nipype.interfaces import utility as niu
-from nipype.interfaces.workbench.cifti import CiftiSmooth
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from num2words import num2words
@@ -20,7 +19,7 @@ from xcp_d.interfaces.censoring import (
 from xcp_d.interfaces.nilearn import DenoiseCifti, DenoiseNifti, Smooth
 from xcp_d.interfaces.plotting import CensoringPlot
 from xcp_d.interfaces.restingstate import DespikePatch
-from xcp_d.interfaces.workbench import CiftiConvert, FixCiftiIntent
+from xcp_d.interfaces.workbench import CiftiConvert, CiftiSmooth, FixCiftiIntent
 from xcp_d.utils.boilerplate import (
     describe_censoring,
     describe_motion_parameters,

--- a/xcp_d/workflows/bold/postprocessing.py
+++ b/xcp_d/workflows/bold/postprocessing.py
@@ -108,7 +108,6 @@ def init_prepare_confounds_wf(
     band_stop_max = config.workflow.band_stop_max
     motion_filter_order = config.workflow.motion_filter_order
     fd_thresh = config.workflow.fd_thresh
-    omp_nthreads = config.nipype.omp_nthreads
 
     dummy_scans_str = ""
     if dummy_scans == "auto":
@@ -201,7 +200,6 @@ def init_prepare_confounds_wf(
         ),
         name="generate_confounds",
         mem_gb=2,
-        omp_nthreads=omp_nthreads,
     )
 
     # Load and filter confounds
@@ -353,7 +351,6 @@ def init_prepare_confounds_wf(
         ),
         name="censor_report",
         mem_gb=2,
-        n_procs=omp_nthreads,
     )
 
     workflow.connect([
@@ -534,7 +531,6 @@ def init_denoise_bold_wf(TR, mem_gb, name="denoise_bold_wf"):
     bandpass_filter = config.workflow.bandpass_filter
     smoothing = config.workflow.smoothing
     file_format = config.workflow.file_format
-    omp_nthreads = config.nipype.omp_nthreads
 
     workflow.__desc__ = """\
 
@@ -618,7 +614,6 @@ approach.
         ),
         name="regress_and_filter_bold",
         mem_gb=mem_gb["timeseries"],
-        n_procs=omp_nthreads,
     )
 
     workflow.connect([
@@ -638,7 +633,6 @@ approach.
         Censor(),
         name="censor_interpolated_data",
         mem_gb=mem_gb["resampled"],
-        omp_nthreads=omp_nthreads,
     )
 
     workflow.connect([
@@ -768,7 +762,6 @@ The denoised BOLD was then smoothed using *Connectome Workbench* with a Gaussian
             FixCiftiIntent(),
             name="fix_cifti_intent",
             mem_gb=1,
-            n_procs=omp_nthreads,
         )
         workflow.connect([
             (smooth_data, fix_cifti_intent, [("out_file", "in_file")]),
@@ -784,7 +777,6 @@ The denoised BOLD was smoothed using *Nilearn* with a Gaussian kernel (FWHM={str
             Smooth(fwhm=smoothing),  # FWHM = kernel size
             name="nifti_smoothing",
             mem_gb=mem_gb["timeseries"],
-            n_procs=omp_nthreads,
         )
         workflow.connect([
             (smooth_data, outputnode, [("out_file", "smoothed_bold")]),

--- a/xcp_d/workflows/bold/postprocessing.py
+++ b/xcp_d/workflows/bold/postprocessing.py
@@ -448,7 +448,7 @@ and converted back to CIFTI format.
             CiftiConvert(target="to"),
             name="convert_to_nifti",
             mem_gb=4,
-            n_procs=omp_nthreads,
+            n_procs=1,
         )
         workflow.connect([
             (inputnode, convert_to_nifti, [("bold_file", "in_file")]),
@@ -460,7 +460,7 @@ and converted back to CIFTI format.
             CiftiConvert(target="from", TR=TR),
             name="convert_to_cifti",
             mem_gb=4,
-            n_procs=omp_nthreads,
+            n_procs=1,
         )
         workflow.connect([
             (inputnode, convert_to_cifti, [("bold_file", "cifti_template")]),
@@ -711,7 +711,6 @@ def init_resd_smoothing_wf(mem_gb, name="resd_smoothing_wf"):
     workflow = Workflow(name=name)
     smoothing = config.workflow.smoothing
     file_format = config.workflow.file_format
-    omp_nthreads = config.nipype.omp_nthreads
 
     inputnode = pe.Node(niu.IdentityInterface(fields=["bold_file"]), name="inputnode")
     outputnode = pe.Node(niu.IdentityInterface(fields=["smoothed_bold"]), name="outputnode")
@@ -754,7 +753,7 @@ The denoised BOLD was then smoothed using *Connectome Workbench* with a Gaussian
             ),
             name="cifti_smoothing",
             mem_gb=mem_gb["timeseries"],
-            n_procs=omp_nthreads,
+            n_procs=1,
         )
 
         # Always check the intent code in CiftiSmooth's output file

--- a/xcp_d/workflows/parcellation.py
+++ b/xcp_d/workflows/parcellation.py
@@ -54,7 +54,6 @@ def init_load_atlases_wf(name="load_atlases_wf"):
     atlases = config.execution.atlases
     output_dir = config.execution.xcp_d_dir
     file_format = config.workflow.file_format
-    omp_nthreads = config.nipype.omp_nthreads
 
     inputnode = pe.Node(
         niu.IdentityInterface(
@@ -121,7 +120,6 @@ def init_load_atlases_wf(name="load_atlases_wf"):
             name="warp_atlases_to_bold_space",
             iterfield=["input_image"],
             mem_gb=2,
-            n_procs=omp_nthreads,
         )
 
         workflow.connect([

--- a/xcp_d/workflows/parcellation.py
+++ b/xcp_d/workflows/parcellation.py
@@ -116,10 +116,12 @@ def init_load_atlases_wf(name="load_atlases_wf"):
                 interpolation="GenericLabel",
                 input_image_type=3,
                 dimension=3,
+                num_threads=config.nipype.omp_nthreads,
             ),
             name="warp_atlases_to_bold_space",
             iterfield=["input_image"],
             mem_gb=2,
+            n_procs=config.nipype.omp_nthreads,
         )
 
         workflow.connect([


### PR DESCRIPTION
Closes none, but addresses an issue identified by @mattcieslak.

## Changes proposed in this pull request

- For any single-threaded nodes in any workflow, drop `n_procs=omp_nthreads`.
- Also drop `omp_nthreads=*` from any nodes using that. Pretty sure it doesn't do anything. 
- Create a WBCommand base interface that sets OMP_NUM_THREADS.
- Use the MultiProc plugin for integration tests, which speeds things up by a fair amount.