### PR TITLE
Fix WM and CSF component selection in acompcor and acompcor_gsr

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -51,6 +51,10 @@ authors:
     family-names: Covitz
     affiliation: Stanford University
     orcid: 'https://orcid.org/0000-0002-7430-4125'
+  - given-names: Roey
+    family-names: Schurr
+    affiliation: Hebrew University of Jerusalem
+    orcid: 'https://orcid.org/0000-0002-5325-2071'
   - given-names: Damien
     family-names: Fair
     affiliation: University of Minnesota

--- a/xcp_d/data/nuisance/acompcor.yml
+++ b/xcp_d/data/nuisance/acompcor.yml
@@ -33,6 +33,6 @@ confounds:
         - rot_y_derivative1
         - rot_z
         - rot_z_derivative1
-        - ^w_comp_cor_0[1-5]$
-        - ^c_comp_cor_0[1-5]$
+        - ^w_comp_cor_0[0-4]$
+        - ^c_comp_cor_0[0-4]$
         - ^cosine\d+$

--- a/xcp_d/data/nuisance/acompcor_gsr.yml
+++ b/xcp_d/data/nuisance/acompcor_gsr.yml
@@ -4,9 +4,8 @@ description: |
     The top 5 aCompCor principal components from the white matter and
     cerebrospinal fluid compartments were selected as nuisance regressors
     [@behzadi2007component],
-    along with the six motion parameters and their temporal derivatives,
-    mean white matter signal, mean cerebrospinal fluid signal, and mean global signal
-    [@benchmarkp;@satterthwaite_2013].
+    along with the six motion parameters and their temporal derivatives
+    and mean global signal [@benchmarkp;@satterthwaite_2013].
     As the aCompCor regressors were generated on high-pass filtered data,
     the associated cosine basis regressors were included.
     This has the effect of high-pass filtering the data as well.
@@ -35,8 +34,6 @@ confounds:
         - rot_z
         - rot_z_derivative1
         - global_signal
-        - csf
-        - white_matter
-        - ^w_comp_cor_0[1-5]$
-        - ^c_comp_cor_0[1-5]$
+        - ^w_comp_cor_0[0-4]$
+        - ^c_comp_cor_0[0-4]$
         - ^cosine\d+$

--- a/xcp_d/tests/test_interfaces_censoring.py
+++ b/xcp_d/tests/test_interfaces_censoring.py
@@ -130,7 +130,7 @@ def test_generate_confounds(ds001419_data, tmp_path_factory):
     assert os.path.isfile(results.outputs.confounds_tsv)
     out_confounds_file = results.outputs.confounds_tsv
     out_df = pd.read_table(out_confounds_file)
-    assert out_df.shape[1] == 31  # 31 parameters
+    assert out_df.shape[1] == 29  # 29 parameters
 
     # Test with signal regressors
     config = load_data.readable('nuisance/24P.yml')


### PR DESCRIPTION
Closes #1497.
Also remove mean WM and mean CSF from acompcor_gsr.

<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
This pull request addresses issue #1497. It includes changes in two config yaml files for aCompCor confound regression:

**1. xcp_d/data/nuisance/acompcor.yml**
The WM and CSF components now includes the first 5 [0-4] components instead of components 2-6 [1-5] as before.
^w_comp_cor_0[0-4]$
^c_comp_cor_0[0-4]$

**2. xcp_d/data/nuisance/acompcor_gsr.yml** 
The same change as in acompcor.yml, in addition to removal of the mean CSF and mean WM signals. 
These two confound signals were removed to maych the confound documentation table (https://xcp-d.readthedocs.io/en/latest/workflows.html#id20).
The removal of these two confound signals will probably not make a big difference, as mean CSF and mean WM signals together lead to similar results with or without the addition of the mean Global Signal component. See Ciric et al., (2017), (https://doi.org/10.1016/j.neuroimage.2017.03.020). 

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
The codumentation of acompcor_gsr.yml was also changed to reflect the removal of the mean CSF and mean WM signals.