### PR TITLE
Don't rerun alff if num threads changes

### DIFF
--- a/xcp_d/interfaces/restingstate.py
+++ b/xcp_d/interfaces/restingstate.py
@@ -111,6 +111,7 @@ class _ComputeALFFInputSpec(BaseInterfaceInputSpec):
         1,
         usedefault=True,
         desc="number of threads to use",
+        nohash=True,
     )
 
 


### PR DESCRIPTION
The `n_threads` input shouldn't trigger a re-run if it changes. This prevents that from happening