### PR TITLE
Change smoothing surf from 'sphere' to 'midthickness'

### DIFF
--- a/xcp_d/workflows/bold/postprocessing.py
+++ b/xcp_d/workflows/bold/postprocessing.py
@@ -830,7 +830,7 @@ The denoised BOLD was then smoothed using *Connectome Workbench* with a Gaussian
                         hemi='R',
                         density='32k',
                         desc=None,
-                        suffix='sphere',
+                        suffix='midthickness',
                         raise_empty=True,
                     )
                 ),
@@ -841,7 +841,7 @@ The denoised BOLD was then smoothed using *Connectome Workbench* with a Gaussian
                         hemi='L',
                         density='32k',
                         desc=None,
-                        suffix='sphere',
+                        suffix='midthickness',
                         raise_empty=True,
                     )
                 ),


### PR DESCRIPTION
Fix for #1564

<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
Fix for #1564 which replaces spheres with midthicknesses when smoothing fsLR-resampled CIFTIs


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
