### PR TITLE
Fix session-wise collection

### DIFF
--- a/xcp_d/data/tests/skeletons/nibabies_crosssectional.yml
+++ b/xcp_d/data/tests/skeletons/nibabies_crosssectional.yml
@@ -1,0 +1,351 @@
+# Skeleton based on Nibabies derivatives
+# There is only a T1w anatomical image, so it should only collect T1w files.
+"01":
+  - anat:
+    - run: 1
+      desc: preproc
+      suffix: T1w
+    - run: 1
+      from: MNI152NLin6Asym
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: MNIInfant+2
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: MNI152NLin6Asym
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: MNIInfant+2
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: fsnative
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - run: 1
+      from: fsnative
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      hemi: L
+      suffix: curv
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: inflated
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      desc: reg
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: sulc
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: thickness
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: curv
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: inflated
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      desc: reg
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: sulc
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: thickness
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      desc: brain
+      suffix: mask
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      desc: preproc
+      suffix: T1w
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      suffix: dseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: CSF
+      suffix: probseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: GM
+      suffix: probseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: WM
+      suffix: probseg
+    - run: 1
+      space: T1w
+      desc: aparcaseg
+      suffix: dseg
+    - run: 1
+      space: T1w
+      desc: aseg
+      suffix: dseg
+    - run: 1
+      space: T1w
+      desc: ribbon
+      suffix: mask
+    - run: 1
+      space: T1w
+      suffix: dseg
+    - run: 1
+      space: T1w
+      label: CSF
+      suffix: probseg
+    - run: 1
+      space: T1w
+      label: GM
+      suffix: probseg
+    - run: 1
+      space: T1w
+      label: WM
+      suffix: probseg
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: curv
+      extension: .dscalar.nii
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: sulc
+      extension: .dscalar.nii
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: thickness
+      extension: .dscalar.nii
+    fmap:
+    - run: 1
+      fmapid: auto00000
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: preproc
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: preproc
+      suffix: fieldmap
+    func:
+    - task: rest
+      dir: PA
+      run: 1
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      desc: confounds
+      suffix: timeseries
+      extension: .tsv
+    - task: rest
+      dir: PA
+      run: 1
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: fsLR
+      den: 91k
+      suffix: bold
+      extension: .dtseries.nii
+    - task: rest
+      dir: PA
+      run: 1
+      desc: coreg
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      desc: hmc
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00000
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00001
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: orig
+      to: boldref
+      mode: image
+      suffix: xfm
+      extension: .txt

