### PR TITLE
Remove xcp_d_dir and clean datasinks

### DIFF
--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -858,9 +858,6 @@ def parse_args(args=None, namespace=None):
     work_dir = config.execution.work_dir
     version = config.environment.version
 
-    if config.execution.xcp_d_dir is None:
-        config.execution.xcp_d_dir = output_dir
-
     # Update the config with an empty dict to trigger initialization of all config
     # sections (we used `init=False` above).
     # This must be done after cleaning the work directory, or we could delete an
@@ -882,7 +879,7 @@ def parse_args(args=None, namespace=None):
         )
 
     # Setup directories
-    config.execution.log_dir = config.execution.xcp_d_dir / "logs"
+    config.execution.log_dir = config.execution.output_dir / "logs"
     # Check and create output and working directories
     config.execution.log_dir.mkdir(exist_ok=True, parents=True)
     output_dir.mkdir(exist_ok=True, parents=True)

--- a/xcp_d/cli/run.py
+++ b/xcp_d/cli/run.py
@@ -118,7 +118,7 @@ def main():
             from xcp_d.utils.sentry import process_crashfile
 
             crashfolders = [
-                config.execution.xcp_d_dir / f"sub-{s}" / "log" / config.execution.run_uuid
+                config.execution.output_dir / f"sub-{s}" / "log" / config.execution.run_uuid
                 for s in config.execution.participant_label
             ]
             for crashfolder in crashfolders:
@@ -139,14 +139,14 @@ def main():
             sentry_sdk.capture_message(success_message, level="info")
 
         # Bother users with the boilerplate only iff the workflow went okay.
