### PR TITLE
Support `--abcc-qc` with `--file-format nifti`

### DIFF
--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -68,7 +68,7 @@ def test_ds001419_nifti(data_dir, output_dir, working_dir):
         '--output-type=censored',
         '--combine-runs=y',
         '--linc-qc=y',
-        '--abcc-qc=y',
+        '--abcc-qc=n',
         '--despike=n',
         '--file-format=nifti',
         '--input-type=fmriprep',

--- a/xcp_d/tests/test_cli.py
+++ b/xcp_d/tests/test_cli.py
@@ -68,7 +68,7 @@ def test_ds001419_nifti(data_dir, output_dir, working_dir):
         '--output-type=censored',
         '--combine-runs=y',
         '--linc-qc=y',
-        '--abcc-qc=n',
+        '--abcc-qc=y',
         '--despike=n',
         '--file-format=nifti',
         '--input-type=fmriprep',

--- a/xcp_d/workflows/anatomical/parcellation.py
+++ b/xcp_d/workflows/anatomical/parcellation.py
@@ -90,7 +90,7 @@ def init_parcellate_surfaces_wf(files_to_parcellate, name='parcellate_surfaces_w
     atlases = collect_atlases(
         datasets=config.execution.datasets,
         atlases=selected_atlases,
-        file_format=config.workflow.file_format,
+        file_format='cifti',
         bids_filters=config.execution.bids_filters,
     )
 


### PR DESCRIPTION
Closes none, but addresses bug detected by user in https://neurostars.org/t/issue-with-running-xcp-d-with-nifti-file-format/31702.

## Changes proposed in this pull request

- Hardcode the atlas format in `init_parcellate_surfaces_wf` as "cifti", so that it uses CIFTI atlases to parcellate surfaces.
- I also tested it out in ds001419_nifti test and it worked. I reverted that change since creating the brainsprite takes a while.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
