### PR TITLE
Parallelize ALFF

### DIFF
--- a/xcp_d/interfaces/restingstate.py
+++ b/xcp_d/interfaces/restingstate.py
@@ -107,6 +107,11 @@ class _ComputeALFFInputSpec(BaseInterfaceInputSpec):
         mandatory=False,
         desc="Temporal mask.",
     )
+    n_threads = traits.Int(
+        1,
+        usedefault=True,
+        desc="number of threads to use",
+    )
 
 
 class _ComputeALFFOutputSpec(TraitedSpec):
@@ -151,6 +156,7 @@ class ComputeALFF(SimpleInterface):
             high_pass=self.inputs.high_pass,
             TR=self.inputs.TR,
             sample_mask=sample_mask,
+            n_threads=self.inputs.n_threads,
         )
 
         # Write out the data

--- a/xcp_d/utils/restingstate.py
+++ b/xcp_d/utils/restingstate.py
@@ -101,7 +101,7 @@ def mesh_adjacency(hemi):
     return adjacency_matrix
 
 
-def compute_alff(data_matrix, low_pass, high_pass, TR, sample_mask=None):
+def compute_alff(*, data_matrix, low_pass, high_pass, TR, sample_mask, n_threads):
     """Compute amplitude of low-frequency fluctuation (ALFF).
 
     Parameters
@@ -116,6 +116,8 @@ def compute_alff(data_matrix, low_pass, high_pass, TR, sample_mask=None):
         repetition time in seconds
     sample_mask : numpy.ndarray or None
         (timepoints,) 1D array with 1s for good volumes and 0s for censored ones.
+    n_threads : int
+        number of threads to use
 
     Returns
     -------
@@ -135,6 +137,8 @@ def compute_alff(data_matrix, low_pass, high_pass, TR, sample_mask=None):
     ----------
     .. footbibliography::
     """
+    from concurrent.futures import ProcessPoolExecutor
+
     fs = 1 / TR  # sampling frequency
     n_voxels, n_volumes = data_matrix.shape
 
@@ -145,69 +149,113 @@ def compute_alff(data_matrix, low_pass, high_pass, TR, sample_mask=None):
     alff = np.zeros(n_voxels)
     for i_voxel in range(n_voxels):
         voxel_data = data_matrix[i_voxel, :]
-        # Check if the voxel's data are all the same value (esp. zeros).
-        # Set ALFF to 0 in that case and move on to the next voxel.
-        if np.std(voxel_data) == 0:
-            alff[i_voxel] = 0
-            continue
+        alff[i_voxel] = _compute_alff_voxel(
+            voxel_data=voxel_data,
+            sample_mask=sample_mask,
+            n_volumes=n_volumes,
+            TR=TR,
+            fs=fs,
+            high_pass=high_pass,
+            low_pass=low_pass,
+        )
 
