### PR TITLE
Make workflow name unique for session-wise processing

### DIFF
--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -220,7 +220,9 @@ def init_single_subject_wf(subject_id: str, anat_session: str, func_sessions: li
     inputnode.inputs.myelin = morphometry_files['myelin']
     inputnode.inputs.myelin_smoothed = morphometry_files['myelin_smoothed']
 
-    workflow = Workflow(name=f'sub_{subject_id}_wf')
+    workflow = Workflow(
+        name=f'sub_{subject_id}_ses_{anat_session}_ses_{"".join(func_sessions)}_wf'
+    )
 
     info_dict = get_preproc_pipeline_info(
         input_type=config.workflow.input_type,


### PR DESCRIPTION
Closes none, but continues from #1438.

## Changes proposed in this pull request

- Include anatomical and functional sessions in `init_single_subject_wf` workflow name.