-        boiler_file = config.execution.xcp_d_dir / "logs" / "CITATION.md"
+        boiler_file = config.execution.output_dir / "logs" / "CITATION.md"
         if boiler_file.exists():
             if config.environment.exec_env in (
                 "apptainer",
                 "docker",
             ):
                 boiler_file = Path("<OUTPUT_PATH>") / boiler_file.relative_to(
-                    config.execution.xcp_d_dir
+                    config.execution.output_dir
                 )
             config.loggers.workflow.log(
                 25,
@@ -160,10 +160,10 @@ def main():
         from xcp_d.reports.core import generate_reports
 
         # Write dataset description before generating reports
-        write_dataset_description(config.execution.fmri_dir, config.execution.xcp_d_dir)
+        write_dataset_description(config.execution.fmri_dir, config.execution.output_dir)
 
         if config.execution.atlases:
-            write_atlas_dataset_description(config.execution.xcp_d_dir / "atlases")
+            write_atlas_dataset_description(config.execution.output_dir / "atlases")
 
         # Generate reports phase
         session_list = (
@@ -173,7 +173,7 @@ def main():
         # Generate reports phase
         failed_reports = generate_reports(
             subject_list=config.execution.participant_label,
-            output_dir=config.execution.xcp_d_dir,
+            output_dir=config.execution.output_dir,
             abcc_qc=config.workflow.abcc_qc,
             run_uuid=config.execution.run_uuid,
             session_list=session_list,

--- a/xcp_d/cli/workflow.py
+++ b/xcp_d/cli/workflow.py
@@ -42,7 +42,7 @@ def build_workflow(config_file, retval):
     msg = check_pipeline_version(
         "XCP-D",
         version,
-        config.execution.xcp_d_dir / "dataset_description.json",
+        config.execution.output_dir / "dataset_description.json",
     )
     if msg is not None:
         build_log.warning(msg)
@@ -72,7 +72,7 @@ def build_workflow(config_file, retval):
 
         failed_reports = generate_reports(
             subject_list=config.execution.participant_label,
-            output_dir=config.execution.xcp_d_dir,
+            output_dir=config.execution.output_dir,
             abcc_qc=config.workflow.abcc_qc,
             run_uuid=config.execution.run_uuid,
             session_list=session_list,
@@ -134,7 +134,7 @@ def build_boilerplate(config_file, workflow):
     from xcp_d import config
 
     config.load(config_file)
-    logs_path = config.execution.xcp_d_dir / "logs"
+    logs_path = config.execution.output_dir / "logs"
     boilerplate = workflow.visit_desc()
     citation_files = {ext: logs_path / f"CITATION.{ext}" for ext in ("bib", "tex", "md", "html")}
 

--- a/xcp_d/config.py
+++ b/xcp_d/config.py
@@ -26,7 +26,7 @@ A Python module to maintain unique, run-wide *XCP-D* settings.
 This module implements the memory structures to keep a consistent, singleton config.
 Settings are passed across processes via filesystem, and a copy of the settings for
 each run and subject is left under
-``<xcp_d_dir>/sub-<participant_id>/log/<run_unique_id>/xcp_d.toml``.
+``<output_dir>/sub-<participant_id>/log/<run_unique_id>/xcp_d.toml``.
 Settings are stored using :abbr:`ToML (Tom's Markup Language)`.
 The module has a :py:func:`~xcp_d.config.to_filename` function to allow writing out
 the settings to hard disk in *ToML* format, which looks like:
@@ -385,8 +385,6 @@ class execution(_Config):
     """Only generate a boilerplate."""
     debug = []
     """Debug mode(s)."""
-    xcp_d_dir = None
-    """Root of XCP-D BIDS Derivatives dataset."""
     fs_license_file = _fs_license
     """An existing file containing a FreeSurfer license."""
     layout = None
@@ -427,7 +425,6 @@ class execution(_Config):
     _paths = (
         "fmri_dir",
         "bids_database_dir",
-        "xcp_d_dir",
         "fs_license_file",
         "layout",
         "log_dir",

--- a/xcp_d/data/tests/config.toml
+++ b/xcp_d/data/tests/config.toml
@@ -14,7 +14,6 @@ bids_description_hash = "123456"
 bids_filters = {}
 boilerplate_only = false
 debug = []
-xcp_d_dir = "ds000005/derivatives/xcp_d"
 fs_license_file = "/opt/freesurfer/license.txt"
 log_dir = "/opt/xcp_d"
 log_level = 40

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -475,9 +475,9 @@ def _run_and_generate(test_name, parameters, input_type, test_main=False):
         retval = build_workflow(config_file, retval={})
         xcpd_wf = retval["workflow"]
         xcpd_wf.run(**config.nipype.get_plugin())
-        write_dataset_description(config.execution.fmri_dir, config.execution.xcp_d_dir)
+        write_dataset_description(config.execution.fmri_dir, config.execution.output_dir)
         if config.execution.atlases:
-            write_atlas_dataset_description(config.execution.xcp_d_dir / "atlases")
+            write_atlas_dataset_description(config.execution.output_dir / "atlases")
 
         build_boilerplate(str(config_file), xcpd_wf)
         session_list = (
@@ -487,12 +487,12 @@ def _run_and_generate(test_name, parameters, input_type, test_main=False):
         )
         generate_reports(
             subject_list=config.execution.participant_label,
-            output_dir=config.execution.xcp_d_dir,
+            output_dir=config.execution.output_dir,
             abcc_qc=config.workflow.abcc_qc,
             run_uuid=config.execution.run_uuid,
             session_list=session_list,
         )
 
     output_list_file = os.path.join(get_test_data_path(), f"{test_name}_outputs.txt")
-    check_generated_files(config.execution.xcp_d_dir, output_list_file)
-    check_affines(config.execution.fmri_dir, config.execution.xcp_d_dir, input_type=input_type)
+    check_generated_files(config.execution.output_dir, output_list_file)
+    check_affines(config.execution.fmri_dir, config.execution.output_dir, input_type=input_type)

--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -68,9 +68,9 @@ def test_warp_surfaces_to_template_wf(
 
     with mock_config():
         config.nipype.omp_nthreads = 1
+        config.execution.output_dir = tmpdir
 
         wf = anatomical.surface.init_warp_surfaces_to_template_wf(
-            output_dir=tmpdir,
             software="FreeSurfer",
             omp_nthreads=1,
         )

--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -107,7 +107,7 @@ def test_postprocess_anat_wf(ds001419_data, tmp_path_factory):
     shutil.copyfile(t1w, t2w)
 
     with mock_config():
-        config.execution.xcp_d_dir = tmpdir
+        config.execution.output_dir = tmpdir
         config.workflow.input_type = "fmriprep"
         config.nipype.omp_nthreads = 1
         config.nipype.mem_gb = 0.1

--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -9,6 +9,7 @@ from xcp_d import config
 from xcp_d.tests.tests import mock_config
 from xcp_d.tests.utils import get_nodes
 from xcp_d.workflows import anatomical
+from xcp_d.workflows.base import clean_datasinks
 
 
 @pytest.fixture
@@ -86,6 +87,7 @@ def test_warp_surfaces_to_template_wf(
         wf.inputs.inputnode.template_to_anat_xfm = pnc_data["template_to_anat_xfm"]
 
         wf.base_dir = tmpdir
+        wf = clean_datasinks(wf)
         wf.run()
 
     # All of the possible fsLR surfaces should be available.
@@ -123,6 +125,7 @@ def test_postprocess_anat_wf(ds001419_data, tmp_path_factory):
         wf.inputs.inputnode.t1w = t1w
         wf.inputs.inputnode.t2w = t2w
         wf.base_dir = tmpdir
+        wf = clean_datasinks(wf)
         wf_res = wf.run()
 
         wf_nodes = get_nodes(wf_res)

--- a/xcp_d/tests/test_workflows_anatomical.py
+++ b/xcp_d/tests/test_workflows_anatomical.py
@@ -90,13 +90,13 @@ def test_warp_surfaces_to_template_wf(
         wf = clean_datasinks(wf)
         wf.run()
 
-    # All of the possible fsLR surfaces should be available.
-    out_anat_dir = os.path.join(tmpdir, "sub-1648798153", "ses-PNC1", "anat")
-    for key, filename in surface_files.items():
-        if "fsLR" in key:
-            out_fname = os.path.basename(filename)
-            out_file = os.path.join(out_anat_dir, out_fname)
-            assert os.path.isfile(out_file), "\n".join(sorted(os.listdir(out_anat_dir)))
+        # All of the possible fsLR surfaces should be available.
+        out_anat_dir = os.path.join(tmpdir, "sub-1648798153", "ses-PNC1", "anat")
+        for key, filename in surface_files.items():
+            if "fsLR" in key:
+                out_fname = os.path.basename(filename)
+                out_file = os.path.join(out_anat_dir, out_fname)
+                assert os.path.isfile(out_file), "\n".join(sorted(os.listdir(tmpdir)))
 
 
 def test_postprocess_anat_wf(ds001419_data, tmp_path_factory):

--- a/xcp_d/tests/test_workflows_connectivity.py
+++ b/xcp_d/tests/test_workflows_connectivity.py
@@ -33,7 +33,7 @@ def test_init_load_atlases_wf_nifti(ds001419_data, tmp_path_factory):
     bold_file = ds001419_data["nifti_file"]
 
     with mock_config():
-        config.execution.xcp_d_dir = tmpdir
+        config.execution.output_dir = tmpdir
         config.workflow.file_format = "nifti"
         config.execution.atlases = ["4S156Parcels", "Glasser"]
         config.nipype.omp_nthreads = 1
@@ -58,7 +58,7 @@ def test_init_load_atlases_wf_cifti(ds001419_data, tmp_path_factory):
     bold_file = ds001419_data["cifti_file"]
 
     with mock_config():
-        config.execution.xcp_d_dir = tmpdir
+        config.execution.output_dir = tmpdir
         config.workflow.file_format = "cifti"
         config.execution.atlases = ["4S156Parcels", "Glasser"]
         config.nipype.omp_nthreads = 1
@@ -137,7 +137,7 @@ def test_init_functional_connectivity_nifti_wf(ds001419_data, tmp_path_factory):
 
     # Let's define the inputs and create the workflow
     with mock_config():
-        config.execution.xcp_d_dir = tmpdir
+        config.execution.output_dir = tmpdir
         config.workflow.bandpass_filter = False
         config.workflow.min_coverage = 0.5
         config.nipype.omp_nthreads = 2
@@ -265,7 +265,7 @@ def test_init_functional_connectivity_cifti_wf(ds001419_data, tmp_path_factory):
 
     # Create the node and a tmpdir to write its results out to
     with mock_config():
-        config.execution.xcp_d_dir = tmpdir
+        config.execution.output_dir = tmpdir
         config.workflow.bandpass_filter = False
         config.workflow.min_coverage = 0.5
         config.nipype.omp_nthreads = 2

--- a/xcp_d/tests/test_workflows_connectivity.py
+++ b/xcp_d/tests/test_workflows_connectivity.py
@@ -17,6 +17,7 @@ from xcp_d.utils.atlas import get_atlas_cifti, get_atlas_nifti
 from xcp_d.utils.bids import _get_tr
 from xcp_d.utils.utils import _create_mem_gb, get_std2bold_xfms
 from xcp_d.utils.write_save import read_ndata, write_ndata
+from xcp_d.workflows.base import clean_datasinks
 from xcp_d.workflows.bold.connectivity import (
     init_functional_connectivity_cifti_wf,
     init_functional_connectivity_nifti_wf,
@@ -70,7 +71,7 @@ def test_init_load_atlases_wf_cifti(ds001419_data, tmp_path_factory):
         load_atlases_wf_res = load_atlases_wf.run()
 
         nodes = get_nodes(load_atlases_wf_res)
-        atlas_names = nodes["load_atlases_wf.ds_atlas"].get_output("out_file")
+        atlas_names = nodes["load_atlases_wf.copy_atlas"].get_output("out_file")
         assert len(atlas_names) == 2
 
 
@@ -157,6 +158,7 @@ def test_init_functional_connectivity_nifti_wf(ds001419_data, tmp_path_factory):
         connectivity_wf.inputs.inputnode.atlas_files = warped_atlases
         connectivity_wf.inputs.inputnode.atlas_labels_files = atlas_labels_files
         connectivity_wf.base_dir = tmpdir
+        connectivity_wf = clean_datasinks(connectivity_wf)
         connectivity_wf_res = connectivity_wf.run()
 
         nodes = get_nodes(connectivity_wf_res)

--- a/xcp_d/tests/test_workflows_connectivity.py
+++ b/xcp_d/tests/test_workflows_connectivity.py
@@ -287,6 +287,7 @@ def test_init_functional_connectivity_cifti_wf(ds001419_data, tmp_path_factory):
         connectivity_wf.inputs.inputnode.atlas_files = atlas_files
         connectivity_wf.inputs.inputnode.atlas_labels_files = atlas_labels_files
         connectivity_wf.base_dir = tmpdir
+        connectivity_wf = clean_datasinks(connectivity_wf)
         connectivity_wf_res = connectivity_wf.run()
 
         nodes = get_nodes(connectivity_wf_res)

--- a/xcp_d/tests/test_workflows_metrics.py
+++ b/xcp_d/tests/test_workflows_metrics.py
@@ -33,7 +33,7 @@ def test_nifti_alff(ds001419_data, tmp_path_factory):
     mem_gbx = _create_mem_gb(bold_file)
 
     with mock_config():
-        config.execution.xcp_d_dir = tempdir
+        config.execution.output_dir = tempdir
         config.workflow.file_format = "nifti"
         config.workflow.low_pass = 0.08
         config.workflow.high_pass = 0.01
@@ -120,7 +120,7 @@ def test_cifti_alff(ds001419_data, tmp_path_factory):
     tempdir = tmp_path_factory.mktemp("test_cifti_alff_01")
 
     with mock_config():
-        config.execution.xcp_d_dir = tempdir
+        config.execution.output_dir = tempdir
         config.workflow.file_format = "cifti"
         config.workflow.low_pass = 0.08
         config.workflow.high_pass = 0.01
@@ -213,7 +213,7 @@ def test_nifti_reho(ds001419_data, tmp_path_factory):
 
     # Set up and run the ReHo wf in a tempdir
     with mock_config():
-        config.execution.xcp_d_dir = tempdir
+        config.execution.output_dir = tempdir
         config.nipype.omp_nthreads = 2
 
         reho_wf = metrics.init_reho_nifti_wf(name_source=bold_file, mem_gb=mem_gbx)
@@ -269,7 +269,7 @@ def test_cifti_reho(ds001419_data, tmp_path_factory):
 
     # Set up and run the ReHo wf in a tempdir
     with mock_config():
-        config.execution.xcp_d_dir = tempdir
+        config.execution.output_dir = tempdir
         config.nipype.omp_nthreads = 2
 
         reho_wf = metrics.init_reho_cifti_wf(

--- a/xcp_d/tests/test_workflows_metrics.py
+++ b/xcp_d/tests/test_workflows_metrics.py
@@ -94,6 +94,7 @@ def test_nifti_alff(ds001419_data, tmp_path_factory):
         alff_wf.base_dir = tempdir
         alff_wf.inputs.inputnode.bold_mask = bold_mask
         alff_wf.inputs.inputnode.denoised_bold = filename
+        alff_wf = clean_datasinks(alff_wf)
         compute_alff_res = alff_wf.run()
         nodes = get_nodes(compute_alff_res)
 

--- a/xcp_d/tests/test_workflows_metrics.py
+++ b/xcp_d/tests/test_workflows_metrics.py
@@ -12,6 +12,7 @@ from xcp_d.tests.utils import get_nodes
 from xcp_d.utils.bids import _get_tr
 from xcp_d.utils.utils import _create_mem_gb
 from xcp_d.utils.write_save import read_ndata, write_ndata
+from xcp_d.workflows.base import clean_datasinks
 from xcp_d.workflows.bold import metrics
 
 
@@ -51,6 +52,7 @@ def test_nifti_alff(ds001419_data, tmp_path_factory):
         alff_wf.base_dir = tempdir
         alff_wf.inputs.inputnode.bold_mask = bold_mask
         alff_wf.inputs.inputnode.denoised_bold = bold_file
+        alff_wf = clean_datasinks(alff_wf)
         compute_alff_res = alff_wf.run()
 
         nodes = get_nodes(compute_alff_res)
@@ -137,6 +139,7 @@ def test_cifti_alff(ds001419_data, tmp_path_factory):
         alff_wf.base_dir = tempdir
         alff_wf.inputs.inputnode.bold_mask = bold_mask
         alff_wf.inputs.inputnode.denoised_bold = bold_file
+        alff_wf = clean_datasinks(alff_wf)
         compute_alff_res = alff_wf.run()
 
         nodes = get_nodes(compute_alff_res)
@@ -220,6 +223,7 @@ def test_nifti_reho(ds001419_data, tmp_path_factory):
         reho_wf.inputs.inputnode.bold_mask = bold_mask
         reho_wf.base_dir = tempdir
         reho_wf.inputs.inputnode.denoised_bold = bold_file
+        reho_wf = clean_datasinks(reho_wf)
         reho_res = reho_wf.run()
 
         nodes = get_nodes(reho_res)
@@ -279,6 +283,7 @@ def test_cifti_reho(ds001419_data, tmp_path_factory):
         )
         reho_wf.base_dir = tempdir
         reho_wf.inputs.inputnode.denoised_bold = orig_bold_file
+        reho_wf = clean_datasinks(reho_wf)
         reho_res = reho_wf.run()
 
         nodes = get_nodes(reho_res)
@@ -303,6 +308,7 @@ def test_cifti_reho(ds001419_data, tmp_path_factory):
         )
         reho_wf.base_dir = tempdir
         reho_wf.inputs.inputnode.denoised_bold = noisy_bold_file
+        reho_wf = clean_datasinks(reho_wf)
         reho_res = reho_wf.run()
 
         nodes = get_nodes(reho_res)

--- a/xcp_d/tests/test_workflows_plotting.py
+++ b/xcp_d/tests/test_workflows_plotting.py
@@ -8,6 +8,7 @@ from xcp_d import config
 from xcp_d.tests.tests import mock_config
 from xcp_d.tests.utils import get_nodes
 from xcp_d.workflows import plotting
+from xcp_d.workflows.base import clean_datasinks
 
 
 def test_init_plot_custom_slices_wf(ds001419_data, tmp_path_factory):
@@ -30,6 +31,7 @@ def test_init_plot_custom_slices_wf(ds001419_data, tmp_path_factory):
         wf.inputs.inputnode.overlay_file = nifti_3d
         wf.inputs.inputnode.underlay_file = ds001419_data["t1w_mni"]
         wf.base_dir = tmpdir
+        wf = clean_datasinks(wf)
         wf_res = wf.run()
 
         nodes = get_nodes(wf_res)

--- a/xcp_d/tests/test_workflows_plotting.py
+++ b/xcp_d/tests/test_workflows_plotting.py
@@ -35,5 +35,5 @@ def test_init_plot_custom_slices_wf(ds001419_data, tmp_path_factory):
         wf_res = wf.run()
 
         nodes = get_nodes(wf_res)
-        overlay_figure = nodes["plot_custom_slices_wf.ds_overlay_figure"].get_output("out_file")
+        overlay_figure = nodes["plot_custom_slices_wf.ds_report_overlay"].get_output("out_file")
         assert os.path.isfile(overlay_figure)

--- a/xcp_d/tests/test_workflows_plotting.py
+++ b/xcp_d/tests/test_workflows_plotting.py
@@ -4,6 +4,8 @@ import os
 
 from nilearn import image
 
+from xcp_d import config
+from xcp_d.tests.tests import mock_config
 from xcp_d.tests.utils import get_nodes
 from xcp_d.workflows import plotting
 
@@ -17,15 +19,19 @@ def test_init_plot_custom_slices_wf(ds001419_data, tmp_path_factory):
     img_3d = image.index_img(nifti_file, 5)
     img_3d.to_filename(nifti_3d)
 
-    wf = plotting.init_plot_custom_slices_wf(
-        desc="SubcorticalOnAtlas",
-        name="plot_custom_slices_wf",
-    )
-    wf.inputs.inputnode.name_source = nifti_file
-    wf.inputs.inputnode.overlay_file = nifti_3d
-    wf.inputs.inputnode.underlay_file = ds001419_data["t1w_mni"]
-    wf.base_dir = tmpdir
-    wf_res = wf.run()
-    nodes = get_nodes(wf_res)
-    overlay_figure = nodes["plot_custom_slices_wf.ds_overlay_figure"].get_output("out_file")
-    assert os.path.isfile(overlay_figure)
+    with mock_config():
+        config.execution.output_dir = tmpdir
+
+        wf = plotting.init_plot_custom_slices_wf(
+            desc="SubcorticalOnAtlas",
+            name="plot_custom_slices_wf",
+        )
+        wf.inputs.inputnode.name_source = nifti_file
+        wf.inputs.inputnode.overlay_file = nifti_3d
+        wf.inputs.inputnode.underlay_file = ds001419_data["t1w_mni"]
+        wf.base_dir = tmpdir
+        wf_res = wf.run()
+
+        nodes = get_nodes(wf_res)
+        overlay_figure = nodes["plot_custom_slices_wf.ds_overlay_figure"].get_output("out_file")
+        assert os.path.isfile(overlay_figure)

--- a/xcp_d/tests/test_workflows_plotting.py
+++ b/xcp_d/tests/test_workflows_plotting.py
@@ -18,7 +18,6 @@ def test_init_plot_custom_slices_wf(ds001419_data, tmp_path_factory):
     img_3d.to_filename(nifti_3d)
 
     wf = plotting.init_plot_custom_slices_wf(
-        output_dir=tmpdir,
         desc="SubcorticalOnAtlas",
         name="plot_custom_slices_wf",
     )

--- a/xcp_d/tests/tests.py
+++ b/xcp_d/tests/tests.py
@@ -61,7 +61,7 @@ def mock_config():
 
     config.execution.work_dir = Path(mkdtemp())
     config.execution.fmri_dir = Path(doc.download_example_data(out_dir=mkdtemp()))
-    config.execution.xcp_d_dir = Path(mkdtemp())
+    config.execution.output_dir = Path(mkdtemp())
     config.execution.bids_database_dir = None
     config.execution._layout = None
     config.execution.init()
@@ -69,7 +69,7 @@ def mock_config():
     yield
 
     shutil.rmtree(config.execution.work_dir)
-    shutil.rmtree(config.execution.xcp_d_dir)
+    shutil.rmtree(config.execution.output_dir)
 
     if not _old_fs:
         del os.environ["FREESURFER_HOME"]

--- a/xcp_d/workflows/anatomical/outputs.py
+++ b/xcp_d/workflows/anatomical/outputs.py
@@ -6,7 +6,6 @@ from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
-from xcp_d import config
 from xcp_d.interfaces.bids import DerivativesDataSink
 from xcp_d.interfaces.utils import FilterUndefined
 from xcp_d.utils.doc import fill_doc
@@ -47,8 +46,6 @@ def init_copy_inputs_to_outputs_wf(name="copy_inputs_to_outputs_wf"):
     myelin_smoothed
     """
     workflow = Workflow(name=name)
-
-    output_dir = config.execution.xcp_d_dir
 
     inputnode = pe.Node(
         niu.IdentityInterface(
@@ -97,10 +94,7 @@ def init_copy_inputs_to_outputs_wf(name="copy_inputs_to_outputs_wf"):
     workflow.connect([(collect_files, filter_out_undefined, [("out", "inlist")])])
 
     ds_copied_outputs = pe.MapNode(
-        DerivativesDataSink(
-            base_directory=output_dir,
-            check_hdr=False,
-        ),
+        DerivativesDataSink(check_hdr=False),
         name="ds_copied_outputs",
         run_without_submitting=True,
         mem_gb=1,

--- a/xcp_d/workflows/anatomical/parcellation.py
+++ b/xcp_d/workflows/anatomical/parcellation.py
@@ -53,7 +53,6 @@ def init_parcellate_surfaces_wf(files_to_parcellate, name="parcellate_surfaces_w
 
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
     atlases = config.execution.atlases
 
     SURF_DESCS = {
@@ -135,7 +134,6 @@ def init_parcellate_surfaces_wf(files_to_parcellate, name="parcellate_surfaces_w
         # Write out the parcellated files
         ds_parcellated_surface = pe.MapNode(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=["hemi", "desc", "den", "res"],
                 desc=SURF_DESCS[file_to_parcellate],
                 statistic="mean",

--- a/xcp_d/workflows/anatomical/plotting.py
+++ b/xcp_d/workflows/anatomical/plotting.py
@@ -67,8 +67,6 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
     """
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
-
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
@@ -176,20 +174,18 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
 
         workflow.connect([(create_framewise_pngs, make_mosaic_node, [("out_file", "png_files")])])
 
-        ds_mosaic_file = pe.Node(
+        ds_report_mosaic_file = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=["desc"],
                 desc="mosaic",
-                datatype="figures",
                 suffix=f"{image_type}w",
             ),
-            name=f"ds_mosaic_file_{image_type}",
+            name=f"ds_report_mosaic_file_{image_type}",
             run_without_submitting=False,
         )
         workflow.connect([
-            (inputnode, ds_mosaic_file, [(inputnode_anat_name, "source_file")]),
-            (make_mosaic_node, ds_mosaic_file, [("mosaic_file", "in_file")]),
+            (inputnode, ds_report_mosaic_file, [(inputnode_anat_name, "source_file")]),
+            (make_mosaic_node, ds_report_mosaic_file, [("mosaic_file", "in_file")]),
         ])  # fmt:skip
 
         # Start working on the selected PNG images for the button
@@ -242,22 +238,20 @@ def init_brainsprite_figures_wf(t1w_available, t2w_available, name="brainsprite_
             ]),
         ])  # fmt:skip
 
-        ds_scenewise_pngs = pe.MapNode(
+        ds_report_scenewise_pngs = pe.MapNode(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=["desc"],
-                datatype="figures",
                 suffix=f"{image_type}w",
             ),
-            name=f"ds_scenewise_pngs_{image_type}",
+            name=f"ds_report_scenewise_pngs_{image_type}",
             run_without_submitting=False,
             iterfield=["desc", "in_file"],
             mem_gb=config.DEFAULT_MEMORY_MIN_GB,
         )
         workflow.connect([
-            (inputnode, ds_scenewise_pngs, [(inputnode_anat_name, "source_file")]),
-            (get_png_scene_names, ds_scenewise_pngs, [("scene_descriptions", "desc")]),
-            (create_scenewise_pngs, ds_scenewise_pngs, [("out_file", "in_file")]),
+            (inputnode, ds_report_scenewise_pngs, [(inputnode_anat_name, "source_file")]),
+            (get_png_scene_names, ds_report_scenewise_pngs, [("scene_descriptions", "desc")]),
+            (create_scenewise_pngs, ds_report_scenewise_pngs, [("out_file", "in_file")]),
         ])  # fmt:skip
 
     return workflow

--- a/xcp_d/workflows/anatomical/surface.py
+++ b/xcp_d/workflows/anatomical/surface.py
@@ -117,7 +117,7 @@ def init_postprocess_surfaces_wf(
 
     abcc_qc = config.workflow.abcc_qc
     process_surfaces = config.workflow.process_surfaces
-    output_dir = config.execution.xcp_d_dir
+    output_dir = config.execution.output_dir
     omp_nthreads = config.nipype.omp_nthreads
 
     inputnode = pe.Node(
@@ -456,7 +456,6 @@ def init_warp_surfaces_to_template_wf(
 
         ds_standard_space_surfaces = pe.MapNode(
             DerivativesDataSink(
-                base_directory=output_dir,
                 space="fsLR",
                 den="32k",
                 extension=".surf.gii",  # the extension is taken from the in_file by default
@@ -508,8 +507,6 @@ def init_generate_hcp_surfaces_wf(name="generate_hcp_surfaces_wf"):
     """
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
-
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
@@ -542,7 +539,6 @@ def init_generate_hcp_surfaces_wf(name="generate_hcp_surfaces_wf"):
 
     ds_midthickness = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             check_hdr=False,
             space="fsLR",
             den="32k",
@@ -575,7 +571,6 @@ def init_generate_hcp_surfaces_wf(name="generate_hcp_surfaces_wf"):
 
     ds_inflated = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             check_hdr=False,
             space="fsLR",
             den="32k",
@@ -594,7 +589,6 @@ def init_generate_hcp_surfaces_wf(name="generate_hcp_surfaces_wf"):
 
     ds_vinflated = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             check_hdr=False,
             space="fsLR",
             den="32k",

--- a/xcp_d/workflows/anatomical/surface.py
+++ b/xcp_d/workflows/anatomical/surface.py
@@ -117,7 +117,6 @@ def init_postprocess_surfaces_wf(
 
     abcc_qc = config.workflow.abcc_qc
     process_surfaces = config.workflow.process_surfaces
-    output_dir = config.execution.output_dir
     omp_nthreads = config.nipype.omp_nthreads
 
     inputnode = pe.Node(
@@ -249,7 +248,6 @@ def init_postprocess_surfaces_wf(
         workflow.__desc__ += " fsnative-space surfaces were then warped to fsLR space."
         # Mesh files are in fsnative and must be warped to fsLR.
         warp_surfaces_to_template_wf = init_warp_surfaces_to_template_wf(
-            output_dir=output_dir,
             software=software,
             omp_nthreads=omp_nthreads,
             name="warp_surfaces_to_template_wf",
@@ -296,7 +294,6 @@ def init_postprocess_surfaces_wf(
 
 @fill_doc
 def init_warp_surfaces_to_template_wf(
-    output_dir,
     software,
     omp_nthreads,
     name="warp_surfaces_to_template_wf",
@@ -311,7 +308,6 @@ def init_warp_surfaces_to_template_wf(
             from xcp_d.workflows.anatomical.surface import init_warp_surfaces_to_template_wf
 
             wf = init_warp_surfaces_to_template_wf(
-                output_dir=".",
                 software="FreeSurfer",
                 omp_nthreads=1,
                 name="warp_surfaces_to_template_wf",
@@ -319,7 +315,6 @@ def init_warp_surfaces_to_template_wf(
 
     Parameters
     ----------
-    %(output_dir)s
     software : {"MCRIBS", "FreeSurfer"}
         The software used to generate the surfaces.
     %(omp_nthreads)s

--- a/xcp_d/workflows/anatomical/volume.py
+++ b/xcp_d/workflows/anatomical/volume.py
@@ -76,7 +76,6 @@ def init_postprocess_anat_wf(
         Path to the preprocessed T2w file in standard space.
     """
     workflow = Workflow(name=name)
-    output_dir = config.execution.xcp_d_dir
     input_type = config.workflow.input_type
 
     inputnode = pe.Node(
@@ -109,7 +108,6 @@ def init_postprocess_anat_wf(
     if t1w_available:
         ds_t1w_std = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 space=target_space,
                 cohort=cohort,
                 extension=".nii.gz",
@@ -125,7 +123,6 @@ def init_postprocess_anat_wf(
     if t2w_available:
         ds_t2w_std = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 space=target_space,
                 cohort=cohort,
                 extension=".nii.gz",

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -78,7 +78,7 @@ def init_xcpd_wf():
         single_subject_wf = init_single_subject_wf(subject_id)
 
         single_subject_wf.config["execution"]["crashdump_dir"] = str(
-            config.execution.xcp_d_dir / f"sub-{subject_id}" / "log" / config.execution.run_uuid
+            config.execution.output_dir / f"sub-{subject_id}" / "log" / config.execution.run_uuid
         )
         for node in single_subject_wf._get_all_nodes():
             node.config = deepcopy(single_subject_wf.config)
@@ -87,7 +87,7 @@ def init_xcpd_wf():
 
         # Dump a copy of the config file into the log directory
         log_dir = (
-            config.execution.xcp_d_dir / f"sub-{subject_id}" / "log" / config.execution.run_uuid
+            config.execution.output_dir / f"sub-{subject_id}" / "log" / config.execution.run_uuid
         )
         log_dir.mkdir(exist_ok=True, parents=True)
         config.to_filename(log_dir / "xcp_d.toml")
@@ -257,9 +257,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
 
     ds_report_summary = pe.Node(
         DerivativesDataSink(
-            base_directory=config.execution.xcp_d_dir,
             source_file=preproc_files[0],
-            datatype="figures",
             desc="summary",
         ),
         name="ds_report_summary",
@@ -267,10 +265,8 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
 
     ds_report_about = pe.Node(
         DerivativesDataSink(
-            base_directory=config.execution.xcp_d_dir,
             source_file=preproc_files[0],
             desc="about",
-            datatype="figures",
         ),
         name="ds_report_about",
         run_without_submitting=True,
@@ -540,7 +536,12 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
     ])  # fmt:skip
 
     for node in workflow.list_node_names():
-        if node.split(".")[-1].startswith("ds_"):
+        node_name = node.split(".")[-1]
+        if node_name.startswith("ds_"):
             workflow.get_node(node).interface.out_path_base = ""
+            workflow.get_node(node).interface.inputs.base_directory = config.execution.output_dir
+
+        if node_name.startswith("ds_report_"):
+            workflow.get_node(node).interface.inputs.datatype = "figures"
 
     return workflow

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -535,6 +535,11 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
         (about, ds_report_about, [("out_report", "in_file")]),
     ])  # fmt:skip
 
+    return clean_datasinks(workflow)
+
+
+def clean_datasinks(workflow):
+    """Clean DerivativesDataSinks in a workflow."""
     for node in workflow.list_node_names():
         node_name = node.split(".")[-1]
         if node_name.startswith("ds_"):

--- a/xcp_d/workflows/bold/concatenation.py
+++ b/xcp_d/workflows/bold/concatenation.py
@@ -74,7 +74,7 @@ def init_concatenate_data_wf(TR, head_radius, name="concatenate_data_wf"):
     """
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
+    output_dir = config.execution.output_dir
     motion_filter_type = config.workflow.motion_filter_type
     smoothing = config.workflow.smoothing
     file_format = config.workflow.file_format
@@ -190,7 +190,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
 
     ds_filtered_motion = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             dismiss_entities=["segmentation", "den", "res", "space", "cohort", "desc"],
             desc="filtered" if motion_filter_type else None,
             suffix="motion",
@@ -211,7 +210,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
     if fd_thresh > 0:
         ds_temporal_mask = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=["segmentation", "den", "res", "space", "cohort", "desc"],
                 suffix="outliers",
                 extension=".tsv",
@@ -232,7 +230,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
     if file_format == "cifti":
         ds_denoised_bold = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=["den"],
                 desc="denoised",
                 den="91k",
@@ -246,7 +243,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
         if smoothing:
             ds_smoothed_denoised_bold = pe.Node(
                 DerivativesDataSink(
-                    base_directory=output_dir,
                     dismiss_entities=["den"],
                     desc="denoisedSmoothed",
                     den="91k",
@@ -260,7 +256,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
     else:
         ds_denoised_bold = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 desc="denoised",
                 extension=".nii.gz",
                 compression=True,
@@ -273,7 +268,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
         if smoothing:
             ds_smoothed_denoised_bold = pe.Node(
                 DerivativesDataSink(
-                    base_directory=output_dir,
                     desc="denoisedSmoothed",
                     extension=".nii.gz",
                     compression=True,
@@ -323,7 +317,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
 
         ds_timeseries = pe.MapNode(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=["desc", "den", "res"],
                 statistic="mean",
                 suffix="timeseries",
@@ -377,7 +370,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
 
         ds_correlations = pe.MapNode(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=["desc"],
                 statistic="pearsoncorrelation",
                 suffix="relmat",
@@ -416,7 +408,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
 
             ds_timeseries_cifti_files = pe.MapNode(
                 DerivativesDataSink(
-                    base_directory=output_dir,
                     check_hdr=False,
                     dismiss_entities=["desc", "den"],
                     den="91k",

--- a/xcp_d/workflows/bold/connectivity.py
+++ b/xcp_d/workflows/bold/connectivity.py
@@ -69,7 +69,6 @@ def init_functional_connectivity_nifti_wf(mem_gb, name="connectivity_wf"):
 
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
     bandpass_filter = config.workflow.bandpass_filter
     min_coverage = config.workflow.min_coverage
 
@@ -163,18 +162,16 @@ or were set to zero (when the parcel had <{min_coverage * 100}% coverage).
             (functional_connectivity, connectivity_plot, [("correlations", "correlations_tsv")]),
         ])  # fmt:skip
 
-        ds_connectivity_plot = pe.Node(
+        ds_report_connectivity_plot = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 desc="connectivityplot",
-                datatype="figures",
             ),
-            name="ds_connectivity_plot",
+            name="ds_report_connectivity_plot",
             run_without_submitting=False,
         )
         workflow.connect([
-            (inputnode, ds_connectivity_plot, [("name_source", "source_file")]),
-            (connectivity_plot, ds_connectivity_plot, [("connectplot", "in_file")]),
+            (inputnode, ds_report_connectivity_plot, [("name_source", "source_file")]),
+            (connectivity_plot, ds_report_connectivity_plot, [("connectplot", "in_file")]),
         ])  # fmt:skip
 
     parcellate_reho = pe.MapNode(
@@ -281,7 +278,6 @@ def init_functional_connectivity_cifti_wf(mem_gb, exact_scans, name="connectivit
 
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
     bandpass_filter = config.workflow.bandpass_filter
     min_coverage = config.workflow.min_coverage
 
@@ -375,17 +371,14 @@ or were set to zero (when the parcel had <{min_coverage * 100}% coverage).
             (parcellate_bold_wf, plot_coverage, [("outputnode.coverage_cifti", "in_files")]),
         ])  # fmt:skip
 
-        ds_plot_coverage = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                datatype="figures",
-            ),
-            name="ds_plot_coverage",
+        ds_report_coverage = pe.Node(
+            DerivativesDataSink(),
+            name="ds_report_coverage",
             run_without_submitting=False,
         )
         workflow.connect([
-            (inputnode, ds_plot_coverage, [("name_source", "source_file")]),
-            (plot_coverage, ds_plot_coverage, [
+            (inputnode, ds_report_coverage, [("name_source", "source_file")]),
+            (plot_coverage, ds_report_coverage, [
                 ("out_file", "in_file"),
                 ("desc", "desc"),
             ]),
@@ -456,19 +449,17 @@ or were set to zero (when the parcel had <{min_coverage * 100}% coverage).
             (dconn_to_tsv, connectivity_plot, [("out_file", "correlations_tsv")]),
         ])  # fmt:skip
 
-        ds_connectivity_plot = pe.Node(
+        ds_report_connectivity = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 desc="connectivityplot",
-                datatype="figures",
             ),
-            name="ds_connectivity_plot",
+            name="ds_report_connectivity",
             run_without_submitting=False,
             mem_gb=0.1,
         )
         workflow.connect([
-            (inputnode, ds_connectivity_plot, [("name_source", "source_file")]),
-            (connectivity_plot, ds_connectivity_plot, [("connectplot", "in_file")]),
+            (inputnode, ds_report_connectivity, [("name_source", "source_file")]),
+            (connectivity_plot, ds_report_connectivity, [("connectplot", "in_file")]),
         ])  # fmt:skip
 
     # Perform exact-time correlations
@@ -561,17 +552,14 @@ or were set to zero (when the parcel had <{min_coverage * 100}% coverage).
             ]),
         ])  # fmt:skip
 
-        ds_plot_reho = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                datatype="figures",
-            ),
-            name="ds_plot_reho",
+        ds_report_reho = pe.Node(
+            DerivativesDataSink(),
+            name="ds_report_reho",
             run_without_submitting=False,
         )
         workflow.connect([
-            (inputnode, ds_plot_reho, [("name_source", "source_file")]),
-            (plot_parcellated_reho, ds_plot_reho, [
+            (inputnode, ds_report_reho, [("name_source", "source_file")]),
+            (plot_parcellated_reho, ds_report_reho, [
                 ("desc", "desc"),
                 ("out_file", "in_file"),
             ]),
@@ -616,17 +604,14 @@ or were set to zero (when the parcel had <{min_coverage * 100}% coverage).
                 ]),
             ])  # fmt:skip
 
-            ds_plot_alff = pe.Node(
-                DerivativesDataSink(
-                    base_directory=output_dir,
-                    datatype="figures",
-                ),
-                name="ds_plot_alff",
+            ds_report_alff = pe.Node(
+                DerivativesDataSink(),
+                name="ds_report_alff",
                 run_without_submitting=False,
             )
             workflow.connect([
-                (inputnode, ds_plot_alff, [("name_source", "source_file")]),
-                (plot_parcellated_alff, ds_plot_alff, [
+                (inputnode, ds_report_alff, [("name_source", "source_file")]),
+                (plot_parcellated_alff, ds_report_alff, [
                     ("out_file", "in_file"),
                     ("desc", "desc"),
                 ]),

--- a/xcp_d/workflows/bold/metrics.py
+++ b/xcp_d/workflows/bold/metrics.py
@@ -95,7 +95,6 @@ def init_alff_wf(
     """
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
     low_pass = config.workflow.low_pass
     high_pass = config.workflow.high_pass
     fd_thresh = config.workflow.fd_thresh
@@ -161,13 +160,11 @@ series to retain the original scaling.
     ])  # fmt:skip
 
     # Plot the ALFF map
-    ds_alff_plot = pe.Node(
+    ds_report_alff = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             source_file=name_source,
-            datatype="figures",
         ),
-        name="ds_alff_plot",
+        name="ds_report_alff",
         run_without_submitting=False,
     )
 
@@ -181,18 +178,18 @@ series to retain the original scaling.
                 ("lh_midthickness", "lh_underlay"),
                 ("rh_midthickness", "rh_underlay"),
             ]),
-            (alff_plot, ds_alff_plot, [("desc", "desc")]),
+            (alff_plot, ds_report_alff, [("desc", "desc")]),
         ])  # fmt:skip
     else:
         alff_plot = pe.Node(
             PlotNifti(name_source=name_source),
             name="alff_plot",
         )
-        ds_alff_plot.inputs.desc = "alffVolumetricPlot"
+        ds_report_alff.inputs.desc = "alffVolumetricPlot"
 
     workflow.connect([
         (alff_compt, alff_plot, [("alff", "in_file")]),
-        (alff_plot, ds_alff_plot, [("out_file", "in_file")]),
+        (alff_plot, ds_report_alff, [("out_file", "in_file")]),
     ])  # fmt:skip
 
     if smoothing:  # If we want to smooth
@@ -316,8 +313,6 @@ For the subcortical, volumetric data, ReHo was computed with neighborhood voxels
 *3dReHo* [@taylor2013fatcat].
 """
 
-    output_dir = config.execution.xcp_d_dir
-
     inputnode = pe.Node(
         niu.IdentityInterface(fields=["denoised_bold", "lh_midthickness", "rh_midthickness"]),
         name="inputnode",
@@ -397,13 +392,11 @@ For the subcortical, volumetric data, ReHo was computed with neighborhood voxels
         ]),
     ])  # fmt:skip
 
-    ds_reho_plot = pe.Node(
+    ds_report_reho = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             source_file=name_source,
-            datatype="figures",
         ),
-        name="ds_reho_plot",
+        name="ds_report_reho",
         run_without_submitting=False,
     )
 
@@ -421,7 +414,7 @@ For the subcortical, volumetric data, ReHo was computed with neighborhood voxels
         (subcortical_reho, merge_cifti, [("out_file", "volume_all")]),
         (merge_cifti, outputnode, [("out_file", "reho")]),
         (merge_cifti, reho_plot, [("out_file", "in_file")]),
-        (reho_plot, ds_reho_plot, [
+        (reho_plot, ds_report_reho, [
             ("out_file", "in_file"),
             ("desc", "desc"),
         ]),
@@ -473,8 +466,6 @@ def init_reho_nifti_wf(name_source, mem_gb, name="reho_nifti_wf"):
     """
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
-
     workflow.__desc__ = """
 Regional homogeneity (ReHo) [@jiang2016regional] was computed with neighborhood voxels using
 *AFNI*'s *3dReHo* [@taylor2013fatcat].
@@ -499,14 +490,12 @@ Regional homogeneity (ReHo) [@jiang2016regional] was computed with neighborhood 
         name="reho_nifti_plot",
     )
 
-    ds_reho_plot = pe.Node(
+    ds_report_reho = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             source_file=name_source,
             desc="rehoVolumetricPlot",
-            datatype="figures",
         ),
-        name="ds_reho_plot",
+        name="ds_report_reho",
         run_without_submitting=False,
     )
 
@@ -518,7 +507,7 @@ Regional homogeneity (ReHo) [@jiang2016regional] was computed with neighborhood 
         ]),
         (compute_reho, outputnode, [("out_file", "reho")]),
         (compute_reho, reho_plot, [("out_file", "in_file")]),
-        (reho_plot, ds_reho_plot, [("out_file", "in_file")]),
+        (reho_plot, ds_report_reho, [("out_file", "in_file")]),
     ])  # fmt:skip
 
     return workflow

--- a/xcp_d/workflows/bold/outputs.py
+++ b/xcp_d/workflows/bold/outputs.py
@@ -99,7 +99,7 @@ def init_postproc_derivatives_wf(
     params = config.workflow.params
     atlases = config.execution.atlases
     file_format = config.workflow.file_format
-    output_dir = config.execution.xcp_d_dir
+    output_dir = config.execution.output_dir
 
     inputnode = pe.Node(
         niu.IdentityInterface(
@@ -186,7 +186,6 @@ def init_postproc_derivatives_wf(
 
     ds_filtered_motion = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             source_file=name_source,
             dismiss_entities=["segmentation", "den", "res", "space", "cohort", "desc"],
             desc="filtered" if motion_filter_type else None,
@@ -217,7 +216,6 @@ def init_postproc_derivatives_wf(
     if fd_thresh > 0:
         ds_temporal_mask = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=["segmentation", "den", "res", "space", "cohort", "desc"],
                 suffix="outliers",
                 extension=".tsv",
@@ -268,7 +266,6 @@ def init_postproc_derivatives_wf(
 
         ds_confounds = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 source_file=name_source,
                 dismiss_entities=["space", "cohort", "den", "res"],
                 datatype="func",
@@ -292,7 +289,6 @@ def init_postproc_derivatives_wf(
     # Write out derivatives via DerivativesDataSink
     ds_denoised_bold = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             source_file=name_source,
             dismiss_entities=["den"],
             cohort=cohort,
@@ -316,7 +312,6 @@ def init_postproc_derivatives_wf(
     if config.workflow.linc_qc:
         ds_qc_file = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 source_file=name_source,
                 dismiss_entities=["desc", "den", "res"],
                 cohort=cohort,
@@ -335,7 +330,6 @@ def init_postproc_derivatives_wf(
         # Write out derivatives via DerivativesDataSink
         ds_smoothed_bold = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 source_file=name_source,
                 dismiss_entities=["den"],
                 cohort=cohort,
@@ -400,7 +394,6 @@ def init_postproc_derivatives_wf(
         # TODO: Add brain mask to Sources (for NIfTIs).
         ds_coverage = pe.MapNode(
             DerivativesDataSink(
-                base_directory=output_dir,
                 source_file=name_source,
                 dismiss_entities=["desc", "den", "res"],
                 cohort=cohort,
@@ -439,7 +432,6 @@ def init_postproc_derivatives_wf(
 
         ds_timeseries = pe.MapNode(
             DerivativesDataSink(
-                base_directory=output_dir,
                 source_file=name_source,
                 dismiss_entities=["desc", "den", "res"],
                 cohort=cohort,
@@ -484,7 +476,6 @@ def init_postproc_derivatives_wf(
 
             ds_correlations = pe.MapNode(
                 DerivativesDataSink(
-                    base_directory=output_dir,
                     source_file=name_source,
                     dismiss_entities=["desc", "den", "res"],
                     cohort=cohort,
@@ -512,7 +503,6 @@ def init_postproc_derivatives_wf(
         if file_format == "cifti":
             ds_coverage_ciftis = pe.MapNode(
                 DerivativesDataSink(
-                    base_directory=output_dir,
                     source_file=name_source,
                     check_hdr=False,
                     dismiss_entities=["desc"],
@@ -552,7 +542,6 @@ def init_postproc_derivatives_wf(
 
             ds_timeseries_ciftis = pe.MapNode(
                 DerivativesDataSink(
-                    base_directory=output_dir,
                     source_file=name_source,
                     check_hdr=False,
                     dismiss_entities=["desc", "den"],
@@ -597,7 +586,6 @@ def init_postproc_derivatives_wf(
 
                 ds_correlation_ciftis = pe.MapNode(
                     DerivativesDataSink(
-                        base_directory=output_dir,
                         source_file=name_source,
                         check_hdr=False,
                         dismiss_entities=["desc", "den"],
@@ -638,7 +626,6 @@ def init_postproc_derivatives_wf(
 
             ds_correlations_exact = pe.MapNode(
                 DerivativesDataSink(
-                    base_directory=output_dir,
                     source_file=name_source,
                     dismiss_entities=["desc", "den", "res"],
                     cohort=cohort,
@@ -660,7 +647,6 @@ def init_postproc_derivatives_wf(
     # Resting state metric outputs
     ds_reho = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             source_file=name_source,
             check_hdr=False,
             dismiss_entities=["desc", "den"],
@@ -701,7 +687,6 @@ def init_postproc_derivatives_wf(
 
         ds_parcellated_reho = pe.MapNode(
             DerivativesDataSink(
-                base_directory=output_dir,
                 source_file=name_source,
                 dismiss_entities=["desc", "den", "res"],
                 cohort=cohort,
@@ -726,7 +711,6 @@ def init_postproc_derivatives_wf(
     if bandpass_filter:
         ds_alff = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 source_file=name_source,
                 check_hdr=False,
                 dismiss_entities=["desc", "den"],
@@ -750,7 +734,6 @@ def init_postproc_derivatives_wf(
         if smoothing:
             ds_smoothed_alff = pe.Node(
                 DerivativesDataSink(
-                    base_directory=output_dir,
                     source_file=name_source,
                     dismiss_entities=["den"],
                     cohort=cohort,
@@ -796,7 +779,6 @@ def init_postproc_derivatives_wf(
 
             ds_parcellated_alff = pe.MapNode(
                 DerivativesDataSink(
-                    base_directory=output_dir,
                     source_file=name_source,
                     dismiss_entities=["desc", "den", "res"],
                     cohort=cohort,

--- a/xcp_d/workflows/bold/plotting.py
+++ b/xcp_d/workflows/bold/plotting.py
@@ -86,8 +86,6 @@ def init_qc_report_wf(
     """
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
-
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
@@ -314,7 +312,6 @@ def init_qc_report_wf(
 
         ds_qc_metadata = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=list(DerivativesDataSink._allowed_entities),
                 allowed_entities=["desc"],
                 desc="linc",
@@ -351,32 +348,24 @@ def init_qc_report_wf(
         else:
             make_qc_plots_nipreps.inputs.mask_file = None
 
-        ds_preproc_qc_plot_nipreps = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                desc="preprocessing",
-                datatype="figures",
-            ),
-            name="ds_preproc_qc_plot_nipreps",
+        ds_report_preproc_qc_nipreps = pe.Node(
+            DerivativesDataSink(desc="preprocessing"),
+            name="ds_report_preproc_qc_nipreps",
             run_without_submitting=False,
         )
         workflow.connect([
-            (inputnode, ds_preproc_qc_plot_nipreps, [("name_source", "source_file")]),
-            (make_qc_plots_nipreps, ds_preproc_qc_plot_nipreps, [("raw_qcplot", "in_file")]),
+            (inputnode, ds_report_preproc_qc_nipreps, [("name_source", "source_file")]),
+            (make_qc_plots_nipreps, ds_report_preproc_qc_nipreps, [("raw_qcplot", "in_file")]),
         ])  # fmt:skip
 
-        ds_postproc_qc_plot_nipreps = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                desc="postprocessing",
-                datatype="figures",
-            ),
-            name="ds_postproc_qc_plot_nipreps",
+        ds_report_postproc_qc_nipreps = pe.Node(
+            DerivativesDataSink(desc="postprocessing"),
+            name="ds_report_postproc_qc_nipreps",
             run_without_submitting=False,
         )
         workflow.connect([
-            (inputnode, ds_postproc_qc_plot_nipreps, [("name_source", "source_file")]),
-            (make_qc_plots_nipreps, ds_postproc_qc_plot_nipreps, [("clean_qcplot", "in_file")]),
+            (inputnode, ds_report_postproc_qc_nipreps, [("name_source", "source_file")]),
+            (make_qc_plots_nipreps, ds_report_postproc_qc_nipreps, [("clean_qcplot", "in_file")]),
         ])  # fmt:skip
 
         functional_qc = pe.Node(
@@ -391,11 +380,7 @@ def init_qc_report_wf(
         ])  # fmt:skip
 
         ds_report_qualitycontrol = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                desc="qualitycontrol",
-                datatype="figures",
-            ),
+            DerivativesDataSink(desc="qualitycontrol"),
             name="ds_report_qualitycontrol",
             run_without_submitting=False,
         )
@@ -417,7 +402,6 @@ def init_qc_report_wf(
 
         ds_abcc_qc = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 datatype="func",
                 desc="abcc",
                 suffix="qc",
@@ -453,34 +437,30 @@ def init_qc_report_wf(
                 (warp_dseg_to_bold, make_qc_plots_es, [("output_image", "seg_data")]),
             ])  # fmt:skip
 
-        ds_preproc_qc_plot_es = pe.Node(
+        ds_report_preproc_qc_es = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=["den"],
-                datatype="figures",
                 desc="preprocESQC",
             ),
-            name="ds_preproc_qc_plot_es",
+            name="ds_report_preproc_qc_es",
             run_without_submitting=True,
         )
         workflow.connect([
-            (inputnode, ds_preproc_qc_plot_es, [("name_source", "source_file")]),
-            (make_qc_plots_es, ds_preproc_qc_plot_es, [("before_process", "in_file")]),
+            (inputnode, ds_report_preproc_qc_es, [("name_source", "source_file")]),
+            (make_qc_plots_es, ds_report_preproc_qc_es, [("before_process", "in_file")]),
         ])  # fmt:skip
 
