### PR TITLE
Make calculations robust to NaNs

### DIFF
--- a/xcp_d/ingression/utils.py
+++ b/xcp_d/ingression/utils.py
@@ -319,7 +319,7 @@ def extract_mean_signal(mask, nifti, work_dir):
     assert os.path.isfile(nifti), f'File DNE: {nifti}'
     masker = maskers.NiftiMasker(mask_img=mask, memory=work_dir, memory_level=5)
     signals = masker.fit_transform(nifti)
-    return np.mean(signals, axis=1)
+    return np.nanmean(signals, axis=1)
 
 
 def plot_bbreg(fixed_image, moving_image, contour, out_file='report.svg'):

--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -378,7 +378,7 @@ class ConnectPlot(SimpleInterface):
         for label in unique_labels:
             start_idx = np.where(labels == label)[0][0]
             if end_idx:
-                break_idx.append(np.mean([start_idx, end_idx]))
+                break_idx.append(np.nanmean([start_idx, end_idx]))
 
             end_idx = np.where(labels == label)[0][-1]
 
@@ -386,7 +386,7 @@ class ConnectPlot(SimpleInterface):
         break_idx = np.array(break_idx)
 
         # Find the locations for the labels in the middles of the communities
-        label_idx = np.mean(np.vstack((break_idx[1:], break_idx[:-1])), axis=0)
+        label_idx = np.nanmean(np.vstack((break_idx[1:], break_idx[:-1])), axis=0)
 
         np.fill_diagonal(corr_mat, 0)
 

--- a/xcp_d/interfaces/utils.py
+++ b/xcp_d/interfaces/utils.py
@@ -295,19 +295,18 @@ class LINCQC(SimpleInterface):
         mean_dvars_before_processing = np.nanmean(dvars_before_processing)
         mean_dvars_after_processing = np.nanmean(dvars_after_processing)
 
-        tmp_fd = preproc_fd.copy()
-        tmp_fd[np.isnan(tmp_fd)] = 0
-        tmp_dvars = dvars_before_processing.copy()
-        tmp_dvars[np.isnan(tmp_dvars)] = 0
-        fd_dvars_correlation_initial = np.corrcoef(tmp_fd, tmp_dvars)[0, 1]
-        del tmp_fd, tmp_dvars
+        preproc_mask = ~np.isnan(preproc_fd) & ~np.isnan(dvars_before_processing)
+        fd_dvars_correlation_initial = np.corrcoef(
+            preproc_fd[preproc_mask],
+            dvars_before_processing[preproc_mask],
+        )[0, 1]
 
-        tmp_fd = postproc_fd.copy()
-        tmp_fd[np.isnan(tmp_fd)] = 0
-        tmp_dvars = dvars_after_processing.copy()
-        tmp_dvars[np.isnan(tmp_dvars)] = 0
-        fd_dvars_correlation_final = np.corrcoef(tmp_fd, tmp_dvars)[0, 1]
-        del tmp_fd, tmp_dvars
+        postproc_mask = ~np.isnan(postproc_fd) & ~np.isnan(dvars_after_processing)
+        fd_dvars_correlation_final = np.corrcoef(
+            postproc_fd[postproc_mask],
+            dvars_after_processing[postproc_mask],
+        )[0, 1]
+
         rmsd_max_value = np.nanmax(rmsd_censored)
 
         # A summary of all the values

