### PR TITLE
Support multi-step composite transforms from Nibabies (overhaul)

### DIFF
--- a/xcp_d/interfaces/ants.py
+++ b/xcp_d/interfaces/ants.py
@@ -242,10 +242,9 @@ class _TransformsToDisplacementInputSpec(ANTSCommandInputSpec):
     )
     transforms = InputMultiObject(
         traits.Either(File(exists=True), 'identity'),
-        argstr='%s',
+        argstr='-t %s',
         mandatory=True,
-        desc='transform files: will be applied in reverse order. For '
-        'example, the last specified transform will be applied first.',
+        desc='transform files: will be applied in forward order.',
     )
     float = traits.Bool(
         argstr='--float %d',

--- a/xcp_d/workflows/anatomical/surface.py
+++ b/xcp_d/workflows/anatomical/surface.py
@@ -8,7 +8,7 @@ from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
 from xcp_d import config
-from xcp_d.interfaces.ants import ApplyTransforms
+from xcp_d.interfaces.ants import TransformsToDisplacement
 from xcp_d.interfaces.bids import CollectRegistrationFiles, DerivativesDataSink
 from xcp_d.interfaces.c3 import C3d  # TM
 from xcp_d.interfaces.nilearn import BinaryMath, Merge
@@ -654,15 +654,17 @@ def init_ants_xfm_to_fsl_wf(mem_gb, name='ants_xfm_to_fsl_wf'):
 
     # Convert the transform into a displacement field.
     # XXX: This is the step that I need to get working.
+    # XXX: Reference image is necessary here
     fwd_to_displacement = pe.Node(
-        ApplyTransforms(),
+        TransformsToDisplacement(dimension=3),
         name='fwd_to_displacement',
         mem_gb=mem_gb,
     )
     workflow.connect([(inputnode, fwd_to_displacement, [('anat_to_template_xfm', 'transforms')])])
 
+    # XXX: Reference image is necessary here
     rvs_to_displacement = pe.Node(
-        ApplyTransforms(),
+        TransformsToDisplacement(dimension=3),
         name='rvs_to_displacement',
         mem_gb=mem_gb,
     )

--- a/xcp_d/workflows/anatomical/surface.py
+++ b/xcp_d/workflows/anatomical/surface.py
@@ -254,7 +254,7 @@ def init_postprocess_surfaces_wf(
         )
         workflow.connect([
             (inputnode, warp_surfaces_to_template_wf, [
-                ('anat_native', 'anat_native'),
+                ('anat_native', 'inputnode.anat_native'),
                 ('lh_subject_sphere', 'inputnode.lh_subject_sphere'),
                 ('rh_subject_sphere', 'inputnode.rh_subject_sphere'),
                 ('lh_pial_surf', 'inputnode.lh_pial_surf'),

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -311,6 +311,7 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
             t2w_available=t2w_available,
             software=software,
         )
+        # XXX: We need to pass along the standard-space anatomical and the native space anatomical.
 
         workflow.connect([
             (inputnode, postprocess_surfaces_wf, [
@@ -338,6 +339,15 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
                     ('outputnode.t2w', 'inputnode.t2w'),
                 ]),
             ])  # fmt:skip
+
+            if t2w_available:
+                workflow.connect([
+                    (inputnode, postprocess_surfaces_wf, [('t2w', 'inputnode.anat_native')]),
+                ])  # fmt:skip
+            else:
+                workflow.connect([
+                    (inputnode, postprocess_surfaces_wf, [('t1w', 'inputnode.anat_native')]),
+                ])  # fmt:skip
 
         else:
             # Use native-space structurals


### PR DESCRIPTION
Closes #1348.

## Changes proposed in this pull request

- Use antsApplyTransforms to convert the transforms into displacement fields instead of decomposing them and applying the affine and warp separately.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
