### PR TITLE
Fix session-wise collection of surface files

### DIFF
--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -64,7 +64,7 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
         layout,
         '1648798153',
         bids_filters={},
-        anat_session=Query.NONE,
+        anat_session='PNC1',
     )
     assert mesh_available is True
     assert standard_space_mesh is False
@@ -94,7 +94,7 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
         layout,
         '1648798153',
         bids_filters={},
-        anat_session=Query.NONE,
+        anat_session='PNC1',
     )
     assert mesh_available is True
     assert standard_space_mesh is True
@@ -126,7 +126,7 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
 
     layout = BIDSLayout(std_mesh_dir, validate=False)
     with pytest.raises(ValueError, match='More than one surface found'):
-        xbids.collect_mesh_data(layout, '1648798153', bids_filters={}, anat_session=Query.NONE)
+        xbids.collect_mesh_data(layout, '1648798153', bids_filters={}, anat_session='PNC1')
 
     # If we include BIDS filters, we should be able to ignore the existing files
     layout = BIDSLayout(datasets['pnc'], validate=False)
@@ -141,7 +141,7 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
             'lh_subject_sphere': {'acquisition': 'test'},
             'rh_subject_sphere': {'acquisition': 'test'},
         },
-        anat_session=Query.NONE,
+        anat_session='PNC1',
     )
     assert mesh_available is False
     assert standard_space_mesh is False

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -5,7 +5,7 @@ import os
 import shutil
 
 import pytest
-from bids.layout import BIDSLayout
+from bids.layout import BIDSLayout, Query
 
 import xcp_d.utils.bids as xbids
 
@@ -48,7 +48,10 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
     # Dataset without mesh files
     layout = BIDSLayout(datasets['fmriprep_without_freesurfer'], validate=False)
     mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(
-        layout, '1648798153', bids_filters={}
+        layout,
+        '1648798153',
+        bids_filters={},
+        anat_session=Query.NONE,
     )
     assert mesh_available is False
     assert standard_space_mesh is False
@@ -56,7 +59,10 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
     # Dataset with native-space mesh files (one file matching each query)
     layout = BIDSLayout(datasets['pnc'], validate=False)
     mesh_available, standard_space_mesh, _, _ = xbids.collect_mesh_data(
-        layout, '1648798153', bids_filters={}
+        layout,
+        '1648798153',
+        bids_filters={},
+        anat_session=Query.NONE,
     )
     assert mesh_available is True
     assert standard_space_mesh is False
@@ -83,7 +89,10 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
 
     layout = BIDSLayout(std_mesh_dir, validate=False)
     mesh_available, standard_space_mesh, _, mesh_files = xbids.collect_mesh_data(
-        layout, '1648798153', bids_filters={}
+        layout,
+        '1648798153',
+        bids_filters={},
+        anat_session=Query.NONE,
     )
     assert mesh_available is True
     assert standard_space_mesh is True
@@ -115,7 +124,7 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
 
     layout = BIDSLayout(std_mesh_dir, validate=False)
     with pytest.raises(ValueError, match='More than one surface found'):
-        xbids.collect_mesh_data(layout, '1648798153', bids_filters={})
+        xbids.collect_mesh_data(layout, '1648798153', bids_filters={}, anat_session=Query.NONE)
 
     # If we include BIDS filters, we should be able to ignore the existing files
     layout = BIDSLayout(datasets['pnc'], validate=False)
@@ -130,6 +139,7 @@ def test_collect_mesh_data(datasets, tmp_path_factory):
             'lh_subject_sphere': {'acquisition': 'test'},
             'rh_subject_sphere': {'acquisition': 'test'},
         },
+        anat_session=Query.NONE,
     )
     assert mesh_available is False
     assert standard_space_mesh is False
@@ -139,12 +149,22 @@ def test_collect_morphometry_data(datasets, tmp_path_factory):
     """Test collect_morphometry_data."""
     # Dataset without morphometry files
     layout = BIDSLayout(datasets['fmriprep_without_freesurfer'], validate=False)
-    morph_file_types, _ = xbids.collect_morphometry_data(layout, '1648798153', bids_filters={})
+    morph_file_types, _ = xbids.collect_morphometry_data(
+        layout,
+        '1648798153',
+        bids_filters={},
+        anat_session=Query.NONE,
+    )
     assert morph_file_types == []
 
     # Dataset with morphometry files (one file matching each query)
     layout = BIDSLayout(datasets['pnc'], validate=False)