-        ds_postproc_qc_plot_es = pe.Node(
+        ds_report_postproc_qc_es = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=["den"],
-                datatype="figures",
                 desc="postprocESQC",
             ),
-            name="ds_postproc_qc_plot_es",
+            name="ds_report_postproc_qc_es",
             run_without_submitting=True,
         )
         workflow.connect([
-            (inputnode, ds_postproc_qc_plot_es, [("name_source", "source_file")]),
-            (make_qc_plots_es, ds_postproc_qc_plot_es, [("after_process", "in_file")]),
+            (inputnode, ds_report_postproc_qc_es, [("name_source", "source_file")]),
+            (make_qc_plots_es, ds_report_postproc_qc_es, [("after_process", "in_file")]),
         ])  # fmt:skip
 
     return workflow
@@ -541,7 +521,6 @@ def init_execsummary_functional_plots_wf(
     """
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
     layout = config.execution.layout
 
     inputnode = pe.Node(
@@ -586,20 +565,18 @@ def init_execsummary_functional_plots_wf(
     else:
         bold_t1w_registration_file = bold_t1w_registration_files[0]
 
-        ds_registration_figure = pe.Node(
+        ds_report_registration = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 in_file=bold_t1w_registration_file,
                 dismiss_entities=["den"],
-                datatype="figures",
                 desc="bbregister",
             ),
-            name="ds_registration_figure",
+            name="ds_report_registration",
             run_without_submitting=True,
             mem_gb=config.DEFAULT_MEMORY_MIN_GB,
         )
 
-        workflow.connect([(inputnode, ds_registration_figure, [("preproc_nifti", "source_file")])])
+        workflow.connect([(inputnode, ds_report_registration, [("preproc_nifti", "source_file")])])
 
     # Calculate the mean bold image
     calculate_mean_bold = pe.Node(
@@ -614,20 +591,18 @@ def init_execsummary_functional_plots_wf(
     workflow.connect([(calculate_mean_bold, plot_meanbold, [("out_file", "in_file")])])
 
     # Write out the figures.
-    ds_meanbold_figure = pe.Node(
+    ds_report_meanbold = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             dismiss_entities=["den"],
-            datatype="figures",
             desc="mean",
         ),
-        name="ds_meanbold_figure",
+        name="ds_report_meanbold",
         run_without_submitting=True,
         mem_gb=config.DEFAULT_MEMORY_MIN_GB,
     )
     workflow.connect([
-        (inputnode, ds_meanbold_figure, [("preproc_nifti", "source_file")]),
-        (plot_meanbold, ds_meanbold_figure, [("out_file", "in_file")]),
+        (inputnode, ds_report_meanbold, [("preproc_nifti", "source_file")]),
+        (plot_meanbold, ds_report_meanbold, [("out_file", "in_file")]),
     ])  # fmt:skip
 
     # Plot the reference bold image
@@ -635,20 +610,18 @@ def init_execsummary_functional_plots_wf(
     workflow.connect([(inputnode, plot_boldref, [("boldref", "in_file")])])
 
     # Write out the figures.
-    ds_boldref_figure = pe.Node(
+    ds_report_boldref = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             dismiss_entities=["den"],
-            datatype="figures",
             desc="boldref",
         ),
-        name="ds_boldref_figure",
+        name="ds_report_boldref",
         run_without_submitting=True,
         mem_gb=config.DEFAULT_MEMORY_MIN_GB,
     )
     workflow.connect([
-        (inputnode, ds_boldref_figure, [("preproc_nifti", "source_file")]),
-        (plot_boldref, ds_boldref_figure, [("out_file", "in_file")]),
+        (inputnode, ds_report_boldref, [("preproc_nifti", "source_file")]),
+        (plot_boldref, ds_report_boldref, [("out_file", "in_file")]),
     ])  # fmt:skip
 
     # Start plotting the overlay figures

--- a/xcp_d/workflows/bold/postprocessing.py
+++ b/xcp_d/workflows/bold/postprocessing.py
@@ -98,7 +98,6 @@ def init_prepare_confounds_wf(
     """
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
     params = config.workflow.params
     dummy_scans = config.workflow.dummy_scans
     random_seed = config.seeds.master
@@ -324,21 +323,19 @@ def init_prepare_confounds_wf(
             (outputnode, plot_design_matrix, [("temporal_mask", "temporal_mask")]),
         ])  # fmt:skip
 
