### PR TITLE
Patch task_id into bids_filters

### DIFF
--- a/xcp_d/config.py
+++ b/xcp_d/config.py
@@ -510,6 +510,11 @@ class execution(_Config):
                 for k, v in filters.items():
                     cls.bids_filters[acq][k] = _process_value(v)
 
+        if cls.task_id:
+            cls.bids_filters = cls.bids_filters or {}
+            cls.bids_filters["bold"] = cls.bids_filters.get("bold", {})
+            cls.bids_filters["bold"]["task"] = cls.task_id
+
         dataset_links = {
             'preprocessed': cls.fmri_dir,
             'templateflow': Path(TF_LAYOUT.root),

--- a/xcp_d/tests/data/ds001419_cifti_filter.json
+++ b/xcp_d/tests/data/ds001419_cifti_filter.json
@@ -1,6 +1,5 @@
 {
     "bold": {
-        "task": "imagery",
         "run": ["01", "02"]
     }
 }

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -92,6 +92,7 @@ def test_ds001419_cifti(data_dir, output_dir, working_dir):
         "participant",
         "--mode=abcd",
         f"-w={work_dir}",
+        "--task-id=imagery",
         f"--bids-filter-file={filter_file}",
         "--nuisance-regressors=acompcor_gsr",
         "--warp_surfaces_native2std=n",


### PR DESCRIPTION
Closes none. Should make it so `--task-id` is correctly used to filter BOLD scans.

## Changes proposed in this pull request

- Path `task_id` into `bids_filters`.