### PR TITLE
Warp anat mask to anat space for coreg QC

### DIFF
--- a/xcp_d/workflows/bold/plotting.py
+++ b/xcp_d/workflows/bold/plotting.py
@@ -203,12 +203,11 @@ def init_qc_report_wf(
         )
         workflow.connect([
             (inputnode, warp_anatmask_to_t1w, [
-                ('bold_mask', 'input_image'),
+                ('anat_brainmask', 'input_image'),
                 ('anat', 'reference_image'),
             ]),
-            (get_native2space_transforms, warp_anatmask_to_t1w, [
-                ('bold_to_t1w_xfms', 'transforms'),
-                ('bold_to_t1w_xfms_invert', 'invert_transform_flags'),
+            (inputnode, warp_anatmask_to_t1w, [
+                ('template_to_anat_xfm', 'transforms'),
             ]),
         ])  # fmt:skip
 


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Coregistration QC was using the BOLD mask warped to anatomical space in place of the anatomical mask, which was a bug. Coregistration QC measures were all 1 before because it was comparing the BOLD brain mask against itself.