-        # We will normalize data matrix over time.
-        # This will ensure that the power spectra from the standard and Lomb-Scargle periodograms
-        # have the same scale.
-        # However, this also changes ALFF's scale, so we retain the SD to rescale ALFF.
-        sd_scale = np.std(voxel_data)
-
-        if sample_mask is not None:
-            voxel_data_censored = voxel_data[sample_mask]
-            voxel_data_censored -= np.mean(voxel_data_censored)
-            voxel_data_censored /= np.std(voxel_data_censored)
-
-            time_arr = np.arange(n_volumes) * TR
-            assert sample_mask.size == time_arr.size, f"{sample_mask.size} != {time_arr.size}"
-            time_arr = time_arr[sample_mask]
-            frequencies_hz = np.linspace(0, 0.5 * fs, (n_volumes // 2) + 1)[1:]
-            angular_frequencies = 2 * np.pi * frequencies_hz
-            power_spectrum = signal.lombscargle(
-                time_arr,
-                voxel_data_censored,
-                angular_frequencies,
-                normalize=True,
-            )
-        else:
-            voxel_data -= np.mean(voxel_data)
-            voxel_data /= np.std(voxel_data)
-            # get array of sample frequencies + power spectrum density
-            frequencies_hz, power_spectrum = signal.periodogram(
-                voxel_data,
-                fs,
-                scaling="spectrum",
-            )
-
-        # square root of power spectrum
-        power_spectrum_sqrt = np.sqrt(power_spectrum)
-        # get the position of the arguments closest to high_pass and low_pass, respectively
-        if high_pass == 0:
-            # If high_pass is 0, then we set it to the minimum frequency
-            high_pass = frequencies_hz[0]
-
-        if low_pass == 0:
-            # If low_pass is 0, then we set it to the maximum frequency
-            low_pass = frequencies_hz[-1]
-
-        ff_alff = [
-            np.argmin(np.abs(frequencies_hz - high_pass)),
-            np.argmin(np.abs(frequencies_hz - low_pass)),
-        ]
-        # alff for that voxel is 2 * the mean of the sqrt of the power spec
-        # from the value closest to the low pass cutoff, to the value closest
-        # to the high pass pass cutoff
-        alff[i_voxel] = len(ff_alff) * np.mean(power_spectrum_sqrt[ff_alff[0] : ff_alff[1]])
-        # Rescale ALFF based on original BOLD scale
-        alff[i_voxel] *= sd_scale
+        with ProcessPoolExecutor(max_workers=n_threads) as executor:
+            futures = [
+                executor.submit(
+                    process_voxel,
+                    i_voxel,
+                    data_matrix,
+                    sample_mask,
+                    TR,
+                    high_pass,
+                    low_pass,
+                )
+                for i_voxel in range(n_voxels)
+            ]
+            for i, future in enumerate(futures):
+                alff[i] = future.result()
 
     assert alff.size == n_voxels, f"{alff.shape} != {n_voxels}"
 
     # Add second dimension to array
     alff = alff[:, None]
+
+    return alff
+
+
+def process_voxel(i_voxel, data_matrix, sample_mask, TR, high_pass, low_pass):
+    """Process a voxel for ALFF calculation."""
+    voxel_data = data_matrix[i_voxel, :]
+    alff = _compute_alff_voxel(
+        voxel_data=voxel_data,
+        sample_mask=sample_mask,
+        n_volumes=voxel_data.size,
+        TR=TR,
+        fs=1 / TR,
+        high_pass=high_pass,
+        low_pass=low_pass,
+    )
+    return alff
+
+
+def _compute_alff_voxel(*, voxel_data, sample_mask, n_volumes, TR, fs, high_pass, low_pass):
+    # Check if the voxel's data are all the same value (esp. zeros).
+    # Set ALFF to 0 in that case and move on to the next voxel.
+    if np.std(voxel_data) == 0:
+        return 0
+
+    # We will normalize data matrix over time.
+    # This will ensure that the power spectra from the standard and Lomb-Scargle periodograms
+    # have the same scale.
+    # However, this also changes ALFF's scale, so we retain the SD to rescale ALFF.
+    sd_scale = np.std(voxel_data)
+
+    if sample_mask is not None:
+        voxel_data_censored = voxel_data[sample_mask]
+        voxel_data_censored -= np.mean(voxel_data_censored)
+        voxel_data_censored /= np.std(voxel_data_censored)
+
+        time_arr = np.arange(n_volumes) * TR
+        assert sample_mask.size == time_arr.size, f"{sample_mask.size} != {time_arr.size}"
+        time_arr = time_arr[sample_mask]
+        frequencies_hz = np.linspace(0, 0.5 * fs, (n_volumes // 2) + 1)[1:]
+        angular_frequencies = 2 * np.pi * frequencies_hz
+        power_spectrum = signal.lombscargle(
+            time_arr,
+            voxel_data_censored,
+            angular_frequencies,
+            normalize=True,
+        )
+    else:
+        voxel_data -= np.mean(voxel_data)
+        voxel_data /= np.std(voxel_data)
+        # get array of sample frequencies + power spectrum density
+        frequencies_hz, power_spectrum = signal.periodogram(
+            voxel_data,
+            fs,
+            scaling="spectrum",
+        )
+
+    # square root of power spectrum
+    power_spectrum_sqrt = np.sqrt(power_spectrum)
+    # get the position of the arguments closest to high_pass and low_pass, respectively
+    if high_pass == 0:
+        # If high_pass is 0, then we set it to the minimum frequency
+        high_pass = frequencies_hz[0]
+
+    if low_pass == 0:
+        # If low_pass is 0, then we set it to the maximum frequency
+        low_pass = frequencies_hz[-1]
+
+    ff_alff = [
+        np.argmin(np.abs(frequencies_hz - high_pass)),
+        np.argmin(np.abs(frequencies_hz - low_pass)),
+    ]
+    # alff for that voxel is 2 * the mean of the sqrt of the power spec
+    # from the value closest to the low pass cutoff, to the value closest
+    # to the high pass pass cutoff
+    alff = len(ff_alff) * np.mean(power_spectrum_sqrt[ff_alff[0] : ff_alff[1]])
+    # Rescale ALFF based on original BOLD scale
+    alff *= sd_scale
 
     return alff

--- a/xcp_d/workflows/bold/metrics.py
+++ b/xcp_d/workflows/bold/metrics.py
@@ -142,7 +142,7 @@ series to retain the original scaling.
 
     # compute alff
     alff_compt = pe.Node(
-        ComputeALFF(TR=TR, low_pass=low_pass, high_pass=high_pass),
+        ComputeALFF(TR=TR, low_pass=low_pass, high_pass=high_pass, n_threads=omp_nthreads),
         mem_gb=mem_gb["resampled"],
         name="alff_compt",
         n_procs=omp_nthreads,


### PR DESCRIPTION
Closes #1257. I don't think it makes sense to try parallelizing the denoising interface until I have voxel-wise regressors up and running. And even then I would only want to parallelize _when_ there are voxel-wise regressors.

## Changes proposed in this pull request

- Use `ProcessPoolExecutor` to parallelize ALFF.