-        ds_design_matrix_plot = pe.Node(
+        ds_report_design_matrix = pe.Node(
             DerivativesDataSink(
-                base_directory=output_dir,
                 dismiss_entities=["space", "res", "den", "desc"],
-                datatype="figures",
                 suffix="design",
                 extension=".svg",
             ),
-            name="ds_design_matrix_plot",
+            name="ds_report_design_matrix",
             run_without_submitting=False,
         )
 
         workflow.connect([
-            (inputnode, ds_design_matrix_plot, [("name_source", "source_file")]),
-            (plot_design_matrix, ds_design_matrix_plot, [("design_matrix_figure", "in_file")]),
+            (inputnode, ds_report_design_matrix, [("name_source", "source_file")]),
+            (plot_design_matrix, ds_report_design_matrix, [("design_matrix_figure", "in_file")]),
         ])  # fmt:skip
 
     censor_report = pe.Node(
@@ -362,8 +359,6 @@ def init_prepare_confounds_wf(
 
     ds_report_censoring = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
-            datatype="figures",
             desc="censoring",
             suffix="motion",
             extension=".svg",

--- a/xcp_d/workflows/parcellation.py
+++ b/xcp_d/workflows/parcellation.py
@@ -136,45 +136,45 @@ def init_load_atlases_wf(name="load_atlases_wf"):
     else:
         workflow.connect([(atlas_file_grabber, atlas_buffer, [("atlas_file", "atlas_file")])])
 
-    ds_atlas = pe.MapNode(
+    copy_atlas = pe.MapNode(
         CopyAtlas(output_dir=output_dir),
-        name="ds_atlas",
+        name="copy_atlas",
         iterfield=["in_file", "atlas"],
         run_without_submitting=True,
     )
-    ds_atlas.inputs.atlas = atlases
+    copy_atlas.inputs.atlas = atlases
 
     workflow.connect([
-        (inputnode, ds_atlas, [("name_source", "name_source")]),
-        (atlas_buffer, ds_atlas, [("atlas_file", "in_file")]),
-        (ds_atlas, outputnode, [("out_file", "atlas_files")]),
+        (inputnode, copy_atlas, [("name_source", "name_source")]),
+        (atlas_buffer, copy_atlas, [("atlas_file", "in_file")]),
+        (copy_atlas, outputnode, [("out_file", "atlas_files")]),
     ])  # fmt:skip
 
-    ds_atlas_labels_file = pe.MapNode(
+    copy_atlas_labels_file = pe.MapNode(
         CopyAtlas(output_dir=output_dir),
-        name="ds_atlas_labels_file",
+        name="copy_atlas_labels_file",
         iterfield=["in_file", "atlas"],
         run_without_submitting=True,
     )
-    ds_atlas_labels_file.inputs.atlas = atlases
+    copy_atlas_labels_file.inputs.atlas = atlases
 
     workflow.connect([
-        (inputnode, ds_atlas_labels_file, [("name_source", "name_source")]),
-        (atlas_file_grabber, ds_atlas_labels_file, [("atlas_labels_file", "in_file")]),
-        (ds_atlas_labels_file, outputnode, [("out_file", "atlas_labels_files")]),
+        (inputnode, copy_atlas_labels_file, [("name_source", "name_source")]),
+        (atlas_file_grabber, copy_atlas_labels_file, [("atlas_labels_file", "in_file")]),
+        (copy_atlas_labels_file, outputnode, [("out_file", "atlas_labels_files")]),
     ])  # fmt:skip
 
-    ds_atlas_metadata = pe.MapNode(
+    copy_atlas_metadata = pe.MapNode(
         CopyAtlas(output_dir=output_dir),
-        name="ds_atlas_metadata",
+        name="copy_atlas_metadata",
         iterfield=["in_file", "atlas"],
         run_without_submitting=True,
     )
-    ds_atlas_metadata.inputs.atlas = atlases
+    copy_atlas_metadata.inputs.atlas = atlases
 
     workflow.connect([
-        (inputnode, ds_atlas_metadata, [("name_source", "name_source")]),
-        (atlas_file_grabber, ds_atlas_metadata, [("atlas_metadata_file", "in_file")]),
+        (inputnode, copy_atlas_metadata, [("name_source", "name_source")]),
+        (atlas_file_grabber, copy_atlas_metadata, [("atlas_metadata_file", "in_file")]),
     ])  # fmt:skip
 
     return workflow

--- a/xcp_d/workflows/parcellation.py
+++ b/xcp_d/workflows/parcellation.py
@@ -52,7 +52,7 @@ def init_load_atlases_wf(name="load_atlases_wf"):
 
     workflow = Workflow(name=name)
     atlases = config.execution.atlases
-    output_dir = config.execution.xcp_d_dir
+    output_dir = config.execution.output_dir
     file_format = config.workflow.file_format
 
     inputnode = pe.Node(

--- a/xcp_d/workflows/plotting.py
+++ b/xcp_d/workflows/plotting.py
@@ -19,8 +19,6 @@ def init_plot_overlay_wf(desc, name="plot_overlay_wf"):
 
     workflow = Workflow(name=name)
 
-    output_dir = config.execution.xcp_d_dir
-
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
@@ -45,22 +43,20 @@ def init_plot_overlay_wf(desc, name="plot_overlay_wf"):
         ]),
     ])  # fmt:skip
 
-    ds_overlay_figure = pe.Node(
+    ds_report_overlay_figure = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             dismiss_entities=["den"],
-            datatype="figures",
             desc=desc,
             extension=".png",
         ),
-        name="ds_overlay_figure",
+        name="ds_report_overlay_figure",
         run_without_submitting=True,
         mem_gb=config.DEFAULT_MEMORY_MIN_GB,
     )
 
     workflow.connect([
-        (inputnode, ds_overlay_figure, [("name_source", "source_file")]),
-        (plot_overlay_figure, ds_overlay_figure, [("out_files", "in_file")]),
+        (inputnode, ds_report_overlay_figure, [("name_source", "source_file")]),
+        (plot_overlay_figure, ds_report_overlay_figure, [("out_files", "in_file")]),
     ])  # fmt:skip
 
     reformat_for_brain_swipes = pe.Node(FormatForBrainSwipes(), name="reformat_for_brain_swipes")
@@ -68,22 +64,20 @@ def init_plot_overlay_wf(desc, name="plot_overlay_wf"):
         (plot_overlay_figure, reformat_for_brain_swipes, [("slicewise_files", "in_files")]),
     ])  # fmt:skip
 
