### PR TITLE
Write out filtered motion parameters when dummy-scans is not zero

### DIFF
--- a/xcp_d/interfaces/censoring.py
+++ b/xcp_d/interfaces/censoring.py
@@ -34,6 +34,11 @@ class _RemoveDummyVolumesInputSpec(BaseInterfaceInputSpec):
             'calculated in an earlier workflow from dummy_scans.'
         ),
     )
+    dummy_scan_source = File(
+        exists=True,
+        mandatory=False,
+        desc='Source file for dummy scans (i.e., the fMRIPrep confounds file).',
+    )
     confounds_tsv = traits.Either(
         File(exists=True),
         None,
@@ -101,7 +106,7 @@ class RemoveDummyVolumes(SimpleInterface):
     def _run_interface(self, runtime):
         dummy_scans = _infer_dummy_scans(
             dummy_scans=self.inputs.dummy_scans,
-            confounds_file=self.inputs.motion_file,
+            confounds_file=self.inputs.dummy_scan_source,
         )
 
         self._results['dummy_scans'] = dummy_scans

--- a/xcp_d/tests/test_interfaces_censoring.py
+++ b/xcp_d/tests/test_interfaces_censoring.py
@@ -304,6 +304,7 @@ def test_removedummyvolumes_nifti(ds001419_data, tmp_path_factory):
         motion_file=confounds_file,
         temporal_mask=confounds_file,
         dummy_scans=0,
+        dummy_scan_source=confounds_file,
     )
     results = remove_nothing.run(cwd=tmpdir)
     undropped_confounds = pd.read_table(results.outputs.confounds_tsv_dropped_TR)
@@ -327,6 +328,7 @@ def test_removedummyvolumes_nifti(ds001419_data, tmp_path_factory):
             motion_file=confounds_file,
             temporal_mask=confounds_file,
             dummy_scans=n,
+            dummy_scan_source=confounds_file,
         )
         results = remove_n_vols.run(cwd=tmpdir)
         dropped_confounds = pd.read_table(results.outputs.confounds_tsv_dropped_TR)
@@ -363,6 +365,7 @@ def test_removedummyvolumes_cifti(ds001419_data, tmp_path_factory):
         motion_file=confounds_file,
         temporal_mask=confounds_file,
         dummy_scans=0,
+        dummy_scan_source=confounds_file,
     )
     results = remove_nothing.run(cwd=tmpdir)
     undropped_confounds = pd.read_table(results.outputs.confounds_tsv_dropped_TR)
@@ -385,6 +388,7 @@ def test_removedummyvolumes_cifti(ds001419_data, tmp_path_factory):
             motion_file=confounds_file,
             temporal_mask=confounds_file,
             dummy_scans=n,
+            dummy_scan_source=confounds_file,
         )
 
         results = remove_n_vols.run(cwd=tmpdir)

--- a/xcp_d/workflows/bold/postprocessing.py
+++ b/xcp_d/workflows/bold/postprocessing.py
@@ -269,10 +269,13 @@ def init_prepare_confounds_wf(
             (inputnode, remove_dummy_scans, [
                 ('preprocessed_bold', 'bold_file'),
                 ('dummy_scans', 'dummy_scans'),
-                # *not* the filtered motion file, which has dummy volume columns removed
-                ('motion_file', 'motion_file'),
+                # The full confounds file, not the filtered motion file
+                ('motion_file', 'dummy_scan_source'),
             ]),
-            (process_motion, remove_dummy_scans, [('temporal_mask', 'temporal_mask')]),
+            (process_motion, remove_dummy_scans, [
+                ('motion_file', 'motion_file'),
+                ('temporal_mask', 'temporal_mask'),
+            ]),
             (remove_dummy_scans, dummy_scan_buffer, [
                 ('bold_file_dropped_TR', 'preprocessed_bold'),
                 ('confounds_tsv_dropped_TR', 'confounds_tsv'),


### PR DESCRIPTION
Closes #1445.

## Changes proposed in this pull request

- Add parameter to `RemoveDummyVolumes` interface called `dummy_scan_source`. Pass the fMRIPrep confounds file in as `dummy_scan_source` and the filtered motion parameters as `motion_file`.