### PR TITLE
Use confounds file with non-steady-state columns to identify dummy volumes

### DIFF
--- a/xcp_d/workflows/bold/postprocessing.py
+++ b/xcp_d/workflows/bold/postprocessing.py
@@ -269,11 +269,10 @@ def init_prepare_confounds_wf(
             (inputnode, remove_dummy_scans, [
                 ('preprocessed_bold', 'bold_file'),
                 ('dummy_scans', 'dummy_scans'),
-            ]),
-            (process_motion, remove_dummy_scans, [
+                # *not* the filtered motion file, which has dummy volume columns removed
                 ('motion_file', 'motion_file'),
-                ('temporal_mask', 'temporal_mask'),
             ]),
+            (process_motion, remove_dummy_scans, [('temporal_mask', 'temporal_mask')]),
             (remove_dummy_scans, dummy_scan_buffer, [
                 ('bold_file_dropped_TR', 'preprocessed_bold'),
                 ('confounds_tsv_dropped_TR', 'confounds_tsv'),


### PR DESCRIPTION
When `--dummy-scans` is set to `auto` (the default), XCP-D attempts to infer the right number of dummy volumes from the fMRIPrep confounds file. However, starting in #1255, I connected the output of a node that _removes_ the dummy volume columns from the confounds file to the node that looks for those columns, which resulted in dummy volumes not being flagged and removed by the post-processing workflow. This was identified by a user, Bianca Serio, in https://neurostars.org/t/filenotfounderror-no-bold-data-found-in-allowed-spaces-fslr/30968.

**THIS BUG AFFECTS VERSIONS 0.10.0rc1 - 0.10.0**

## Changes proposed in this pull request

- Use unfiltered confounds file to identify non-steady-state (i.e., dummy) volumes to remove from the BOLD data, rather than the filtered version that only include motion columns.