-    ds_reformatted_figure = pe.Node(
+    ds_report_reformatted_figure = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             dismiss_entities=["den"],
-            datatype="figures",
             desc=f"{desc}BrainSwipes",
             extension=".png",
         ),
-        name="ds_reformatted_figure",
+        name="ds_report_reformatted_figure",
         run_without_submitting=True,
         mem_gb=config.DEFAULT_MEMORY_MIN_GB,
     )
 
     workflow.connect([
-        (inputnode, ds_reformatted_figure, [("name_source", "source_file")]),
-        (reformat_for_brain_swipes, ds_reformatted_figure, [("out_file", "in_file")]),
+        (inputnode, ds_report_reformatted_figure, [("name_source", "source_file")]),
+        (reformat_for_brain_swipes, ds_report_reformatted_figure, [("out_file", "in_file")]),
     ])  # fmt:skip
 
     return workflow
@@ -91,7 +85,6 @@ def init_plot_overlay_wf(desc, name="plot_overlay_wf"):
 
 @fill_doc
 def init_plot_custom_slices_wf(
-    output_dir,
     desc,
     name="plot_custom_slices_wf",
 ):
@@ -108,7 +101,6 @@ def init_plot_custom_slices_wf(
             from xcp_d.workflows.execsummary import init_plot_custom_slices_wf
 
             wf = init_plot_custom_slices_wf(
-                output_dir=".",
                 desc="AtlasOnSubcorticals",
                 name="plot_custom_slices_wf",
             )
@@ -175,21 +167,19 @@ def init_plot_custom_slices_wf(
 
     workflow.connect([(make_image, combine_images, [("out_file", "in_files")])])
 
-    ds_overlay_figure = pe.Node(
+    ds_report_overlay_figure = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir,
             dismiss_entities=["den"],
-            datatype="figures",
             desc=desc,
             extension=".png",
         ),
-        name="ds_overlay_figure",
+        name="ds_report_overlay_figure",
         run_without_submitting=True,
         mem_gb=config.DEFAULT_MEMORY_MIN_GB,
     )
     workflow.connect([
-        (inputnode, ds_overlay_figure, [("name_source", "source_file")]),
-        (combine_images, ds_overlay_figure, [("out_file", "in_file")]),
+        (inputnode, ds_report_overlay_figure, [("name_source", "source_file")]),
+        (combine_images, ds_report_overlay_figure, [("out_file", "in_file")]),
     ])  # fmt:skip
 
     return workflow

--- a/xcp_d/workflows/plotting.py
+++ b/xcp_d/workflows/plotting.py
@@ -43,20 +43,20 @@ def init_plot_overlay_wf(desc, name="plot_overlay_wf"):
         ]),
     ])  # fmt:skip
 
