### PR TITLE
Rename `--derivatives` parameter to `--datasets`

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,7 +51,7 @@ command: ::
 
     $ apptainer build xcp_d-<version>.simg docker://pennlinc/xcp_d:<version>
 
-where ``<version>`` should be replaced with the desired version of *xcp-d* that you want to
+where ``<version>`` should be replaced with the desired version of *XCP-D* that you want to
 download.
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -520,7 +520,7 @@ Last, run XCP-D with your custom configuration file and the path to the custom d
       /mnt/output/directory \
       participant \
       --participant_label X \
-      --derivatives custom=/mnt/custom_confounds \
+      --datasets custom=/mnt/custom_confounds \
       --nuisance-regressors /mnt/custom_config.yaml
 
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -545,8 +545,8 @@ please refer to :footcite:t:`benchmarkp`.
    fMRIPrep removed AROMA support in 23.1.0.
    In order to use the ``aroma`` or ``aroma_gsr`` strategies,
    please run ``fMRIPost-AROMA`` on your fMRIPrep outputs before running XCP-D.
-   You will need to supply the AROMA derivatives dataset to XCP-D via the ``--derivatives``
-   parameter (i.e., ``--derivatives aroma=/path/to/fmripost-aroma/dset``).
+   You will need to supply the AROMA derivatives dataset to XCP-D via the ``--datasets``
+   parameter (i.e., ``--datasets aroma=/path/to/fmripost-aroma/dset``).
 
 
 .. warning::
@@ -570,7 +570,7 @@ while the ``confounds`` section specifies which confounds will actually be used.
 
 The ``confounds`` section is a dictionary/object, with a unique key for each set of confounds.
 Each set of confounds must contain a ``dataset`` key, which specifies the dataset to use.
-The dataset must be linked to what the user provides in the ``--derivatives`` parameter,
+The dataset must be linked to what the user provides in the ``--datasets`` parameter,
 though the "preprocessed" key is a protected value for the dataset given to XCP-D as the
 ``fmri_dir`` positional argument.
 For example, in the example below, three columns are collected from the fMRIPrep confounds file:

--- a/xcp_d/cli/combineqc.py
+++ b/xcp_d/cli/combineqc.py
@@ -47,4 +47,4 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    raise RuntimeError("this should be run after xcp_d;\nrun xcp-d first")
+    raise RuntimeError("this should be run after xcp_d;\nrun XCP-D first")

--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -128,7 +128,7 @@ def _build_parser():
     )
     g_bids.add_argument(
         "-d",
-        "--derivatives",
+        "--datasets",
         action=parser_utils.ToDict,
         metavar="PACKAGE=PATH",
         type=str,
@@ -136,7 +136,7 @@ def _build_parser():
         help=(
             "Search PATH(s) for pre-computed derivatives. "
             "These may be provided as named folders "
-            "(e.g., `--derivatives smriprep=/path/to/smriprep`)."
+            "(e.g., `--datasets smriprep=/path/to/smriprep`)."
         ),
     )
     g_bids.add_argument(

--- a/xcp_d/cli/workflow.py
+++ b/xcp_d/cli/workflow.py
@@ -92,8 +92,8 @@ def build_workflow(config_file, retval):
         f"Run identifier: {config.execution.run_uuid}.",
     ]
 
-    if config.execution.derivatives:
-        init_msg += [f"Searching for derivatives: {config.execution.derivatives}."]
+    if config.execution.datasets:
+        init_msg += [f"Searching for derivatives: {config.execution.datasets}."]
 
     build_log.log(25, f"\n{' ' * 11}* ".join(init_msg))
 

--- a/xcp_d/config.py
+++ b/xcp_d/config.py
@@ -379,7 +379,7 @@ class execution(_Config):
 
     fmri_dir = None
     """An existing path to the preprocessing derivatives dataset, which must be BIDS-compliant."""
-    derivatives = {}
+    datasets = {}
     """Path(s) to search for pre-computed derivatives"""
     aggr_ses_reports = None
     """Maximum number of sessions aggregated in one subject's visual report."""
@@ -434,7 +434,7 @@ class execution(_Config):
 
     _paths = (
         "fmri_dir",
-        "derivatives",
+        "datasets",
         "bids_database_dir",
         "fs_license_file",
         "layout",
@@ -524,8 +524,8 @@ class execution(_Config):
             "preprocessed": cls.fmri_dir,
             "templateflow": Path(TF_LAYOUT.root),
         }
