### PR TITLE
Fix atlas names in concatenated parcellated output files

### DIFF
--- a/xcp_d/workflows/bold/concatenation.py
+++ b/xcp_d/workflows/bold/concatenation.py
@@ -410,7 +410,9 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
             )
 
             workflow.connect([
-                ((filter_runs, _combine_name), ds_cifti_ts, [('timeseries_ciftis', 'source_file')]),
+                ((filter_runs, _combine_name), ds_cifti_ts, [
+                    ('timeseries_ciftis', 'source_file'),
+                ]),
                 (concatenate_inputs, ds_cifti_ts, [('timeseries_ciftis', 'in_file')]),
                 (cifti_ts_src, ds_cifti_ts, [('metadata', 'meta_dict')]),
             ])  # fmt:skip
@@ -433,13 +435,22 @@ def _combine_name(in_files):
 
     Examples
     --------
-    >>> _combine_name(['/path/to/sub-01_task-rest_run-1_bold.nii.gz', '/path/to/sub-01_task-rest_run-2_bold.nii.gz'])
+    >>> _combine_name([
+    ...     '/path/to/sub-01_task-rest_run-1_bold.nii.gz',
+    ...     '/path/to/sub-01_task-rest_run-2_bold.nii.gz',
+    ... ])
     '/path/to/sub-01_task-rest_bold.nii.gz'
 
-    >>> _combine_name(['/path/to/sub-01_task-rest_dir-AP_run-1_bold.nii.gz', '/path/to/sub-01_task-rest_dir-PA_run-2_bold.nii.gz'])
+    >>> _combine_name([
+    ...     '/path/to/sub-01_task-rest_dir-AP_run-1_bold.nii.gz',
+    ...     '/path/to/sub-01_task-rest_dir-PA_run-2_bold.nii.gz',
+    ... ])
     '/path/to/sub-01_task-rest_bold.nii.gz'
 
-    >>> _combine_name(['/path/to/sub-01_task-rest_dir-AP_run-1_bold.nii.gz', '/path/to/sub-01_task-rest_dir-AP_run-2_bold.nii.gz'])
+    >>> _combine_name([
+    ...     '/path/to/sub-01_task-rest_dir-AP_run-1_bold.nii.gz',
+    ...     '/path/to/sub-01_task-rest_dir-AP_run-2_bold.nii.gz',
+    ... ])
     '/path/to/sub-01_task-rest_dir-AP_bold.nii.gz'
 
     """


### PR DESCRIPTION
Closes #1406.

## Changes proposed in this pull request

- Derive source files from input (pre-concatenated) files instead of passing in the atlas label from the Config object.