### PR TITLE
Apply consistency across XCP-D quick-start instructions

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -544,7 +544,8 @@ Last, run *XCP-D* with your custom configuration file and the path to the custom
 
 .. code-block:: bash
 
-   apptainer run --cleanenv -B /my/project/directory:/data xcpd_<version>.simg \
+   apptainer run -B /data:/data \
+      --cleanenv xcpd_<version>.simg \
       /path/to/fmriprep_dir \
       /path/to/output_dir \
       participant \ # analysis_level
@@ -621,7 +622,8 @@ Here's what the *XCP-D* call might look like:
 
 .. code-block:: bash
 
-   apptainer run --cleanenv -B /data:/data xcpd_<version>.simg \
+   apptainer run -B /data:/data \
+      --cleanenv xcpd_<version>.simg \
       /path/to/fmriprep_dir \
       /path/to/output_dir \
       participant \ # analysis_level

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -331,7 +331,7 @@ A Docker container can be created using the following command:
       -v /path/to/output_dir:/out:rw \
       pennlinc/xcp_d:<version> \
       /fmriprep \
-      /path/to/output_dir \
+      /output_dir \
       participant \ # analysis_level
       --mode <mode> \ # required
       --participant-label <label> # optional

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -326,9 +326,9 @@ A Docker container can be created using the following command:
 .. code-block:: bash
 
    docker run --rm -it \
-      -v /dset/derivatives/fmriprep:/fmriprep:ro \
+      -v /path/to/fmriprep_dir:/fmriprep:ro \
       -v /tmp/wkdir:/work:rw \
-      -v /dset/derivatives/xcp_d:/out:rw \
+      -v /path/to/output_dir:/out:rw \
       pennlinc/xcp_d:<version> \
       /path/to/fmriprep_dir \
       /path/to/output_dir \
@@ -544,7 +544,7 @@ Last, run *XCP-D* with your custom configuration file and the path to the custom
 
 .. code-block:: bash
 
-   apptainer run --cleanenv -B /my/project/directory:/mnt xcpd_<version>.simg \
+   apptainer run --cleanenv -B /my/project/directory:/data xcpd_<version>.simg \
       /path/to/fmriprep_dir \
       /path/to/output_dir \
       participant \ # analysis_level

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -331,7 +331,7 @@ A Docker container can be created using the following command:
       -v /path/to/output_dir:/out:rw \
       pennlinc/xcp_d:<version> \
       /fmriprep \
-      /output_dir \
+      /out \
       participant \ # analysis_level
       --mode <mode> \ # required
       --participant-label <label> # optional

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,7 +34,11 @@ command-line structure, for example:
 
 .. code-block:: bash
 
-   xcp_d <fmriprep_dir> <output_dir> participant --file-format cifti --despike --head_radius 40 -w /wkdir --smoothing 6
+   xcp_d /path/to/fmriprep_dir \
+      /path/to/output_dir \
+      participant \ # analysis_level
+      --mode <mode> \ # required
+      --participant-label <label> # optional
 
 However, we strongly recommend using :ref:`installation_container_technologies`.
 Here, the command-line will be composed of a preamble to configure the container execution,
@@ -325,9 +329,12 @@ A Docker container can be created using the following command:
       -v /dset/derivatives/fmriprep:/fmriprep:ro \
       -v /tmp/wkdir:/work:rw \
       -v /dset/derivatives/xcp_d:/out:rw \
-      pennlinc/xcp_d:latest \
-      /fmriprep /out participant \
-      --file-format cifti --despike --head_radius 40 -w /work --smoothing 6
+      pennlinc/xcp_d:<version> \
+      /path/to/fmriprep_dir \
+      /path/to/output_dir \
+      participant \ # analysis_level
+      --mode <mode> \ # required
+      --participant-label <label> # optional
 
 .. _run_apptainer:
 
@@ -343,11 +350,12 @@ If the data to be preprocessed is also on the HPC or a personal computer, you ar
 
 .. code-block:: bash
 
-    apptainer run --cleanenv xcp_d-<version>.simg \
-        /dset/derivatives/fmriprep  \
-        /dset/derivatives/xcp_d \
-        participant \
-        --participant-label label
+   apptainer run --cleanenv xcp_d-<version>.simg \
+      /path/to/fmriprep_dir \
+      /path/to/output_dir \
+      participant \ # analysis_level
+      --mode <mode> \ # required
+      --participant-label <label> # optional
 
 
 Relevant aspects of the ``$HOME`` directory within the container
@@ -365,10 +373,10 @@ argument (``--home``) as follows:
 
 .. code-block:: bash
 
-    apptainer run -B $HOME:/home/xcp \
-        --home /home/xcp \
-        --cleanenv xcp_d-<version>.simg \
-        <xcp_d arguments>
+   apptainer run -B $HOME:/home/xcp \
+      --home /home/xcp \
+      --cleanenv xcp_d-<version>.simg \
+      <xcp_d arguments>
 
 Therefore, once a user specifies the container options and the image to be run,
 the command line options are the same as the *bare-metal* installation.