-        for deriv_name, deriv_path in cls.derivatives.items():
-            dataset_links[deriv_name] = deriv_path
+        for dset_name, dset_path in cls.datasets.items():
+            dataset_links[dset_name] = dset_path
         cls.dataset_links = dataset_links
 
         if "all" in cls.debug:

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -29,7 +29,7 @@ class ExecutiveSummary(object):
     Parameters
     ----------
     xcpd_path : :obj:`str`
-        Path to the xcp-d derivatives.
+        Path to the XCP-D derivatives.
     subject_id : :obj:`str`
         Subject ID.
     session_id : None or :obj:`str`, optional

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -421,7 +421,7 @@ def _run_and_generate(test_name, parameters, input_type, test_main=False):
 
     if test_main:
         # This runs, but for some reason doesn't count toward coverage.
-        argv = ["xcp-d"] + parameters
+        argv = ["xcp_d"] + parameters
         with patch.object(sys, "argv", argv):
             with pytest.raises(SystemExit) as e:
                 run.main()

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -49,7 +49,7 @@ def test_ds001419_nifti(data_dir, output_dir, working_dir):
         out_dir,
         "participant",
         "--mode=none",
-        "--derivatives",
+        "--datasets",
         f"aroma={derivs_dir}",
         f"-w={work_dir}",
         f"--bids-filter-file={filter_file}",

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -757,7 +757,7 @@ def write_derivative_description(
     fmri_dir : :obj:`str`
         Path to the BIDS derivative dataset being ingested.
     output_dir : :obj:`str`
-        Path to the output xcp-d dataset.
+        Path to the output XCP-D dataset.
     atlases : :obj:`list` of :obj:`str`, optional
         Names of requested XCP-D atlases.
     custom_confounds_folder : :obj:`str`, optional

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -705,11 +705,15 @@ def collect_confounds(
                 continue
 
             if isinstance(v, (Path, str)):
-                layout_dict[k] = BIDSLayout(
+                layout = BIDSLayout(
                     v,
                     config=["bids", "derivatives", xcp_d_config],
                     indexer=_indexer,
                 )
+                if layout.get_dataset_description().get("DatasetType") != "derivatives":
+                    print(f"Dataset {k} is not a derivatives dataset. Skipping.")
+
+                layout_dict[k] = layout
             else:
                 layout_dict[k] = v
 
@@ -719,7 +723,7 @@ def collect_confounds(
         if confound_def["dataset"] not in layout_dict.keys():
             raise ValueError(
                 f"Missing dataset required by confound spec: *{confound_def['dataset']}*. "
-                "Did you provide it with the `--derivatives` flag?"
+                "Did you provide it with the `--datasets` flag?"
             )
 
         layout = layout_dict[confound_def["dataset"]]

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -424,7 +424,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
                 confounds_dict = collect_confounds(
                     bold_file=bold_file,
                     preproc_dataset=config.execution.layout,
-                    derivatives_datasets=config.execution.derivatives,
+                    derivatives_datasets=config.execution.datasets,
                     confound_spec=yaml.safe_load(config.execution.confounds_config.read_text()),
                 )
                 run_data["confounds"] = confounds_dict

--- a/xcp_d/workflows/bold/plotting.py
+++ b/xcp_d/workflows/bold/plotting.py
@@ -214,7 +214,7 @@ def init_qc_report_wf(
 
         # NIFTI files require a tissue-type segmentation in the same space as the BOLD data.
         # Get the set of transforms from MNI152NLin6Asym (the dseg) to the BOLD space.
-        # Given that xcp-d doesn't process native-space data, this transform will never be used.
+        # Given that XCP-D doesn't process native-space data, this transform will never be used.
         get_mni_to_bold_xfms = pe.Node(
             Function(
                 input_names=["bold_file"],


### PR DESCRIPTION
Closes none. Splits out a backward-incompatible change from #1265.

## Changes proposed in this pull request

- Rename the `--derivatives` parameter to `--datasets`, to prepare to allow BIDS-Atlas datasets.
- Change `xcp-d` to `XCP-D` throughout the package.