### PR TITLE
Parallelize image denoising

### DIFF
--- a/xcp_d/interfaces/nilearn.py
+++ b/xcp_d/interfaces/nilearn.py
@@ -264,6 +264,7 @@ class _DenoiseImageInputSpec(BaseInterfaceInputSpec):
     low_pass = traits.Float(mandatory=True, desc='Lowpass filter in Hz')
     high_pass = traits.Float(mandatory=True, desc='Highpass filter in Hz')
     filter_order = traits.Int(mandatory=True, desc='Filter order')
+    num_threads = traits.Int(1, usedefault=True, desc='denoise on this many cpus')
 
 
 class _DenoiseImageOutputSpec(TraitedSpec):
@@ -335,6 +336,7 @@ class DenoiseCifti(NilearnBaseInterface, SimpleInterface):
             high_pass=high_pass,
             filter_order=self.inputs.filter_order,
             TR=self.inputs.TR,
+            num_threads=self.inputs.num_threads,
         )
 
         # Transpose from TxS (nilearn order) to SxT (xcpd order)
@@ -421,6 +423,7 @@ class DenoiseNifti(NilearnBaseInterface, SimpleInterface):
             high_pass=high_pass,
             filter_order=self.inputs.filter_order,
             TR=self.inputs.TR,
+            num_threads=self.inputs.num_threads,
         )
 
         self._results['denoised_interpolated_bold'] = os.path.join(

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -73,6 +73,8 @@ def test_ds001419_nifti(data_dir, output_dir, working_dir):
         '--file-format=nifti',
         '--input-type=fmriprep',
         '--warp-surfaces-native2std=n',
+        '--nthreads=2',
+        '--omp-nthreads=2',
     ]
     _run_and_generate(
         test_name=test_name,
@@ -122,6 +124,8 @@ def test_ds001419_cifti(data_dir, output_dir, working_dir):
         '4S356Parcels',
         '4S456Parcels',
         '--linc-qc',
+        '--nthreads=2',
+        '--omp-nthreads=2',
     ]
     _run_and_generate(
         test_name=test_name,
@@ -159,6 +163,8 @@ def test_ukbiobank(data_dir, output_dir, working_dir):
         '--min-coverage=0.1',
         '--random-seed=8675309',
         '--min-time=100',
+        '--nthreads=2',
+        '--omp-nthreads=2'
     ]
     _run_and_generate(
         test_name=test_name,
@@ -216,6 +222,8 @@ def test_pnc_cifti(data_dir, output_dir, working_dir):
         '480',
         'all',
         '--linc-qc=n',
+        '--nthreads=2',
+        '--omp-nthreads=2'
     ]
     _run_and_generate(
         test_name=test_name,
@@ -270,6 +278,8 @@ def test_pnc_cifti_t2wonly(data_dir, output_dir, working_dir):
         '--disable-bandpass-filter',
         '--create-matrices=all',
         '--linc-qc=n',
+        '--nthreads=2',
+        '--omp-nthreads=2',
     ]
     _run_and_generate(
         test_name=test_name,
@@ -416,6 +426,8 @@ def test_nibabies(data_dir, output_dir, working_dir):
         '--create-matrices=all',
         '--motion-filter-type=none',
         '--linc-qc=n',
+        '--nthreads=2',
+        '--omp-nthreads=2',
     ]
     _run_and_generate(
         test_name=test_name,

--- a/xcp_d/tests/test_interfaces_nilearn.py
+++ b/xcp_d/tests/test_interfaces_nilearn.py
@@ -136,6 +136,7 @@ def test_nilearn_denoisenifti(ds001419_data, tmp_path_factory):
         high_pass=0.01,
         low_pass=0.08,
         filter_order=2,
+        num_threads=1,
     )
     results = interface.run(cwd=tmpdir)
 

--- a/xcp_d/workflows/bold/postprocessing.py
+++ b/xcp_d/workflows/bold/postprocessing.py
@@ -645,6 +645,7 @@ approach.
             high_pass=high_pass,
             filter_order=bpf_order,
             bandpass_filter=bandpass_filter,
+            num_threads=config.nipype.omp_nthreads
         ),
         name='regress_and_filter_bold',
         mem_gb=mem_gb['timeseries'],


### PR DESCRIPTION
The image denoising function can probably be parallelized to run in chunks, such that you can keep all the available cpus running at all times. This is an attempt to use multiprocessing to split up input data to be processed on all cpus separately and ultimately combined