@@ -537,12 +545,13 @@ Last, run *XCP-D* with your custom configuration file and the path to the custom
 .. code-block:: bash
 
    apptainer run --cleanenv -B /my/project/directory:/mnt xcpd_<version>.simg \
-      /mnt/input/fmriprep \
-      /mnt/output/directory \
-      participant \
-      --participant_label X \
-      --datasets custom=/mnt/custom_confounds \
-      --nuisance-regressors /mnt/custom_config.yaml
+      /path/to/fmriprep_dir \
+      /path/to/output_dir \
+      participant \ # analysis_level
+      --mode <mode> \ # required
+      --participant-label <label> # optional
+      --datasets custom=/path/to/custom_confounds \
+      --nuisance-regressors /path/to/custom_config.yaml
 
 
 ****************
@@ -613,11 +622,11 @@ Here's what the *XCP-D* call might look like:
 .. code-block:: bash
 
    apptainer run --cleanenv -B /data:/data xcpd_<version>.simg \
-      /data/dataset/derivatives/fmriprep \
-      /data/dataset/derivatives/xcp_d \
-      participant \
-      --mode linc \
-      --datasets schaefer=/data/atlases/schaefer aal==/data/atlases/aal \
+      /path/to/fmriprep_dir \
+      /path/to/output_dir \
+      participant \ # analysis_level
+      --mode <mode> \ # required
+      --datasets schaefer=/path/to/schaefer_atlas aal==/path/to/aal_atlas \
       --atlases Schaefer100 AAL 4S156Parcels
 
 *XCP-D* will search for ``atlas-Schaefer100``, ``atlas-AAL``, and ``atlas-4S156Parcels`` across the

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -330,7 +330,7 @@ A Docker container can be created using the following command:
       -v /tmp/wkdir:/work:rw \
       -v /path/to/output_dir:/out:rw \
       pennlinc/xcp_d:<version> \
-      /path/to/fmriprep_dir \
+      /fmriprep \
       /path/to/output_dir \
       participant \ # analysis_level
       --mode <mode> \ # required

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -343,7 +343,7 @@ If the data to be preprocessed is also on the HPC or a personal computer, you ar
 
 .. code-block:: bash
 
-    apptainer run --cleanenv xcp_d.sif \
+    apptainer run --cleanenv xcp_d-<version>.simg \
         /dset/derivatives/fmriprep  \
         /dset/derivatives/xcp_d \
         --participant-label label
@@ -366,7 +366,7 @@ argument (``--home``) as follows:
 
     apptainer run -B $HOME:/home/xcp \
         --home /home/xcp \
-        --cleanenv xcp_d.simg \
+        --cleanenv xcp_d-<version>.simg \
         <xcp_d arguments>
 
 Therefore, once a user specifies the container options and the image to be run,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,7 +34,7 @@ command-line structure, for example:
 
 .. code-block:: bash
 
-   xcp_d <fmriprep_dir> <output_dir> --file-format cifti --despike --head_radius 40 -w /wkdir --smoothing 6
+   xcp_d <fmriprep_dir> <output_dir> participant --file-format cifti --despike --head_radius 40 -w /wkdir --smoothing 6
 
 However, we strongly recommend using :ref:`installation_container_technologies`.
 Here, the command-line will be composed of a preamble to configure the container execution,
@@ -346,6 +346,7 @@ If the data to be preprocessed is also on the HPC or a personal computer, you ar
     apptainer run --cleanenv xcp_d-<version>.simg \
         /dset/derivatives/fmriprep  \
         /dset/derivatives/xcp_d \
+        participant \
         --participant-label label
 
 
@@ -535,7 +536,7 @@ Last, run *XCP-D* with your custom configuration file and the path to the custom
 
 .. code-block:: bash
 
-   apptainer run --cleanenv -B /my/project/directory:/mnt xcpd_latest.sif \
+   apptainer run --cleanenv -B /my/project/directory:/mnt xcpd_<version>.simg \
       /mnt/input/fmriprep \
       /mnt/output/directory \
       participant \
@@ -611,7 +612,7 @@ Here's what the *XCP-D* call might look like:
 
 .. code-block:: bash
 
-   apptainer run --cleanenv -B /data:/data xcpd_latest.sif \
+   apptainer run --cleanenv -B /data:/data xcpd_<version>.simg \
       /data/dataset/derivatives/fmriprep \
       /data/dataset/derivatives/xcp_d \
       participant \


### PR DESCRIPTION
Relates to #1378 

## Changes proposed in this pull request
Apply consistent formatting and command usage across examples in `usage.rst`

## Documentation that should be reviewed
`usage.rst`