--- a/xcp_d/data/tests/skeletons/nibabies_longitudinal_one_to_all.yml
+++ b/xcp_d/data/tests/skeletons/nibabies_longitudinal_one_to_all.yml
@@ -1,0 +1,604 @@
+# Skeleton based on Nibabies derivatives
+# There is only a T1w anatomical image, so it should only collect T1w files.
+"01":
+  - anat:
+    - run: 1
+      desc: preproc
+      suffix: T1w
+    - run: 1
+      from: MNI152NLin6Asym
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: MNIInfant+2
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: MNI152NLin6Asym
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: MNIInfant+2
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: fsnative
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - run: 1
+      from: fsnative
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      hemi: L
+      suffix: curv
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: inflated
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      desc: reg
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: sulc
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: thickness
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: curv
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: inflated
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      desc: reg
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: sulc
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: thickness
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      desc: brain
+      suffix: mask
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      desc: preproc
+      suffix: T1w
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      suffix: dseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: CSF
+      suffix: probseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: GM
+      suffix: probseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: WM
+      suffix: probseg
+    - run: 1
+      space: T1w
+      desc: aparcaseg
+      suffix: dseg
+    - run: 1
+      space: T1w
+      desc: aseg
+      suffix: dseg
+    - run: 1
+      space: T1w
+      desc: ribbon
+      suffix: mask
+    - run: 1
+      space: T1w
+      suffix: dseg
+    - run: 1
+      space: T1w
+      label: CSF
+      suffix: probseg
+    - run: 1
+      space: T1w
+      label: GM
+      suffix: probseg
+    - run: 1
+      space: T1w
+      label: WM
+      suffix: probseg
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: curv
+      extension: .dscalar.nii
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: sulc
+      extension: .dscalar.nii
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: thickness
+      extension: .dscalar.nii
+  - session: V02
+    fmap:
+    - run: 1
+      fmapid: auto00000
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: preproc
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: preproc
+      suffix: fieldmap
+    func:
+    - task: rest
+      dir: PA
+      run: 1
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      desc: confounds
+      suffix: timeseries
+      extension: .tsv
+    - task: rest
+      dir: PA
+      run: 1
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: fsLR
+      den: 91k
+      suffix: bold
+      extension: .dtseries.nii
+    - task: rest
+      dir: PA
+      run: 1
+      desc: coreg
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      desc: hmc
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00000
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00001
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: orig
+      to: boldref
+      mode: image
+      suffix: xfm
+      extension: .txt
+  - session: V03
+    fmap:
+    - run: 1
+      fmapid: auto00000
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: preproc
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: preproc
+      suffix: fieldmap
+    func:
+    - task: rest
+      dir: PA
+      run: 1
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      desc: confounds
+      suffix: timeseries
+      extension: .tsv
+    - task: rest
+      dir: PA
+      run: 1
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: fsLR
+      den: 91k
+      suffix: bold
+      extension: .dtseries.nii
+    - task: rest
+      dir: PA
+      run: 1
+      desc: coreg
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      desc: hmc
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00000
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00001
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: orig
+      to: boldref
+      mode: image
+      suffix: xfm
+      extension: .txt
+  - session: V04
+    fmap:
+    - run: 1
+      fmapid: auto00000
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: preproc
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: preproc
+      suffix: fieldmap
+    func:
+    - task: rest
+      dir: PA
+      run: 1
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      desc: confounds
+      suffix: timeseries
+      extension: .tsv
+    - task: rest
+      dir: PA
+      run: 1
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: fsLR
+      den: 91k
+      suffix: bold
+      extension: .dtseries.nii
+    - task: rest
+      dir: PA
+      run: 1
+      desc: coreg
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      desc: hmc
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00000
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00001
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: orig
+      to: boldref
+      mode: image
+      suffix: xfm
+      extension: .txt

