### PR TITLE
Ingress BOLD brain mask in ABCD-BIDS and HCP processing

### DIFF
--- a/xcp_d/ingression/abcdbids.py
+++ b/xcp_d/ingression/abcdbids.py
@@ -269,10 +269,9 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
             )
             copy_dictionary[bold_cifti_orig] = [bold_cifti_fmriprep]
 
-            # Use anatomical brain mask as bold mask
-            bold_mask_orig = os.path.join(anat_dir_orig, 'brainmask_fs.2.0.nii.gz')
+            bold_mask_orig = os.path.join(task_dir_orig, 'brainmask_fs.2.0.nii.gz')
             if not os.path.isfile(bold_mask_orig):
-                bold_mask_orig = os.path.join(anat_dir_orig, 'brainmask_fs.nii.gz')
+                bold_mask_orig = os.path.join(task_dir_orig, 'brainmask_fs.nii.gz')
 
             bold_mask_fmriprep = os.path.join(
                 func_dir_bids,

--- a/xcp_d/ingression/abcdbids.py
+++ b/xcp_d/ingression/abcdbids.py
@@ -269,6 +269,17 @@ def convert_dcan_to_bids_single_subject(in_dir, out_dir, sub_ent):
             )
             copy_dictionary[bold_cifti_orig] = [bold_cifti_fmriprep]
 
+            # Use anatomical brain mask as bold mask
+            bold_mask_orig = os.path.join(anat_dir_orig, 'brainmask_fs.2.0.nii.gz')
+            if not os.path.isfile(bold_mask_orig):
+                bold_mask_orig = os.path.join(anat_dir_orig, 'brainmask_fs.nii.gz')
+
+            bold_mask_fmriprep = os.path.join(
+                func_dir_bids,
+                f'{func_prefix}_{volspace_ent}_{RES_ENT}_desc-brain_mask.nii.gz',
+            )
+            copy_dictionary[bold_mask_orig] = [bold_mask_fmriprep]
+
             # Extract metadata for JSON files
             bold_metadata = {
                 'RepetitionTime': float(nb.load(bold_nifti_orig).header.get_zooms()[-1]),

--- a/xcp_d/ingression/hcpya.py
+++ b/xcp_d/ingression/hcpya.py
@@ -290,6 +290,16 @@ def convert_hcp_to_bids_single_subject(in_dir, out_dir, sub_ent):
         )
         copy_dictionary[bold_cifti_orig] = [bold_cifti_fmriprep]
 
+        bold_mask_orig = os.path.join(task_dir_orig, 'brainmask_fs.2.0.nii.gz')
+        if not os.path.isfile(bold_mask_orig):
+            bold_mask_orig = os.path.join(task_dir_orig, 'brainmask_fs.nii.gz')
+
+        bold_mask_fmriprep = os.path.join(
+            func_dir_bids,
+            f'{func_prefix}_{volspace_ent}_{RES_ENT}_desc-brain_mask.nii.gz',
+        )
+        copy_dictionary[bold_mask_orig] = [bold_mask_fmriprep]
+
         # Extract metadata for JSON files
         bold_metadata = {
             'RepetitionTime': float(nb.load(bold_nifti_orig).header.get_zooms()[-1]),

--- a/xcp_d/ingression/utils.py
+++ b/xcp_d/ingression/utils.py
@@ -21,8 +21,10 @@ def collect_anatomical_files(anat_dir_orig, anat_dir_bids, base_anatomical_ents)
     ANAT_DICT = {
         # XXX: Why have T1w here and T1w_restore for HCP?
         'T1w.nii.gz': 'desc-preproc_T1w.nii.gz',
-        'brainmask_fs.nii.gz': 'desc-brain_mask.nii.gz',
         'ribbon.nii.gz': 'desc-ribbon_T1w.nii.gz',
+        # Use either brainmask_fs or brainmask_fs.2.0, depending on which is available.
+        'brainmask_fs.nii.gz': 'desc-brain_mask.nii.gz',
+        'brainmask_fs.2.0.nii.gz': 'desc-brain_mask.nii.gz',
     }
     copy_dictionary = {}
 


### PR DESCRIPTION
Closes none, but addresses a bug identified by @rosemccollum. Basically, in 0.10.7 we started using a brain mask NIfTI in the CIFTI workflow in order to mask out non-brain voxels in the executive summary (see #1425), but I didn't add a brain mask to the converted ABCD/HCP data.

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
