### PR TITLE
Remove colorbar from brainsprite

### DIFF
--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -528,6 +528,8 @@ def _plot_single_slice(img, i_slice, rh_pial, lh_pial, rh_wm, lh_wm, root_dir):
         annotate=False,
         vmin=vmin,
         vmax=vmax,
+        colorbar=False,
+        black_bg=True,
     )
 
     # Load the surface mesh (GIFTI format)


### PR DESCRIPTION
Related to #1528.

## Changes proposed in this pull request

- Set `black_bg=True` and `colorbar=False` in the brainsprite-generating `plot_anat` call.