--- a/xcp_d/data/tests/skeletons/nibabies_longitudinal_one_to_one.yml
+++ b/xcp_d/data/tests/skeletons/nibabies_longitudinal_one_to_one.yml
@@ -1,0 +1,1050 @@
+# Skeleton based on Nibabies derivatives
+# There is only a T1w anatomical image, so it should only collect T1w files.
+"01":
+  - session: V02
+    anat:
+    - run: 1
+      desc: preproc
+      suffix: T1w
+    - run: 1
+      from: MNI152NLin6Asym
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: MNIInfant+2
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: MNI152NLin6Asym
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: MNIInfant+2
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: fsnative
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - run: 1
+      from: fsnative
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      hemi: L
+      suffix: curv
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: inflated
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      desc: reg
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: sulc
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: thickness
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: curv
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: inflated
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      desc: reg
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: sulc
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: thickness
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      desc: brain
+      suffix: mask
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      desc: preproc
+      suffix: T1w
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      suffix: dseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: CSF
+      suffix: probseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: GM
+      suffix: probseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: WM
+      suffix: probseg
+    - run: 1
+      space: T1w
+      desc: aparcaseg
+      suffix: dseg
+    - run: 1
+      space: T1w
+      desc: aseg
+      suffix: dseg
+    - run: 1
+      space: T1w
+      desc: ribbon
+      suffix: mask
+    - run: 1
+      space: T1w
+      suffix: dseg
+    - run: 1
+      space: T1w
+      label: CSF
+      suffix: probseg
+    - run: 1
+      space: T1w
+      label: GM
+      suffix: probseg
+    - run: 1
+      space: T1w
+      label: WM
+      suffix: probseg
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: curv
+      extension: .dscalar.nii
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: sulc
+      extension: .dscalar.nii
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: thickness
+      extension: .dscalar.nii
+    fmap:
+    - run: 1
+      fmapid: auto00000
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: preproc
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: preproc
+      suffix: fieldmap
+    func:
+    - task: rest
+      dir: PA
+      run: 1
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      desc: confounds
+      suffix: timeseries
+      extension: .tsv
+    - task: rest
+      dir: PA
+      run: 1
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: fsLR
+      den: 91k
+      suffix: bold
+      extension: .dtseries.nii
+    - task: rest
+      dir: PA
+      run: 1
+      desc: coreg
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      desc: hmc
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00000
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00001
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: orig
+      to: boldref
+      mode: image
+      suffix: xfm
+      extension: .txt
+  - session: V03
+    anat:
+    - run: 1
+      desc: preproc
+      suffix: T1w
+    - run: 1
+      from: MNI152NLin6Asym
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: MNIInfant+2
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: MNI152NLin6Asym
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: MNIInfant+2
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: fsnative
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - run: 1
+      from: fsnative
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      hemi: L
+      suffix: curv
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: inflated
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      desc: reg
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: sulc
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: thickness
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: curv
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: inflated
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      desc: reg
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: sulc
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: thickness
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      desc: brain
+      suffix: mask
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      desc: preproc
+      suffix: T1w
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      suffix: dseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: CSF
+      suffix: probseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: GM
+      suffix: probseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: WM
+      suffix: probseg
+    - run: 1
+      space: T1w
+      desc: aparcaseg
+      suffix: dseg
+    - run: 1
+      space: T1w
+      desc: aseg
+      suffix: dseg
+    - run: 1
+      space: T1w
+      desc: ribbon
+      suffix: mask
+    - run: 1
+      space: T1w
+      suffix: dseg
+    - run: 1
+      space: T1w
+      label: CSF
+      suffix: probseg
+    - run: 1
+      space: T1w
+      label: GM
+      suffix: probseg
+    - run: 1
+      space: T1w
+      label: WM
+      suffix: probseg
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: curv
+      extension: .dscalar.nii
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: sulc
+      extension: .dscalar.nii
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: thickness
+      extension: .dscalar.nii
+    fmap:
+    - run: 1
+      fmapid: auto00000
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: preproc
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: preproc
+      suffix: fieldmap
+    func:
+    - task: rest
+      dir: PA
+      run: 1
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      desc: confounds
+      suffix: timeseries
+      extension: .tsv
+    - task: rest
+      dir: PA
+      run: 1
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: fsLR
+      den: 91k
+      suffix: bold
+      extension: .dtseries.nii
+    - task: rest
+      dir: PA
+      run: 1
+      desc: coreg
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      desc: hmc
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00000
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00001
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: orig
+      to: boldref
+      mode: image
+      suffix: xfm
+      extension: .txt
+  - session: V04
+    anat:
+    - run: 1
+      desc: preproc
+      suffix: T1w
+    - run: 1
+      from: MNI152NLin6Asym
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: MNIInfant+2
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: MNI152NLin6Asym
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: MNIInfant+2
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      from: T1w
+      to: fsnative
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - run: 1
+      from: fsnative
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .h5
+    - run: 1
+      hemi: L
+      suffix: curv
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: inflated
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      den: 32k
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      space: fsLR
+      desc: reg
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: L
+      suffix: sulc
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: thickness
+      extension: .shape.gii
+    - run: 1
+      hemi: L
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: curv
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: inflated
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: midthickness
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: pial
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      den: 32k
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      space: fsLR
+      desc: reg
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: sphere
+      extension: .surf.gii
+    - run: 1
+      hemi: R
+      suffix: sulc
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: thickness
+      extension: .shape.gii
+    - run: 1
+      hemi: R
+      suffix: white
+      extension: .surf.gii
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      desc: brain
+      suffix: mask
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      desc: preproc
+      suffix: T1w
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      suffix: dseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: CSF
+      suffix: probseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: GM
+      suffix: probseg
+    - run: 1
+      space: MNI152NLin6Asym
+      res: 2
+      label: WM
+      suffix: probseg
+    - run: 1
+      space: T1w
+      desc: aparcaseg
+      suffix: dseg
+    - run: 1
+      space: T1w
+      desc: aseg
+      suffix: dseg
+    - run: 1
+      space: T1w
+      desc: ribbon
+      suffix: mask
+    - run: 1
+      space: T1w
+      suffix: dseg
+    - run: 1
+      space: T1w
+      label: CSF
+      suffix: probseg
+    - run: 1
+      space: T1w
+      label: GM
+      suffix: probseg
+    - run: 1
+      space: T1w
+      label: WM
+      suffix: probseg
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: curv
+      extension: .dscalar.nii
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: sulc
+      extension: .dscalar.nii
+    - run: 1
+      space: fsLR
+      den: 91k
+      suffix: thickness
+      extension: .dscalar.nii
+    fmap:
+    - run: 1
+      fmapid: auto00000
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00000
+      desc: preproc
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: coeff
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: epi
+      suffix: fieldmap
+    - run: 1
+      fmapid: auto00001
+      desc: preproc
+      suffix: fieldmap
+    func:
+    - task: rest
+      dir: PA
+      run: 1
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      desc: confounds
+      suffix: timeseries
+      extension: .tsv
+    - task: rest
+      dir: PA
+      run: 1
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: fsLR
+      den: 91k
+      suffix: bold
+      extension: .dtseries.nii
+    - task: rest
+      dir: PA
+      run: 1
+      desc: coreg
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      desc: hmc
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: MNI152NLin6Asym
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: preproc
+      suffix: bold
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      suffix: boldref
+    - task: rest
+      dir: PA
+      run: 1
+      space: T1w
+      desc: brain
+      suffix: mask
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00000
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: auto00001
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: boldref
+      to: T1w
+      mode: image
+      suffix: xfm
+      extension: .txt
+    - task: rest
+      dir: PA
+      run: 1
+      from: orig
+      to: boldref
+      mode: image
+      suffix: xfm
+      extension: .txt

