### PR TITLE
Downgrade connectome workbench version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 .dockersetup:
   &dockersetup
   docker:
-    - image: pennlinc/xcp_d_build:0.0.20
+    - image: pennlinc/xcp_d_build:0.0.21
   working_directory: /src/xcp_d
 
 runinstall:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pennlinc/xcp_d_build:0.0.20
+FROM pennlinc/xcp_d_build:0.0.21
 
 # Install xcp_d
 COPY . /src/xcp_d

--- a/xcp_d/tests/run_local_tests.py
+++ b/xcp_d/tests/run_local_tests.py
@@ -32,6 +32,13 @@ def _get_parser():
         required=False,
         default=None,
     )
+    parser.add_argument(
+        '--check_path',
+        action='store_true',
+        help='Check if the path is correct.',
+        required=False,
+        default=False,
+    )
     return parser
 
 


### PR DESCRIPTION
Closes none, but fixes the weird brainsprites we've been seeing for non-normalized surfaces.

## Changes proposed in this pull request

- Switch back from 2.0.0 to 1.5.0 for connectome workbench.