--- a/xcp_d/interfaces/utils.py
+++ b/xcp_d/interfaces/utils.py
@@ -169,12 +169,12 @@ class _LINCQCInputSpec(BaseInterfaceInputSpec):
     temporal_mask = traits.Either(
         File(exists=True),
         Undefined,
-        desc='Temporal mask',
+        desc='Temporal mask without dummy scans',
     )
     motion_file = File(
         exists=True,
         mandatory=True,
-        desc='fMRIPrep confounds file, after dummy scans removal',
+        desc='fMRIPrep confounds file, after dummy scan removal',
     )
     cleaned_file = File(
         exists=True,

--- a/xcp_d/interfaces/utils.py
+++ b/xcp_d/interfaces/utils.py
@@ -294,8 +294,20 @@ class LINCQC(SimpleInterface):
         mean_relative_rms = np.nanmean(rmsd_censored)  # first value can be NaN if no dummy scans
         mean_dvars_before_processing = np.nanmean(dvars_before_processing)
         mean_dvars_after_processing = np.nanmean(dvars_after_processing)
-        fd_dvars_correlation_initial = np.corrcoef(preproc_fd, dvars_before_processing)[0, 1]
-        fd_dvars_correlation_final = np.corrcoef(postproc_fd, dvars_after_processing)[0, 1]
+
+        tmp_fd = preproc_fd.copy()
+        tmp_fd[np.isnan(tmp_fd)] = 0
+        tmp_dvars = dvars_before_processing.copy()
+        tmp_dvars[np.isnan(tmp_dvars)] = 0
+        fd_dvars_correlation_initial = np.corrcoef(tmp_fd, tmp_dvars)[0, 1]
+        del tmp_fd, tmp_dvars
+
+        tmp_fd = postproc_fd.copy()
+        tmp_fd[np.isnan(tmp_fd)] = 0
+        tmp_dvars = dvars_after_processing.copy()
+        tmp_dvars[np.isnan(tmp_dvars)] = 0
+        fd_dvars_correlation_final = np.corrcoef(tmp_fd, tmp_dvars)[0, 1]
+        del tmp_fd, tmp_dvars
         rmsd_max_value = np.nanmax(rmsd_censored)
 
         # A summary of all the values

--- a/xcp_d/interfaces/utils.py
+++ b/xcp_d/interfaces/utils.py
@@ -289,11 +289,11 @@ class LINCQC(SimpleInterface):
             qc_values_dict[entity.split('-')[0]] = entity.split('-')[1]
 
         # Calculate QC measures
-        mean_fd = np.mean(preproc_fd)
-        mean_fd_post_censoring = np.mean(postproc_fd)
+        mean_fd = np.nanmean(preproc_fd)
+        mean_fd_post_censoring = np.nanmean(postproc_fd)
         mean_relative_rms = np.nanmean(rmsd_censored)  # first value can be NaN if no dummy scans
-        mean_dvars_before_processing = np.mean(dvars_before_processing)
-        mean_dvars_after_processing = np.mean(dvars_after_processing)
+        mean_dvars_before_processing = np.nanmean(dvars_before_processing)
+        mean_dvars_after_processing = np.nanmean(dvars_after_processing)
         fd_dvars_correlation_initial = np.corrcoef(preproc_fd, dvars_before_processing)[0, 1]
         fd_dvars_correlation_final = np.corrcoef(postproc_fd, dvars_after_processing)[0, 1]
         rmsd_max_value = np.nanmax(rmsd_censored)

--- a/xcp_d/tests/test_despike.py
+++ b/xcp_d/tests/test_despike.py
@@ -31,8 +31,8 @@ def test_nifti_despike(fmriprep_without_freesurfer_data, tmp_path_factory):
     # Create some spikes in the second voxel
     file_data = read_ndata(boldfile, maskfile)
     voxel_data = file_data[2, :]  # a voxel across time
-    voxel_data_mean = np.mean(voxel_data)
-    voxel_data_std = np.std(voxel_data)
+    voxel_data_mean = np.nanmean(voxel_data)
+    voxel_data_std = np.nanstd(voxel_data)
     voxel_data[2] = voxel_data_mean + 10 * voxel_data_std
     voxel_data[3] = voxel_data_mean - 10 * voxel_data_std
 
@@ -88,8 +88,8 @@ def test_cifti_despike(ds001419_data, tmp_path_factory):
     # Let's add some noise
     file_data = read_ndata(boldfile)
     voxel_data = file_data[2, :]  # a voxel across time
-    voxel_data_mean = np.mean(voxel_data)
-    voxel_data_std = np.std(voxel_data)
+    voxel_data_mean = np.nanmean(voxel_data)
+    voxel_data_std = np.nanstd(voxel_data)
     voxel_data[2] = voxel_data_mean + 10 * voxel_data_std
     voxel_data[3] = voxel_data_mean - 10 * voxel_data_std
 

--- a/xcp_d/tests/test_interfaces_utils.py
+++ b/xcp_d/tests/test_interfaces_utils.py
@@ -146,6 +146,7 @@ def test_lincqc(ds001419_data, tmp_path):
         anat_mask_anatspace=ds001419_data['brain_mask_file'],
         template_mask=ds001419_data['brain_mask_file'],
         bold_mask_anatspace=ds001419_data['brain_mask_file'],
+        bold_mask_stdspace=ds001419_data['brain_mask_file'],
     )
 
     res = lincqc.run(cwd=tmp_path)

--- a/xcp_d/tests/test_interfaces_utils.py
+++ b/xcp_d/tests/test_interfaces_utils.py
@@ -115,7 +115,8 @@ def test_conversion_to_32bit_cifti(ds001419_data, tmp_path_factory):
 def test_lincqc(ds001419_data, tmp_path):
     """Test the LINCQC interface."""
     # Create test data
