### PR TITLE
Check DatasetType for "derivative" or "derivatives"

### DIFF
--- a/xcp_d/utils/bids.py
+++ b/xcp_d/utils/bids.py
@@ -820,8 +820,12 @@ def collect_confounds(
                     config=['bids', 'derivatives', xcp_d_config],
                     indexer=_indexer,
                 )
-                if layout.get_dataset_description().get('DatasetType') != 'derivatives':
-                    print(f'Dataset {k} is not a derivatives dataset. Skipping.')
+                desc = layout.get_dataset_description()
+                # Check for derivative or derivatives. The latter is a typo, but one that I've
+                # used in other places, and I don't want to have to update all of my test datasets.
+                if desc.get('DatasetType') not in ['derivative', 'derivatives']:
+                    print(f'Dataset {k} is not a derivative dataset. Skipping.')
+                    continue
 
                 layout_dict[k] = layout
             else:


### PR DESCRIPTION
Closes none, but should address https://neurostars.org/t/xcp-d-not-recognizing-fmripost-aroma-output/33835.

## Changes proposed in this pull request

- Check dataset_description.DatasetType for "derivative" or "derivatives." "derivatives" is a typo, but it's one that I've accidentally used in the past in test datasets and possibly other packages, so it's just easier to allow it for now.