-    ds_report_overlay_figure = pe.Node(
+    ds_report_overlay = pe.Node(
         DerivativesDataSink(
             dismiss_entities=["den"],
             desc=desc,
             extension=".png",
         ),
-        name="ds_report_overlay_figure",
+        name="ds_report_overlay",
         run_without_submitting=True,
         mem_gb=config.DEFAULT_MEMORY_MIN_GB,
     )
 
     workflow.connect([
-        (inputnode, ds_report_overlay_figure, [("name_source", "source_file")]),
-        (plot_overlay_figure, ds_report_overlay_figure, [("out_files", "in_file")]),
+        (inputnode, ds_report_overlay, [("name_source", "source_file")]),
+        (plot_overlay_figure, ds_report_overlay, [("out_files", "in_file")]),
     ])  # fmt:skip
 
     reformat_for_brain_swipes = pe.Node(FormatForBrainSwipes(), name="reformat_for_brain_swipes")
@@ -167,19 +167,19 @@ def init_plot_custom_slices_wf(
 
     workflow.connect([(make_image, combine_images, [("out_file", "in_files")])])
 
-    ds_report_overlay_figure = pe.Node(
+    ds_report_overlay = pe.Node(
         DerivativesDataSink(
             dismiss_entities=["den"],
             desc=desc,
             extension=".png",
         ),
-        name="ds_report_overlay_figure",
+        name="ds_report_overlay",
         run_without_submitting=True,
         mem_gb=config.DEFAULT_MEMORY_MIN_GB,
     )
     workflow.connect([
-        (inputnode, ds_report_overlay_figure, [("name_source", "source_file")]),
-        (combine_images, ds_report_overlay_figure, [("out_file", "in_file")]),
+        (inputnode, ds_report_overlay, [("name_source", "source_file")]),
+        (combine_images, ds_report_overlay, [("out_file", "in_file")]),
     ])  # fmt:skip
 
     return workflow


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Drop config.execution.xcp_d_dir in favor of the existing config.execution.output_dir.
- Rename any figure-generating datasinks to start with `ds_report_` and drop `datatype="figures"`.
- Loop over nodes and automatically set `datatype` to `"figures"` for nodes starting with `ds_report_`.
- Loop over nodes and automatically set `base_directory` to `config.execution.output_dir` for nodes starting with `ds_`.