-    n_timepoints = 100
+    img = nb.load(ds001419_data['nifti_file'])
+    n_timepoints = img.shape[3]
     dummy_scans = 5
 
     # Create motion parameters

--- a/xcp_d/tests/test_interfaces_utils.py
+++ b/xcp_d/tests/test_interfaces_utils.py
@@ -1,14 +1,13 @@
 """Tests for xcp_d.interfaces.utils module."""
 
-import os
 import json
+import os
 
 import nibabel as nb
 import numpy as np
 import pandas as pd
-import pytest
 
-from xcp_d.interfaces.utils import ConvertTo32, LINCQC
+from xcp_d.interfaces.utils import LINCQC, ConvertTo32
 
 
 def test_conversion_to_32bit_nifti(ds001419_data, tmp_path_factory):
@@ -128,9 +127,7 @@ def test_lincqc(ds001419_data, tmp_path):
     pd.DataFrame(motion_data).to_csv(motion_file, sep='\t', index=False)
 
     # Create temporal mask
-    temporal_mask_data = {
-        'framewise_displacement': np.zeros(n_timepoints, dtype=int)
-    }
+    temporal_mask_data = {'framewise_displacement': np.zeros(n_timepoints, dtype=int)}
     # Mark some volumes as censored (value = 1)
     temporal_mask_data['framewise_displacement'][10:15] = 1
     temporal_mask_file = tmp_path / 'temporal_mask.tsv'