--- a/xcp_d/tests/test_utils_bids_collect_data.py
+++ b/xcp_d/tests/test_utils_bids_collect_data.py
@@ -3,7 +3,7 @@
 import os
 
 import pytest
-from bids.layout import BIDSLayout
+from bids.layout import BIDSLayout, Query
 from niworkflows.utils.testing import generate_bids_skeleton
 
 import xcp_d.utils.bids as xbids
@@ -22,6 +22,8 @@ def test_collect_data_ds001419(datasets):
         participant_label='01',
         bids_filters=None,
         file_format='nifti',
+        anat_session=Query.NONE,
+        func_sessions=[Query.NONE],
     )
 
     assert len(subj_data['bold']) == 4
@@ -38,6 +40,8 @@ def test_collect_data_ds001419(datasets):
         participant_label='01',
         bids_filters={'bold': {'task': 'rest'}},
         file_format='cifti',
+        anat_session=Query.NONE,
+        func_sessions=[Query.NONE],
     )
 
     assert len(subj_data['bold']) == 1
@@ -67,6 +71,8 @@ def test_collect_data_nibabies(datasets):
         participant_label='01',
         bids_filters=None,
         file_format='nifti',
+        anat_session='1m0',
+        func_sessions=['1mo'],
     )
 
     assert len(subj_data['bold']) == 1
@@ -85,6 +91,8 @@ def test_collect_data_nibabies(datasets):
             participant_label='01',
             bids_filters=None,
             file_format='cifti',
+            anat_session='1m0',
+            func_sessions=['1mo'],
         )
 
 
@@ -105,6 +113,8 @@ def test_collect_data_nibabies_t1w_only(tmp_path_factory, caplog):
         participant_label='01',
         bids_filters=None,
         file_format='cifti',
+        anat_session='V03',
+        func_sessions=['V03'],
     )
     assert subj_data['t1w'] is not None
     assert subj_data['t2w'] is None
@@ -128,6 +138,8 @@ def test_collect_data_nibabies_t2w_only(tmp_path_factory, caplog):
         participant_label='01',
         bids_filters=None,
         file_format='cifti',
+        anat_session='V03',
+        func_sessions=['V03'],
     )
     assert subj_data['t1w'] is None
     assert subj_data['t2w'] is not None
@@ -152,6 +164,8 @@ def test_collect_data_nibabies_no_t1w_t2w(tmp_path_factory, caplog):
             participant_label='01',
             bids_filters=None,
             file_format='cifti',
+            anat_session='V03',
+            func_sessions=['V03'],
         )
 
 
@@ -178,6 +192,8 @@ def test_collect_data_nibabies_ignore_t2w(tmp_path_factory, caplog):
         participant_label='01',
         bids_filters=None,
         file_format='cifti',
+        anat_session='V03',
+        func_sessions=['V03'],
     )
     assert subj_data['t1w'] is not None
     assert subj_data['t2w'] is None
@@ -210,6 +226,8 @@ def test_collect_data_nibabies_t2w_to_t1w(tmp_path_factory, caplog):
         participant_label='01',
         bids_filters=None,
         file_format='cifti',