-    morph_file_types, _ = xbids.collect_morphometry_data(layout, '1648798153', bids_filters={})
+    morph_file_types, _ = xbids.collect_morphometry_data(
+        layout,
+        '1648798153',
+        bids_filters={},
+        anat_session=Query.NONE,
+    )
     assert morph_file_types == ['cortical_thickness', 'sulcal_curv', 'sulcal_depth']
 
     # Dataset with multiple files matching each query (raises an error)
@@ -167,7 +187,12 @@ def test_collect_morphometry_data(datasets, tmp_path_factory):
 
     layout = BIDSLayout(bad_morph_dir, validate=False)
     with pytest.raises(ValueError, match='More than one .* found'):
-        xbids.collect_morphometry_data(layout, '1648798153', bids_filters={})
+        xbids.collect_morphometry_data(
+            layout,
+            '1648798153',
+            bids_filters={},
+            anat_session=Query.NONE,
+        )
 
     # If we include BIDS filters, we should be able to ignore the existing files
     layout = BIDSLayout(datasets['pnc'], validate=False)
@@ -179,6 +204,7 @@ def test_collect_morphometry_data(datasets, tmp_path_factory):
             'sulcal_curv': {'acquisition': 'test'},
             'sulcal_depth': {'acquisition': 'test'},
         },
+        anat_session=Query.NONE,
     )
     assert morph_file_types == []
 

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -6,8 +6,10 @@ import shutil
 
 import pytest
 from bids.layout import BIDSLayout, Query
+from niworkflows.utils.testing import generate_bids_skeleton
 
 import xcp_d.utils.bids as xbids
+from xcp_d.data import load as load_data
 
 
 def test_collect_participants(datasets):
@@ -424,3 +426,132 @@ def test_group_across_runs():
         '/path/sub-01_task-rest_dir-LR_run-2_bold.nii.gz',
         '/path/sub-01_task-rest_dir-RL_run-2_bold.nii.gz',
     ]