--- a/xcp_d/tests/test_interfaces_utils.py
+++ b/xcp_d/tests/test_interfaces_utils.py
@@ -137,11 +137,12 @@ def test_lincqc(ds001419_data, tmp_path):
     lincqc = LINCQC(
         name_source='sub-01_task-rest_bold.nii.gz',
         bold_file=ds001419_data['nifti_file'],
-        dummy_scans=4,
+        dummy_scans=dummy_scans,
         motion_file=ds001419_data['confounds_file'],
         cleaned_file=ds001419_data['nifti_file'],
         TR=2.0,
         head_radius=50,
+        temporal_mask=temporal_mask_file,
         bold_mask_inputspace=ds001419_data['brain_mask_file'],
         anat_mask_anatspace=ds001419_data['brain_mask_file'],
         template_mask=ds001419_data['brain_mask_file'],

--- a/xcp_d/tests/test_utils_confounds.py
+++ b/xcp_d/tests/test_utils_confounds.py
@@ -133,7 +133,7 @@ def test_motion_filtering_notch():
 
     lowcut, highcut = band_stop_min / 60, band_stop_max / 60
     stopband_hz_adjusted = [lowcut, highcut]
-    freq_to_remove = np.mean(stopband_hz_adjusted)
+    freq_to_remove = np.nanmean(stopband_hz_adjusted)
     bandwidth = np.abs(np.diff(stopband_hz_adjusted))
 
     # Create filter coefficients.

--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -181,7 +181,7 @@ def filter_motion(
         highpass_hz = band_stop_max / 60
         stopband_hz = np.array([lowpass_hz, highpass_hz])
         # Convert stopband to a single notch frequency.
-        freq_to_remove = np.mean(stopband_hz)
+        freq_to_remove = np.nanmean(stopband_hz)
         bandwidth = np.abs(np.diff(stopband_hz))
 
         # Create filter coefficients.

--- a/xcp_d/utils/plotting.py
+++ b/xcp_d/utils/plotting.py
@@ -340,7 +340,7 @@ def plot_global_signal_es(time_series, ax, run_index=None):
         color='#497DB3',
     )
 
-    std_mean = np.mean(time_series['Std'])
+    std_mean = np.nanmean(time_series['Std'])
     ax_right.set_ylim(
         (1.5 * np.min(time_series['Std'] - std_mean)) + std_mean,
         (1.5 * np.max(time_series['Std'] - std_mean)) + std_mean,
@@ -359,7 +359,7 @@ def plot_global_signal_es(time_series, ax, run_index=None):
 
     ax.set_xlim((0, ntsteps - 1))
 
-    mean_mean = np.mean(time_series['Mean'])
+    mean_mean = np.nanmean(time_series['Mean'])
     ax.set_ylim(
         (1.5 * np.min(time_series['Mean'] - mean_mean)) + mean_mean,
         (1.5 * np.max(time_series['Mean'] - mean_mean)) + mean_mean,

--- a/xcp_d/utils/restingstate.py
+++ b/xcp_d/utils/restingstate.py
@@ -51,7 +51,7 @@ def compute_2d_reho(datat, adjacency_matrix):
         rankmean = np.sum(rankeddata, axis=0)  # add up ranks
         # kc is the sum of the squared rankmean minus the timepoints into
         # the mean of the rankmean squared
-        kc = np.sum(np.power(rankmean, 2)) - n_volumes * np.power(np.mean(rankmean), 2)
+        kc = np.sum(np.power(rankmean, 2)) - n_volumes * np.power(np.nanmean(rankmean), 2)
 
         # square number of neighbours, multiply by (cubed timepoint - timepoint)
         denom = np.power(n_neighbors, 2) * (np.power(n_volumes, 3) - n_volumes)
@@ -156,7 +156,7 @@ def compute_alff(*, data_matrix, low_pass, high_pass, TR, sample_mask):
         voxel_data = data_matrix[i_voxel, :]
         # Check if the voxel's data are all the same value (esp. zeros).
         # Set ALFF to 0 in that case and move on to the next voxel.
-        if np.std(voxel_data) == 0:
+        if np.nanstd(voxel_data) == 0:
             alff[i_voxel] = 0
             continue
 
@@ -164,12 +164,12 @@ def compute_alff(*, data_matrix, low_pass, high_pass, TR, sample_mask):
         # This will ensure that the power spectra from the standard and Lomb-Scargle periodograms
         # have the same scale.
         # However, this also changes ALFF's scale, so we retain the SD to rescale ALFF.
-        sd_scale = np.std(voxel_data)
+        sd_scale = np.nanstd(voxel_data)
 
         if sample_mask is not None:
             voxel_data_censored = voxel_data[sample_mask]
-            voxel_data_censored -= np.mean(voxel_data_censored)
-            voxel_data_censored /= np.std(voxel_data_censored)
+            voxel_data_censored -= np.nanmean(voxel_data_censored)
+            voxel_data_censored /= np.nanstd(voxel_data_censored)
 
             time_arr = np.arange(n_volumes) * TR
             assert sample_mask.size == time_arr.size, f'{sample_mask.size} != {time_arr.size}'
@@ -183,8 +183,8 @@ def compute_alff(*, data_matrix, low_pass, high_pass, TR, sample_mask):
                 normalize=True,
             )
         else:
-            voxel_data -= np.mean(voxel_data)
-            voxel_data /= np.std(voxel_data)
+            voxel_data -= np.nanmean(voxel_data)
+            voxel_data /= np.nanstd(voxel_data)
             # get array of sample frequencies + power spectrum density
             frequencies_hz, power_spectrum = signal.periodogram(
                 voxel_data,
@@ -210,7 +210,7 @@ def compute_alff(*, data_matrix, low_pass, high_pass, TR, sample_mask):
         # alff for that voxel is 2 * the mean of the sqrt of the power spec
         # from the value closest to the low pass cutoff, to the value closest
         # to the high pass pass cutoff
-        alff[i_voxel] = len(ff_alff) * np.mean(power_spectrum_sqrt[ff_alff[0] : ff_alff[1]])
+        alff[i_voxel] = len(ff_alff) * np.nanmean(power_spectrum_sqrt[ff_alff[0] : ff_alff[1]])
         # Rescale ALFF based on original BOLD scale
         alff[i_voxel] *= sd_scale
 

--- a/xcp_d/utils/restingstate.py
+++ b/xcp_d/utils/restingstate.py
@@ -51,7 +51,7 @@ def compute_2d_reho(datat, adjacency_matrix):
         rankmean = np.sum(rankeddata, axis=0)  # add up ranks
         # kc is the sum of the squared rankmean minus the timepoints into
         # the mean of the rankmean squared
-        kc = np.sum(np.power(rankmean, 2)) - n_volumes * np.power(np.nanmean(rankmean), 2)
+        kc = np.sum(np.power(rankmean, 2)) - n_volumes * np.power(np.mean(rankmean), 2)
 
         # square number of neighbours, multiply by (cubed timepoint - timepoint)
         denom = np.power(n_neighbors, 2) * (np.power(n_volumes, 3) - n_volumes)


### PR DESCRIPTION
Closes #1395.

## Changes proposed in this pull request

- Replace uses of numpy.mean and numpy.std with numpy.nanmean and numpynanstd, respectively.
- For corrcoefs, replace NaNs with zeros.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