+        anat_session='V03',
+        func_sessions=['V03'],
     )
     assert subj_data['t1w'] is not None
     assert subj_data['t2w'] is not None
@@ -244,6 +262,8 @@ def test_collect_data_nibabies_ignore_t1w(tmp_path_factory, caplog):
         participant_label='01',
         bids_filters=None,
         file_format='cifti',
+        anat_session='V03',
+        func_sessions=['V03'],
     )
     assert subj_data['t1w'] is None
     assert subj_data['t2w'] is not None
@@ -276,6 +296,8 @@ def test_collect_data_nibabies_t1w_to_t2w(tmp_path_factory, caplog):
         participant_label='01',
         bids_filters=None,
         file_format='cifti',
+        anat_session='V03',
+        func_sessions=['V03'],
     )
     assert subj_data['t1w'] is not None
     assert subj_data['t2w'] is not None
@@ -307,6 +329,8 @@ def test_collect_data_nibabies_t1wspace_t2w(tmp_path_factory, caplog):
         participant_label='01',
         bids_filters=None,
         file_format='cifti',
+        anat_session='V03',
+        func_sessions=['V03'],
     )
     assert subj_data['t1w'] is not None
     assert subj_data['t2w'] is not None
@@ -335,6 +359,8 @@ def test_collect_data_nibabies_t2wspace_t1w(tmp_path_factory, caplog):
         participant_label='01',
         bids_filters=None,
         file_format='cifti',
+        anat_session='V03',
+        func_sessions=['V03'],
     )
     assert subj_data['t1w'] is not None
     assert subj_data['t2w'] is not None
@@ -342,3 +368,78 @@ def test_collect_data_nibabies_t2wspace_t1w(tmp_path_factory, caplog):
     assert 'Both T1w and T2w found. Checking for T1w-space T2w.' in caplog.text
     assert 'No T1w-space T2w found. Checking for T2w-space T1w.' in caplog.text
     assert 'T2w-space T1w found. Processing anatomical images in T2w space.' in caplog.text
+
+
+def test_collect_data_crosssectional(tmp_path_factory, caplog):
+    """Test that XCP-D works on a cross-sectional dataset."""
+    skeleton = load_data('tests/skeletons/nibabies_crosssectional.yml')
+    bids_dir = tmp_path_factory.mktemp('test_collect_data_crosssectional') / 'bids'
+    generate_bids_skeleton(str(bids_dir), str(skeleton))
+    xcp_d_config = str(load_data('xcp_d_bids_config2.json'))
+    layout = BIDSLayout(
+        bids_dir,
+        validate=False,
+        config=['bids', 'derivatives', xcp_d_config],
+    )
+    subj_data = xbids.collect_data(
+        layout=layout,
+        input_type='nibabies',
+        participant_label='01',
+        bids_filters=None,
+        file_format='cifti',
+        anat_session=Query.NONE,
+        func_sessions=[Query.NONE],
+    )
+    assert subj_data['t1w'] is not None
+    assert subj_data['t2w'] is None
+    assert 'T1w found, but no T2w. Enabling T1w-only processing.' in caplog.text
+
+
+def test_collect_data_longitudinal_one_to_all(tmp_path_factory, caplog):
+    """Test that XCP-D works on a longitudinal dataset with one anat for all sessions."""
+    skeleton = load_data('tests/skeletons/nibabies_longitudinal_one_to_all.yml')
+    bids_dir = tmp_path_factory.mktemp('test_collect_data_longitudinal_one_to_one') / 'bids'
+    generate_bids_skeleton(str(bids_dir), str(skeleton))
+    xcp_d_config = str(load_data('xcp_d_bids_config2.json'))
+    layout = BIDSLayout(
+        bids_dir,
+        validate=False,
+        config=['bids', 'derivatives', xcp_d_config],
+    )
+    subj_data = xbids.collect_data(
+        layout=layout,
+        input_type='nibabies',
+        participant_label='01',
+        bids_filters=None,
+        file_format='cifti',
+        anat_session=Query.NONE,
+        func_sessions=['V02', 'V03', 'V04'],
+    )
+    assert subj_data['t1w'] is not None
+    assert subj_data['t2w'] is None
+    assert 'T1w found, but no T2w. Enabling T1w-only processing.' in caplog.text
+
+
+def test_collect_data_longitudinal_one_to_one(tmp_path_factory, caplog):
+    """Test that XCP-D works on a longitudinal dataset with one anat for each session."""
+    skeleton = load_data('tests/skeletons/nibabies_longitudinal_one_to_one.yml')
+    bids_dir = tmp_path_factory.mktemp('test_collect_data_longitudinal_one_to_one') / 'bids'
+    generate_bids_skeleton(str(bids_dir), str(skeleton))
+    xcp_d_config = str(load_data('xcp_d_bids_config2.json'))
+    layout = BIDSLayout(
+        bids_dir,
+        validate=False,
+        config=['bids', 'derivatives', xcp_d_config],
+    )
+    subj_data = xbids.collect_data(
+        layout=layout,
+        input_type='nibabies',
+        participant_label='01',
+        bids_filters=None,
+        file_format='cifti',
+        anat_session='V03',
+        func_sessions=['V03'],
+    )
+    assert subj_data['t1w'] is not None
+    assert subj_data['t2w'] is None
+    assert 'T1w found, but no T2w. Enabling T1w-only processing.' in caplog.text

