### PR TITLE
Bump Docker deployment version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,7 +543,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker24
           docker_layer_caching: true
       - run:
           name: Build Docker image


### PR DESCRIPTION
Apparently 19.03.13 is no longer available.