+
+
+def test_collect_mesh_data_crosssectional(tmp_path_factory, caplog):
+    """Test that XCP-D works on a cross-sectional dataset."""
+    skeleton = load_data('tests/skeletons/nibabies_crosssectional.yml')
+    bids_dir = tmp_path_factory.mktemp('test_collect_mesh_data_crosssectional') / 'bids'
+    generate_bids_skeleton(str(bids_dir), str(skeleton))
+    xcp_d_config = str(load_data('xcp_d_bids_config2.json'))
+    layout = BIDSLayout(
+        bids_dir,
+        validate=False,
+        config=['bids', 'derivatives', xcp_d_config],
+    )
+    mesh_available, standard_space_mesh, software, _ = xbids.collect_mesh_data(
+        layout=layout,
+        participant_label='01',
+        bids_filters=None,
+        anat_session=Query.NONE,
+    )
+    assert mesh_available is True
+    assert standard_space_mesh is True
+    assert software == 'Freesurfer'
+
+
+def test_collect_mesh_data_longitudinal_one_to_all(tmp_path_factory, caplog):
+    """Test that XCP-D works on a longitudinal dataset with one anat for all sessions."""
+    skeleton = load_data('tests/skeletons/nibabies_longitudinal_one_to_all.yml')
+    bids_dir = tmp_path_factory.mktemp('test_collect_mesh_data_longitudinal_one_to_all') / 'bids'
+    generate_bids_skeleton(str(bids_dir), str(skeleton))
+    xcp_d_config = str(load_data('xcp_d_bids_config2.json'))
+    layout = BIDSLayout(
+        bids_dir,
+        validate=False,
+        config=['bids', 'derivatives', xcp_d_config],
+    )
+    mesh_available, standard_space_mesh, software, _ = xbids.collect_mesh_data(
+        layout=layout,
+        participant_label='01',
+        bids_filters=None,
+        anat_session=Query.NONE,
+    )
+    assert mesh_available is True
+    assert standard_space_mesh is True
+    assert software == 'Freesurfer'
+
+
+def test_collect_mesh_data_longitudinal_one_to_one(tmp_path_factory, caplog):
+    """Test that XCP-D works on a longitudinal dataset with one anat for each session."""
+    skeleton = load_data('tests/skeletons/nibabies_longitudinal_one_to_one.yml')
+    bids_dir = tmp_path_factory.mktemp('test_collect_mesh_data_longitudinal_one_to_one') / 'bids'
+    generate_bids_skeleton(str(bids_dir), str(skeleton))
+    xcp_d_config = str(load_data('xcp_d_bids_config2.json'))
+    layout = BIDSLayout(
+        bids_dir,
+        validate=False,
+        config=['bids', 'derivatives', xcp_d_config],
+    )
+    mesh_available, standard_space_mesh, software, _ = xbids.collect_mesh_data(
+        layout=layout,
+        participant_label='01',
+        bids_filters=None,
+        anat_session='V03',
+    )
+    assert mesh_available is True
+    assert standard_space_mesh is True
+    assert software == 'Freesurfer'
+
+
+def test_collect_morphometry_data_crosssectional(tmp_path_factory, caplog):
+    """Test that XCP-D works on a cross-sectional dataset."""
+    skeleton = load_data('tests/skeletons/nibabies_crosssectional.yml')
+    bids_dir = tmp_path_factory.mktemp('test_collect_morphometry_data_crosssectional') / 'bids'
+    generate_bids_skeleton(str(bids_dir), str(skeleton))
+    xcp_d_config = str(load_data('xcp_d_bids_config2.json'))
+    layout = BIDSLayout(
+        bids_dir,
+        validate=False,
+        config=['bids', 'derivatives', xcp_d_config],
+    )
+    morph_file_types, morphometry_files = xbids.collect_morphometry_data(
+        layout=layout,
+        participant_label='01',
+        bids_filters=None,
+        anat_session=Query.NONE,
+    )
+    assert morph_file_types == ['cortical_thickness', 'sulcal_curv', 'sulcal_depth']
+    assert morphometry_files is not None
+
+
+def test_collect_morphometry_data_longitudinal_one_to_all(tmp_path_factory, caplog):
+    """Test that XCP-D works on a longitudinal dataset with one anat for all sessions."""
+    skeleton = load_data('tests/skeletons/nibabies_longitudinal_one_to_all.yml')
+    bids_dir = tmp_path_factory.mktemp('test_collect_morph_data_longitudinal_one_to_all') / 'bids'
+    generate_bids_skeleton(str(bids_dir), str(skeleton))
+    xcp_d_config = str(load_data('xcp_d_bids_config2.json'))
+    layout = BIDSLayout(
+        bids_dir,
+        validate=False,
+        config=['bids', 'derivatives', xcp_d_config],
+    )
+    morph_file_types, morphometry_files = xbids.collect_morphometry_data(
+        layout=layout,
+        participant_label='01',
+        bids_filters=None,
+        anat_session=Query.NONE,
+    )
+    assert morph_file_types == ['cortical_thickness', 'sulcal_curv', 'sulcal_depth']
+    assert morphometry_files is not None
+
+
+def test_collect_morphometry_data_longitudinal_one_to_one(tmp_path_factory, caplog):
+    """Test that XCP-D works on a longitudinal dataset with one anat for each session."""
+    skeleton = load_data('tests/skeletons/nibabies_longitudinal_one_to_one.yml')
+    bids_dir = tmp_path_factory.mktemp('test_collect_morph_data_longitudinal_one_to_one') / 'bids'
+    generate_bids_skeleton(str(bids_dir), str(skeleton))
+    xcp_d_config = str(load_data('xcp_d_bids_config2.json'))
+    layout = BIDSLayout(
+        bids_dir,
+        validate=False,
+        config=['bids', 'derivatives', xcp_d_config],
+    )
+    morph_file_types, morphometry_files = xbids.collect_morphometry_data(
+        layout=layout,
+        participant_label='01',
+        bids_filters=None,
+        anat_session='V03',
+    )
+    assert morph_file_types == ['cortical_thickness', 'sulcal_curv', 'sulcal_depth']
+    assert morphometry_files is not None

--- a/xcp_d/tests/test_utils_bids.py
+++ b/xcp_d/tests/test_utils_bids.py
@@ -165,7 +165,7 @@ def test_collect_morphometry_data(datasets, tmp_path_factory):
         layout,
         '1648798153',
         bids_filters={},
-        anat_session=Query.NONE,
+        anat_session='PNC1',
     )
     assert morph_file_types == ['cortical_thickness', 'sulcal_curv', 'sulcal_depth']
 
@@ -193,7 +193,7 @@ def test_collect_morphometry_data(datasets, tmp_path_factory):
             layout,
             '1648798153',
             bids_filters={},
-            anat_session=Query.NONE,
+            anat_session='PNC1',
         )
 
     # If we include BIDS filters, we should be able to ignore the existing files
