### PR TITLE
Change memory argument destination to `memory_gb`

### DIFF
--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -187,7 +187,7 @@ def _build_parser():
     g_perfm.add_argument(
         '--mem-mb',
         '--mem_mb',
-        dest='memory_mb',
+        dest='memory_gb',
         action='store',
         type=parser_utils._to_gb,
         help='Upper bound memory limit, in megabytes, for XCP-D processes.',


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->
Closes #1489 

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
Changes the `dest` for `mem-mb` argument to `memory_gb`

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
