### PR TITLE
Fix ingression of standard-space mesh files

### DIFF
--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -161,11 +161,16 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
         (std_mesh_dir / "sub-1648798153/ses-PNC1/anat").joinpath(f).touch()
 
     layout = BIDSLayout(std_mesh_dir, validate=False)
-    mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(
+    mesh_available, standard_space_mesh, _, mesh_files = xbids.collect_mesh_data(
         layout, "1648798153", bids_filters={}
     )
     assert mesh_available is True
     assert standard_space_mesh is True
+    order = ["lh_pial_surf", "lh_wm_surf", "rh_pial_surf", "rh_wm_surf"]
+    for i, k in enumerate(order):
+        assert mesh_files[k] == str(
+            (std_mesh_dir / "sub-1648798153/ses-PNC1/anat").joinpath(files[i])
+        )
 
     # Dataset with multiple files matching each query (raises an error)
     bad_mesh_dir = tmp_path_factory.mktemp("standard_mesh")

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -152,6 +152,10 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
         "sub-1648798153_ses-PNC1_hemi-L_space-fsLR_den-32k_white.surf.gii",
         "sub-1648798153_ses-PNC1_hemi-R_space-fsLR_den-32k_pial.surf.gii",
         "sub-1648798153_ses-PNC1_hemi-R_space-fsLR_den-32k_white.surf.gii",
+        "sub-1648798153_ses-PNC1_hemi-L_pial.surf.gii",
+        "sub-1648798153_ses-PNC1_hemi-L_white.surf.gii",
+        "sub-1648798153_ses-PNC1_hemi-R_pial.surf.gii",
+        "sub-1648798153_ses-PNC1_hemi-R_white.surf.gii",
     ]
     for f in files:
         (std_mesh_dir / "sub-1648798153/ses-PNC1/anat").joinpath(f).touch()

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -415,10 +415,11 @@ def collect_mesh_data(layout, participant_label, bids_filters):
         LOGGER.info("No standard-space surfaces found.")
 
     # Now that we know if there are standard-space surfaces available, we can grab the files.
-    query_extras = {}
-    if not standard_space_mesh:
+    query_extras = {"space": None}
+    if standard_space_mesh:
         query_extras = {
-            "space": None,
+            "space": "fsLR",
+            "den": "32k",
         }
 
     initial_mesh_files = {}


### PR DESCRIPTION
Closes #1305.

## Changes proposed in this pull request

- Include `'space': 'fsLR', 'den': '32k'` in mesh query when standard-space mesh files are found.
- Update test to ensure it would fail in the old scenario, but passes with the fix.