--- a/xcp_d/tests/test_utils_bids_collect_data.py
+++ b/xcp_d/tests/test_utils_bids_collect_data.py
@@ -71,7 +71,7 @@ def test_collect_data_nibabies(datasets):
         participant_label='01',
         bids_filters=None,
         file_format='nifti',
-        anat_session='1m0',
+        anat_session='1mo',
         func_sessions=['1mo'],
     )
 
@@ -91,7 +91,7 @@ def test_collect_data_nibabies(datasets):
             participant_label='01',
             bids_filters=None,
             file_format='cifti',
-            anat_session='1m0',
+            anat_session='1mo',
             func_sessions=['1mo'],
         )
 

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -154,6 +154,8 @@ def collect_data(
     participant_label,
     bids_filters,
     file_format,
+    anat_session,
+    func_sessions,
 ):
     """Collect data from a BIDS dataset.
 
@@ -164,6 +166,8 @@ def collect_data(
     participant_label
     bids_filters
     file_format
+    anat_session
+    func_sessions
 
     Returns
     -------
@@ -185,6 +189,13 @@ def collect_data(
     for acq in queries.keys():
         if acq in bids_filters:
             queries[acq].update(bids_filters[acq])
+
+    # Add sessions to queries
+    for acq, query in queries.items():
+        if query['datatype'] == 'anat':
+            queries[acq].update({'session': anat_session})
+        elif query['datatype'] == 'func':
+            queries[acq].update({'session': func_sessions})
 
     # Select the best available space.
     if 'space' in queries['bold']:

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -134,22 +134,14 @@ def init_single_subject_wf(subject_id: str, anat_session: str, func_sessions: li
     # If session is in the anatomical files, loop over sessions and collect functional data
     # separately for each session.
     # Otherwise, collect functional data for all sessions at once.
-    # Patch the sessions into the bids_filters
-    anat_session = anat_session or Query.NONE
-    func_sessions = [ses or Query.NONE for ses in func_sessions]
-    bids_filters = config.execution.bids_filters or {}
-    bids_filters['bold'] = bids_filters.get('bold', {})
-    bids_filters['bold']['session'] = func_sessions
-    bids_filters['T1w'] = bids_filters.get('T1w', {})
-    bids_filters['T1w']['session'] = anat_session
-    bids_filters['T2w'] = bids_filters.get('T2w', {})
-    bids_filters['T2w']['session'] = anat_session
     subj_data = collect_data(
         layout=config.execution.layout,
         participant_label=subject_id,
-        bids_filters=bids_filters,
+        bids_filters=config.execution.bids_filters or {},
         input_type=config.workflow.input_type,
         file_format=config.workflow.file_format,
+        anat_session=anat_session or Query.NONE,
+        func_sessions=[ses or Query.NONE for ses in func_sessions],
     )
     t1w_available = subj_data['t1w'] is not None
     t2w_available = subj_data['t2w'] is not None


### PR DESCRIPTION
Closes none, but fixes bus introduced in #1438.

## Changes proposed in this pull request

- Remove manual session patching in bids_filters from base.py.
- Update collect_data (in xcp_d/utils/bids.py) to accept and propagate anat_session and func_sessions.
- Enhance tests to validate these changes across cross‐sectional and longitudinal datasets.