@@ -206,7 +206,7 @@ def test_collect_morphometry_data(datasets, tmp_path_factory):
             'sulcal_curv': {'acquisition': 'test'},
             'sulcal_depth': {'acquisition': 'test'},
         },
-        anat_session=Query.NONE,
+        anat_session='PNC1',
     )
     assert morph_file_types == []
 
@@ -447,7 +447,7 @@ def test_collect_mesh_data_crosssectional(tmp_path_factory, caplog):
     )
     assert mesh_available is True
     assert standard_space_mesh is True
-    assert software == 'Freesurfer'
+    assert software == 'FreeSurfer'
 
 
 def test_collect_mesh_data_longitudinal_one_to_all(tmp_path_factory, caplog):
@@ -469,7 +469,7 @@ def test_collect_mesh_data_longitudinal_one_to_all(tmp_path_factory, caplog):
     )
     assert mesh_available is True
     assert standard_space_mesh is True
-    assert software == 'Freesurfer'
+    assert software == 'FreeSurfer'
 
 
 def test_collect_mesh_data_longitudinal_one_to_one(tmp_path_factory, caplog):
@@ -491,7 +491,7 @@ def test_collect_mesh_data_longitudinal_one_to_one(tmp_path_factory, caplog):
     )
     assert mesh_available is True
     assert standard_space_mesh is True
-    assert software == 'Freesurfer'
+    assert software == 'FreeSurfer'
 
 
 def test_collect_morphometry_data_crosssectional(tmp_path_factory, caplog):

--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -423,7 +423,7 @@ def collect_data(
 
 
 @fill_doc
-def collect_mesh_data(layout, participant_label, bids_filters):
+def collect_mesh_data(layout, participant_label, bids_filters, anat_session):
     """Collect surface files from preprocessed derivatives.
 
     This function will try to collect fsLR-space, 32k-resolution surface files first.
@@ -435,6 +435,7 @@ def collect_mesh_data(layout, participant_label, bids_filters):
     %(layout)s
     participant_label : :obj:`str`
         Subject ID.
+    anat_session : :obj:`str` or Query.NONE
 
     Returns
     -------
@@ -459,6 +460,8 @@ def collect_mesh_data(layout, participant_label, bids_filters):
     for acq in queries.keys():
         if acq in bids_filters:
             queries[acq].update(bids_filters[acq])
+
+        queries[acq].update({'session': anat_session})
 
     # First, try to grab the first base surface file in standard (fsLR) space.
     # If it's not available, switch to native fsnative-space data.
@@ -549,7 +552,7 @@ def collect_mesh_data(layout, participant_label, bids_filters):
 
 
 @fill_doc
-def collect_morphometry_data(layout, participant_label, bids_filters):
+def collect_morphometry_data(layout, participant_label, bids_filters, anat_session):
     """Collect morphometry surface files from preprocessed derivatives.
 
     This function will look for fsLR-space, 91k-resolution morphometry CIFTI files.
@@ -559,6 +562,7 @@ def collect_morphometry_data(layout, participant_label, bids_filters):
     %(layout)s
     participant_label : :obj:`str`
         Subject ID.
+    anat_session : :obj:`str` or Query.NONE
 
     Returns
     -------
@@ -578,6 +582,8 @@ def collect_morphometry_data(layout, participant_label, bids_filters):
     for acq in queries.keys():
         if acq in bids_filters:
             queries[acq].update(bids_filters[acq])
+
+        queries[acq].update({'session': anat_session})
 
     morphometry_files = {}
     for name, query in queries.items():

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -151,11 +151,13 @@ def init_single_subject_wf(subject_id: str, anat_session: str, func_sessions: li
         layout=config.execution.layout,
         participant_label=subject_id,
         bids_filters=config.execution.bids_filters,
+        anat_session=anat_session or Query.NONE,
     )
     morph_file_types, morphometry_files = collect_morphometry_data(
         layout=config.execution.layout,
         participant_label=subject_id,
         bids_filters=config.execution.bids_filters,
+        anat_session=anat_session or Query.NONE,
     )
 
     # determine the appropriate post-processing workflow


### PR DESCRIPTION
Closes none, but fixes bug introduced in #1438.

## Changes proposed in this pull request

- Update collect_mesh_data and collect_morphometry_data (in xcp_d/utils/bids.py) to accept and propagate anat_session.
- Enhance tests to validate these changes across cross‐sectional and longitudinal datasets.