### PR TITLE
Remove Freesurfer node from surface normalization workflow

### DIFF
--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -694,7 +694,8 @@ anatomical tissue segmentation, and an HDF5 file containing motion levels at dif
         type=PathExists,
         help=(
             "Path to FreeSurfer license key file. Get it (for free) by registering "
-            "at https://surfer.nmr.mgh.harvard.edu/registration.html."
+            "at https://surfer.nmr.mgh.harvard.edu/registration.html. "
+            "This is not currently required, but may be in the future."
         ),
     )
     g_other.add_argument(
@@ -923,16 +924,16 @@ def _validate_parameters(opts, build_log, parser):
             os.environ["FS_LICENSE"] = str(opts.fs_license_file)
 
         else:
-            error_messages.append(f"Freesurfer license DNE: {opts.fs_license_file}.")
+            build_log.warning(f"Freesurfer license DNE: {opts.fs_license_file}.")
     else:
         fs_license_file = os.environ.get("FS_LICENSE", "/opt/freesurfer/license.txt")
         if not Path(fs_license_file).is_file():
-            error_messages.append(
-                "A valid FreeSurfer license file is required. "
+            build_log.warning(
+                "A valid FreeSurfer license file is recommended. "
                 "Set the FS_LICENSE environment variable or use the '--fs-license-file' flag."
             )
-
-        os.environ["FS_LICENSE"] = str(fs_license_file)
+        else:
+            os.environ["FS_LICENSE"] = str(fs_license_file)
 
     # Resolve custom confounds folder
     if opts.custom_confounds:

--- a/xcp_d/tests/conftest.py
+++ b/xcp_d/tests/conftest.py
@@ -1,6 +1,5 @@
 """Fixtures for the CircleCI tests."""
 
-import base64
 import os
 
 import pytest
@@ -212,16 +211,16 @@ def fmriprep_without_freesurfer_data(datasets):
     return files
 
 
-@pytest.fixture(scope="session", autouse=True)
-def fslicense(working_dir):
-    """Set the FreeSurfer license as an environment variable."""
-    FS_LICENSE = os.path.join(working_dir, "license.txt")
-    os.environ["FS_LICENSE"] = FS_LICENSE
-    LICENSE_CODE = (
-        "bWF0dGhldy5jaWVzbGFrQHBzeWNoLnVjc2IuZWR1CjIwNzA2CipDZmVWZEg1VVQ4clkKRlNCWVouVWtlVElDdwo="
-    )
-    with open(FS_LICENSE, "w") as f:
-        f.write(base64.b64decode(LICENSE_CODE).decode())
+# @pytest.fixture(scope="session", autouse=True)
+# def fslicense(working_dir):
+#     """Set the FreeSurfer license as an environment variable."""
+#     FS_LICENSE = os.path.join(working_dir, "license.txt")
+#     os.environ["FS_LICENSE"] = FS_LICENSE
+#     LICENSE_CODE = (
+#         "bWF0dGhldy5jaWVzbGFrQHBzeWNoLnVjc2IuZWR1CjIwNzA2CipDZmVWZEg1VVQ4clkKRlNCWVouVWtlVElDdwo="
+#     )
+#     with open(FS_LICENSE, "w") as f:
+#         f.write(base64.b64decode(LICENSE_CODE).decode())
 
 
 @pytest.fixture(scope="session")

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -84,7 +84,6 @@ def test_ds001419_cifti(data_dir, output_dir, working_dir):
 
     test_data_dir = get_test_data_path()
     filter_file = os.path.join(test_data_dir, "ds001419_cifti_filter.json")
-    fs_license_file = os.environ["FS_LICENSE"]
 
     parameters = [
         dataset_dir,
@@ -112,7 +111,6 @@ def test_ds001419_cifti(data_dir, output_dir, working_dir):
         "4S256Parcels",
         "4S356Parcels",
         "4S456Parcels",
-        f"--fs-license-file={fs_license_file}",
         "--linc-qc",
     ]
     _run_and_generate(


### PR DESCRIPTION
Closes none. Unfortunately some tests fail because of a cache issue from #1255.

## Changes proposed in this pull request

- Make `--fs-license-file` (which is unused) optional.
- Drop `mrisconvert` command in surface normalization workflow. This was an artifact from when we collected the `sphere.reg` file from Freesurfer. Now that fMRIPrep and Nibabies write out the sphere files as a GIFTI, we no longer need to convert it to GIFTI.
- Remove FREESURFER_LICENSE from environment variables.