### PR TITLE
Remove background label in ConnectPlot

### DIFF
--- a/xcp_d/interfaces/connectivity.py
+++ b/xcp_d/interfaces/connectivity.py
@@ -460,7 +460,11 @@ class ConnectPlot(SimpleInterface):
             dseg_file = self.inputs.atlas_tsvs[atlas_idx]
 
             column_name = COMMUNITY_LOOKUP.get(atlas, 'network_label')
-            dseg_df = pd.read_table(dseg_file)
+            dseg_df = pd.read_table(dseg_file, index_col='index')
+            # Remove background label
+            if 0 in dseg_df.index:
+                dseg_df = dseg_df.drop(index=[0])
+
             corrs_df = pd.read_table(atlas_file, index_col='Node')
 
             if atlas.startswith('4S'):


### PR DESCRIPTION
Closes #1418.

## Changes proposed in this pull request

- If a background label (index = 0) is present in an atlas's TSV file, remove it in ConnectPlot.