### PR TITLE
Add tests for ingression module

### DIFF
--- a/xcp_d/tests/test_ingression_abcdbids.py
+++ b/xcp_d/tests/test_ingression_abcdbids.py
@@ -1,0 +1,146 @@
+"""Tests for xcp_d.ingression.abcdbids."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xcp_d.ingression import abcdbids
+
+
+def test_convert_dcan2bids_no_subjects_raises(tmp_path):
+    """convert_dcan2bids raises ValueError when no subjects found."""
+    in_dir = tmp_path / 'dcan_in'
+    in_dir.mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with pytest.raises(ValueError, match='No subject found'):
+        abcdbids.convert_dcan2bids(str(in_dir), str(out_dir), participant_ids=None)
+
+
+def test_convert_dcan2bids_discovers_subjects(tmp_path):
+    """convert_dcan2bids discovers sub* directories when participant_ids is None."""
+    in_dir = tmp_path / 'dcan_in'
+    in_dir.mkdir()
+    (in_dir / 'sub-01').mkdir()
+    (in_dir / 'sub-02').mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with patch.object(abcdbids, 'convert_dcan_to_bids_single_subject') as mock_single:
+        result = abcdbids.convert_dcan2bids(str(in_dir), str(out_dir))
+    assert result == ['sub-01', 'sub-02']
+    assert mock_single.call_count == 2
+
+
+def test_convert_dcan2bids_with_participant_ids(tmp_path):
+    """convert_dcan2bids calls single-subject for each given participant."""
+    in_dir = tmp_path / 'dcan_in'
+    in_dir.mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with patch.object(abcdbids, 'convert_dcan_to_bids_single_subject') as mock_single:
+        result = abcdbids.convert_dcan2bids(
+            str(in_dir), str(out_dir), participant_ids=['sub-01']
+        )
+    assert result == ['sub-01']
+    mock_single.assert_called_once_with(
+        in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='sub-01'
+    )
+
+
+def test_convert_dcan2bids_passes_participant_ids_through(tmp_path):
+    """convert_dcan2bids returns the participant_ids list as given and passes to single-subject."""
+    in_dir = tmp_path / 'dcan_in'
+    in_dir.mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with patch.object(abcdbids, 'convert_dcan_to_bids_single_subject') as mock_single:
+        result = abcdbids.convert_dcan2bids(
+            str(in_dir), str(out_dir), participant_ids=['01']
+        )
+    assert result == ['01']
+    mock_single.assert_called_once_with(
+        in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='01'
+    )
+
+
+def test_convert_dcan_to_bids_single_subject_asserts_inputs():
+    """convert_dcan_to_bids_single_subject asserts in_dir exists and types."""
+    with pytest.raises(AssertionError):
+        abcdbids.convert_dcan_to_bids_single_subject(
+            in_dir='/nonexistent',
+            out_dir='/out',
+            sub_ent='sub-01',
+        )
+
+
+def test_convert_dcan_to_bids_single_subject_raises_when_no_sessions(tmp_path):
+    """convert_dcan_to_bids_single_subject raises when no session folders."""
+    in_dir = tmp_path / 'in'
+    in_dir.mkdir()
+    (in_dir / 'sub-01').mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with pytest.raises(FileNotFoundError, match='No session volumes'):
+        abcdbids.convert_dcan_to_bids_single_subject(
+            in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='sub-01'
+        )
+
+
+def test_convert_dcan_to_bids_single_subject_skips_when_dataset_description_exists(
+    tmp_path,
+):
+    """convert_dcan_to_bids_single_subject skips when dataset_description.json exists."""
+    in_dir = tmp_path / 'in'
+    in_dir.mkdir()
+    sub_dir = in_dir / 'sub-01'
+    sub_dir.mkdir()
+    ses_dir = sub_dir / 'ses-01'
+    ses_dir.mkdir()
+    files_dir = ses_dir / 'files' / 'MNINonLinear'
+    files_dir.mkdir(parents=True)
+    (files_dir / 'T1w.nii.gz').write_bytes(b'')
+    results = files_dir / 'Results'
+    results.mkdir()
+    task_dir = results / 'ses-01_task-rest_run-1'
+    task_dir.mkdir()
+    (task_dir / 'ses-01_task-rest_run-1_SBRef.nii.gz').write_bytes(b'')
+    (task_dir / 'ses-01_task-rest_run-1.nii.gz').write_bytes(b'')
+    (task_dir / 'brainmask_fs.2.0.nii.gz').write_bytes(b'')
+    (task_dir / 'Movement_Regressors.txt').write_text('0 0 0 0 0 0\n')
+    (task_dir / 'Movement_AbsoluteRMS.txt').write_text('0\n')
+    (task_dir / 'ses-01_task-rest_run-1_Atlas.dtseries.nii').write_bytes(b'')
+    fsaverage = files_dir / 'fsaverage_LR32k'
+    fsaverage.mkdir()
+    (fsaverage / '01.L.pial.32k_fs_LR.surf.gii').write_bytes(b'')
+    (fsaverage / '01.R.pial.32k_fs_LR.surf.gii').write_bytes(b'')
+    (files_dir / 'vent_2mm_01_mask_eroded.nii.gz').write_bytes(b'')
+    (files_dir / 'wm_2mm_01_mask_eroded.nii.gz').write_bytes(b'')
+
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    (out_dir / 'dataset_description.json').write_text('{}')
+
+    with patch.object(abcdbids, 'collect_anatomical_files') as mock_anat:
+        with patch.object(abcdbids, 'collect_meshes') as mock_mesh:
+            with patch.object(abcdbids, 'collect_morphs') as mock_morph:
+                with patch.object(abcdbids, 'collect_hcp_confounds'):
+                    with patch.object(abcdbids, 'plot_bbreg'):
+                        with patch.object(abcdbids, 'copy_files_in_dict'):
+                            with patch.object(abcdbids, 'nb') as mock_nb:
+                                mock_img = mock_nb.load.return_value
+                                mock_img.header.get_zooms.return_value = (
+                                    2.0,
+                                    2.0,
+                                    2.0,
+                                    2.0,
+                                )
+                                abcdbids.convert_dcan_to_bids_single_subject(
+                                    in_dir=str(in_dir),
+                                    out_dir=str(out_dir),
+                                    sub_ent='sub-01',
+                                )
+    mock_anat.assert_not_called()
+    mock_mesh.assert_not_called()
+    mock_morph.assert_not_called()

--- a/xcp_d/tests/test_ingression_abcdbids.py
+++ b/xcp_d/tests/test_ingression_abcdbids.py
@@ -1,7 +1,5 @@
 """Tests for xcp_d.ingression.abcdbids."""
 
-import os
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -40,13 +38,9 @@ def test_convert_dcan2bids_with_participant_ids(tmp_path):
     out_dir = tmp_path / 'out'
     out_dir.mkdir()
     with patch.object(abcdbids, 'convert_dcan_to_bids_single_subject') as mock_single:
-        result = abcdbids.convert_dcan2bids(
-            str(in_dir), str(out_dir), participant_ids=['sub-01']
-        )
+        result = abcdbids.convert_dcan2bids(str(in_dir), str(out_dir), participant_ids=['sub-01'])
     assert result == ['sub-01']
-    mock_single.assert_called_once_with(
-        in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='sub-01'
-    )
+    mock_single.assert_called_once_with(in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='sub-01')
 
 
 def test_convert_dcan2bids_passes_participant_ids_through(tmp_path):
@@ -56,13 +50,9 @@ def test_convert_dcan2bids_passes_participant_ids_through(tmp_path):
     out_dir = tmp_path / 'out'
     out_dir.mkdir()
     with patch.object(abcdbids, 'convert_dcan_to_bids_single_subject') as mock_single:
-        result = abcdbids.convert_dcan2bids(
-            str(in_dir), str(out_dir), participant_ids=['01']
-        )
+        result = abcdbids.convert_dcan2bids(str(in_dir), str(out_dir), participant_ids=['01'])
     assert result == ['01']
-    mock_single.assert_called_once_with(
-        in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='01'
-    )
+    mock_single.assert_called_once_with(in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='01')
 
 
 def test_convert_dcan_to_bids_single_subject_asserts_inputs():

--- a/xcp_d/tests/test_ingression_hcpya.py
+++ b/xcp_d/tests/test_ingression_hcpya.py
@@ -1,0 +1,120 @@
+"""Tests for xcp_d.ingression.hcpya."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xcp_d.ingression import hcpya
+
+
+def test_convert_hcp2bids_no_subjects_raises(tmp_path):
+    """convert_hcp2bids raises ValueError when no subjects found."""
+    in_dir = tmp_path / 'hcp_in'
+    in_dir.mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with pytest.raises(ValueError, match='No subject found'):
+        hcpya.convert_hcp2bids(str(in_dir), str(out_dir), participant_ids=None)
+
+
+def test_convert_hcp2bids_with_participant_ids_calls_single_subject(tmp_path):
+    """convert_hcp2bids calls convert_hcp_to_bids_single_subject for each ID."""
+    in_dir = tmp_path / 'hcp_in'
+    in_dir.mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with patch.object(hcpya, 'convert_hcp_to_bids_single_subject') as mock_single:
+        result = hcpya.convert_hcp2bids(
+            str(in_dir), str(out_dir), participant_ids=['sub-01', 'sub-02']
+        )
+    assert result == ['sub-01', 'sub-02']
+    assert mock_single.call_count == 2
+    mock_single.assert_any_call(
+        in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='sub-01'
+    )
+    mock_single.assert_any_call(
+        in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='sub-02'
+    )
+
+
+def test_convert_hcp2bids_passes_participant_ids_through(tmp_path):
+    """convert_hcp2bids returns the participant_ids list as given and passes to single-subject."""
+    in_dir = tmp_path / 'hcp_in'
+    in_dir.mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with patch.object(hcpya, 'convert_hcp_to_bids_single_subject') as mock_single:
+        result = hcpya.convert_hcp2bids(
+            str(in_dir), str(out_dir), participant_ids=['01']
+        )
+    assert result == ['01']
+    mock_single.assert_called_once_with(
+        in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='01'
+    )
+
+
+def test_convert_hcp_to_bids_single_subject_asserts_inputs():
+    """convert_hcp_to_bids_single_subject asserts in_dir, out_dir, sub_ent."""
+    with pytest.raises(AssertionError):
+        hcpya.convert_hcp_to_bids_single_subject(
+            in_dir='/nonexistent',
+            out_dir='/out',
+            sub_ent='sub-01',
+        )
+
+
+def test_convert_hcp_to_bids_single_subject_skips_when_dataset_description_exists(
+    tmp_path,
+):
+    """convert_hcp_to_bids_single_subject skips when dataset_description.json exists."""
+    in_dir = tmp_path / 'in'
+    in_dir.mkdir()
+    sub_id = '01'
+    (in_dir / sub_id).mkdir()
+    mni = in_dir / sub_id / 'MNINonLinear'
+    mni.mkdir()
+    (mni / 'T1w.nii.gz').write_bytes(b'')
+    fsaverage = mni / 'fsaverage_LR32k'
+    fsaverage.mkdir()
+    (fsaverage / '01.L.pial.32k_fs_LR.surf.gii').write_bytes(b'')
+    (fsaverage / '01.R.pial.32k_fs_LR.surf.gii').write_bytes(b'')
+    results = mni / 'Results'
+    results.mkdir()
+    task_dir = results / 'tfMRI_REST1_RL'
+    task_dir.mkdir()
+    (task_dir / 'SBRef_dc.nii.gz').write_bytes(b'')
+    (task_dir / 'tfMRI_REST1_RL.nii.gz').write_bytes(b'')
+    (task_dir / 'brainmask_fs.2.nii.gz').write_bytes(b'')
+    (task_dir / 'brainmask_fs.2.0.nii.gz').write_bytes(b'')
+    (task_dir / 'Movement_Regressors.txt').write_text('0 0 0 0 0 0\n')
+    (task_dir / 'Movement_AbsoluteRMS.txt').write_text('0\n')
+    (task_dir / 'tfMRI_REST1_RL_Atlas_MSMAll.dtseries.nii').write_bytes(b'')
+
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    (out_dir / 'dataset_description.json').write_text('{}')
+
+    with patch.object(hcpya, 'collect_anatomical_files') as mock_anat:
+        with patch.object(hcpya, 'collect_meshes') as mock_mesh:
+            with patch.object(hcpya, 'collect_morphs') as mock_morph:
+                with patch.object(hcpya, 'collect_hcp_confounds'):
+                    with patch.object(hcpya, 'plot_bbreg'):
+                        with patch.object(hcpya, 'copy_files_in_dict'):
+                            with patch.object(hcpya, 'nb') as mock_nb:
+                                mock_img = mock_nb.load.return_value
+                                mock_img.header.get_zooms.return_value = (
+                                    2.0,
+                                    2.0,
+                                    2.0,
+                                    2.0,
+                                )
+                                hcpya.convert_hcp_to_bids_single_subject(
+                                    in_dir=str(in_dir),
+                                    out_dir=str(out_dir),
+                                    sub_ent='sub-01',
+                                )
+    mock_anat.assert_not_called()
+    mock_mesh.assert_not_called()
+    mock_morph.assert_not_called()

--- a/xcp_d/tests/test_ingression_hcpya.py
+++ b/xcp_d/tests/test_ingression_hcpya.py
@@ -1,7 +1,5 @@
 """Tests for xcp_d.ingression.hcpya."""
 
-import os
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -31,12 +29,8 @@ def test_convert_hcp2bids_with_participant_ids_calls_single_subject(tmp_path):
         )
     assert result == ['sub-01', 'sub-02']
     assert mock_single.call_count == 2
-    mock_single.assert_any_call(
-        in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='sub-01'
-    )
-    mock_single.assert_any_call(
-        in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='sub-02'
-    )
+    mock_single.assert_any_call(in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='sub-01')
+    mock_single.assert_any_call(in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='sub-02')
 
 
 def test_convert_hcp2bids_passes_participant_ids_through(tmp_path):
@@ -46,13 +40,9 @@ def test_convert_hcp2bids_passes_participant_ids_through(tmp_path):
     out_dir = tmp_path / 'out'
     out_dir.mkdir()
     with patch.object(hcpya, 'convert_hcp_to_bids_single_subject') as mock_single:
-        result = hcpya.convert_hcp2bids(
-            str(in_dir), str(out_dir), participant_ids=['01']
-        )
+        result = hcpya.convert_hcp2bids(str(in_dir), str(out_dir), participant_ids=['01'])
     assert result == ['01']
-    mock_single.assert_called_once_with(
-        in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='01'
-    )
+    mock_single.assert_called_once_with(in_dir=str(in_dir), out_dir=str(out_dir), sub_ent='01')
 
 
 def test_convert_hcp_to_bids_single_subject_asserts_inputs():

--- a/xcp_d/tests/test_ingression_ukbiobank.py
+++ b/xcp_d/tests/test_ingression_ukbiobank.py
@@ -1,0 +1,85 @@
+"""Tests for xcp_d.ingression.ukbiobank."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xcp_d.ingression import ukbiobank
+
+
+def test_convert_ukb2bids_no_subjects_raises(tmp_path):
+    """convert_ukb2bids raises ValueError when no subjects found."""
+    in_dir = tmp_path / 'ukb_in'
+    in_dir.mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with pytest.raises(ValueError, match='No subject found'):
+        ukbiobank.convert_ukb2bids(str(in_dir), str(out_dir), participant_ids=None)
+
+
+def test_convert_ukb2bids_discovers_subjects(tmp_path):
+    """convert_ukb2bids discovers subject dirs matching *_*_2_0."""
+    in_dir = tmp_path / 'ukb_in'
+    in_dir.mkdir()
+    (in_dir / 'sub1_01_2_0').mkdir()
+    (in_dir / 'sub2_02_2_0').mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with patch.object(ukbiobank, 'convert_ukb_to_bids_single_subject') as mock_single:
+        result = ukbiobank.convert_ukb2bids(str(in_dir), str(out_dir))
+    assert 'sub1' in result
+    assert 'sub2' in result
+    assert mock_single.call_count == 2
+
+
+def test_convert_ukb2bids_with_participant_ids(tmp_path):
+    """convert_ukb2bids calls single-subject for given participants and sessions."""
+    in_dir = tmp_path / 'ukb_in'
+    in_dir.mkdir()
+    sub_ses = in_dir / 'sub1_01_2_0'
+    sub_ses.mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with patch.object(ukbiobank, 'convert_ukb_to_bids_single_subject') as mock_single:
+        result = ukbiobank.convert_ukb2bids(
+            str(in_dir),
+            str(out_dir),
+            participant_ids=['sub1'],
+            bids_filters={'bold': {'session': ['01']}},
+        )
+    assert result == ['sub1']
+    mock_single.assert_called()
+    call_kw = mock_single.call_args[1]
+    assert call_kw['sub_id'] == 'sub1'
+    assert call_kw['ses_id'] == '01'
+
+
+def test_convert_ukb_to_bids_single_subject_asserts_inputs():
+    """convert_ukb_to_bids_single_subject asserts in_dir exists."""
+    with pytest.raises(AssertionError):
+        ukbiobank.convert_ukb_to_bids_single_subject(
+            in_dir='/nonexistent',
+            out_dir='/out',
+            sub_id='01',
+            ses_id='01',
+        )
+
+
+def test_convert_ukb_to_bids_single_subject_raises_when_bold_missing(tmp_path):
+    """convert_ukb_to_bids_single_subject raises when BOLD file missing."""
+    in_dir = tmp_path / 'in'
+    in_dir.mkdir()
+    (in_dir / 'fMRI').mkdir()
+    (in_dir / 'fMRI' / 'rfMRI.ica').mkdir()
+    (in_dir / 'T1').mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    with pytest.raises(AssertionError, match='File DNE'):
+        ukbiobank.convert_ukb_to_bids_single_subject(
+            in_dir=str(in_dir),
+            out_dir=str(out_dir),
+            sub_id='01',
+            ses_id='01',
+        )

--- a/xcp_d/tests/test_ingression_ukbiobank.py
+++ b/xcp_d/tests/test_ingression_ukbiobank.py
@@ -1,7 +1,5 @@
 """Tests for xcp_d.ingression.ukbiobank."""
 
-import os
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest

--- a/xcp_d/tests/test_ingression_utils.py
+++ b/xcp_d/tests/test_ingression_utils.py
@@ -1,0 +1,404 @@
+"""Tests for xcp_d.ingression.utils."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import nibabel as nb
+import numpy as np
+import pandas as pd
+import pytest
+
+from xcp_d.ingression import utils as ingress_utils
+
+
+def _minimal_nifti_3d(shape=(4, 4, 4), path=None):
+    """Write a minimal 3D NIfTI (e.g. mask) with zeros."""
+    arr = np.zeros(shape, dtype=np.float32)
+    img = nb.Nifti1Image(arr, np.eye(4))
+    if path:
+        os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+        img.to_filename(path)
+    return img if path is None else path
+
+
+def _minimal_nifti_4d(shape=(4, 4, 4, 5), path=None):
+    """Write a minimal 4D NIfTI (e.g. BOLD) with zeros."""
+    arr = np.zeros(shape, dtype=np.float32)
+    img = nb.Nifti1Image(arr, np.eye(4))
+    if path:
+        os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+        img.to_filename(path)
+    return img if path is None else path
+
+
+def test_write_json(tmp_path):
+    """write_json writes a dict to a JSON file."""
+    outfile = tmp_path / 'out.json'
+    data = {'a': 1, 'b': [2, 3]}
+    result = ingress_utils.write_json(data, str(outfile))
+    assert result == str(outfile)
+    assert outfile.exists()
+    with open(outfile) as f:
+        assert json.load(f) == data
+
+
+def test_copy_file(tmp_path):
+    """copy_file copies source to destination."""
+    src = tmp_path / 'src.txt'
+    dst = tmp_path / 'dst.txt'
+    src.write_text('hello')
+    ingress_utils.copy_file(str(src), str(dst))
+    assert dst.read_text() == 'hello'
+    # Idempotent when content matches
+    ingress_utils.copy_file(str(src), str(dst))
+    assert dst.read_text() == 'hello'
+
+
+def test_copy_file_overwrites_when_different(tmp_path):
+    """copy_file overwrites destination when content differs."""
+    src = tmp_path / 'src.txt'
+    dst = tmp_path / 'dst.txt'
+    src.write_text('hello')
+    dst.write_text('old')
+    ingress_utils.copy_file(str(src), str(dst))
+    assert dst.read_text() == 'hello'
+
+
+def test_copy_files_in_dict(tmp_path):
+    """copy_files_in_dict copies each source to its list of destinations."""
+    a = tmp_path / 'a.txt'
+    b = tmp_path / 'b.txt'
+    c = tmp_path / 'c.txt'
+    a.write_text('a')
+    copy_dictionary = {
+        str(a): [str(b)],
+        str(a): [str(c)],  # same source, different dest (last wins in dict)
+    }
+    copy_dictionary = {str(a): [str(b), str(c)]}
+    ingress_utils.copy_files_in_dict(copy_dictionary)
+    assert b.read_text() == 'a'
+    assert c.read_text() == 'a'
+
+
+def test_copy_files_in_dict_raises_when_value_not_list(tmp_path):
+    """copy_files_in_dict raises ValueError when a value is not a list."""
+    f = tmp_path / 'f.txt'
+    f.write_text('x')
+    with pytest.raises(ValueError, match='should be a list'):
+        ingress_utils.copy_files_in_dict({str(f): str(tmp_path / 'out.txt')})
+
+
+def test_collect_anatomical_files_none_present(tmp_path):
+    """collect_anatomical_files returns empty dict when no expected files exist."""
+    anat_orig = tmp_path / 'anat_orig'
+    anat_orig.mkdir()
+    anat_bids = tmp_path / 'anat_bids'
+    anat_bids.mkdir()
+    base = 'sub-01_space-MNI152NLin6Asym_res-2'
+    out = ingress_utils.collect_anatomical_files(
+        str(anat_orig), str(anat_bids), base
+    )
+    assert out == {}
+
+
+def test_collect_anatomical_files_some_present(tmp_path):
+    """collect_anatomical_files maps existing files to BIDS paths."""
+    anat_orig = tmp_path / 'anat_orig'
+    anat_bids = tmp_path / 'anat_bids'
+    anat_orig.mkdir()
+    anat_bids.mkdir()
+    t1w = anat_orig / 'T1w.nii.gz'
+    ribbon = anat_orig / 'ribbon.nii.gz'
+    t1w.write_bytes(b'')
+    ribbon.write_bytes(b'')
+    base = 'sub-01_space-MNI152NLin6Asym_res-2'
+    out = ingress_utils.collect_anatomical_files(
+        str(anat_orig), str(anat_bids), base
+    )
+    assert len(out) == 2
+    assert str(t1w) in out
+    assert out[str(t1w)] == [
+        os.path.join(anat_bids, f'{base}_desc-preproc_T1w.nii.gz')
+    ]
+    assert str(ribbon) in out
+    assert out[str(ribbon)] == [
+        os.path.join(anat_bids, f'{base}_desc-ribbon_T1w.nii.gz')
+    ]
+
+
+def test_collect_anatomical_files_brainmask_variants(tmp_path):
+    """collect_anatomical_files accepts brainmask_fs or brainmask_fs.2.0."""
+    anat_orig = tmp_path / 'anat_orig'
+    anat_bids = tmp_path / 'anat_bids'
+    anat_orig.mkdir()
+    anat_bids.mkdir()
+    (anat_orig / 'brainmask_fs.2.0.nii.gz').write_bytes(b'')
+    base = 'sub-01_space-MNI152NLin6Asym_res-2'
+    out = ingress_utils.collect_anatomical_files(
+        str(anat_orig), str(anat_bids), base
+    )
+    assert len(out) == 1
+    assert list(out.values())[0][0].endswith('_desc-brain_mask.nii.gz')
+
+
+def test_collect_meshes_none_present(tmp_path):
+    """collect_meshes returns empty dict when no surface files exist."""
+    anat_orig = tmp_path / 'anat_orig'
+    anat_bids = tmp_path / 'anat_bids'
+    anat_orig.mkdir()
+    (anat_orig / 'fsaverage_LR32k').mkdir()
+    anat_bids.mkdir()
+    out = ingress_utils.collect_meshes(
+        str(anat_orig), str(anat_bids), 'subid', 'sub-01'
+    )
+    assert out == {}
+
+
+def test_collect_meshes_some_present(tmp_path):
+    """collect_meshes maps L/R pial and white surfaces to BIDS paths."""
+    anat_orig = tmp_path / 'anat_orig'
+    anat_bids = tmp_path / 'anat_bids'
+    fsaverage = anat_orig / 'fsaverage_LR32k'
+    fsaverage.mkdir(parents=True)
+    anat_bids.mkdir()
+    (fsaverage / 'subid.L.pial.32k_fs_LR.surf.gii').write_bytes(b'')
+    (fsaverage / 'subid.R.pial.32k_fs_LR.surf.gii').write_bytes(b'')
+    (fsaverage / 'subid.L.white.32k_fs_LR.surf.gii').write_bytes(b'')
+    (fsaverage / 'subid.R.white.32k_fs_LR.surf.gii').write_bytes(b'')
+    out = ingress_utils.collect_meshes(
+        str(anat_orig), str(anat_bids), 'subid', 'sub-01'
+    )
+    assert len(out) == 4
+    out_paths = [p for v in out.values() for p in v]
+    assert any('hemi-L_pial' in p for p in out_paths)
+    assert any('hemi-R_pial' in p for p in out_paths)
+    assert any('hemi-L_smoothwm' in p for p in out_paths)
+    assert any('hemi-R_smoothwm' in p for p in out_paths)
+
+
+def test_collect_morphs_skips_when_files_missing(tmp_path):
+    """collect_morphs skips morphometry when L or R file is missing."""
+    anat_orig = tmp_path / 'anat_orig'
+    anat_bids = tmp_path / 'anat_bids'
+    fsaverage = anat_orig / 'fsaverage_LR32k'
+    fsaverage.mkdir(parents=True)
+    anat_bids.mkdir()
+    (fsaverage / 'subid.L.thickness.32k_fs_LR.shape.gii').write_bytes(b'')
+    # No R file
+    with patch.object(ingress_utils, 'CiftiCreateDenseScalar') as mock_wb:
+        out = ingress_utils.collect_morphs(
+            str(anat_orig), str(anat_bids), 'subid', 'sub-01'
+        )
+    assert out == {}
+    mock_wb.assert_not_called()
+
+
+def test_collect_morphs_calls_interface_when_both_hemis_present(tmp_path):
+    """collect_morphs runs CiftiCreateDenseScalar when L and R files exist."""
+    anat_orig = tmp_path / 'anat_orig'
+    anat_bids = tmp_path / 'anat_bids'
+    fsaverage = anat_orig / 'fsaverage_LR32k'
+    fsaverage.mkdir(parents=True)
+    anat_bids.mkdir()
+    lh = fsaverage / 'subid.L.thickness.32k_fs_LR.shape.gii'
+    rh = fsaverage / 'subid.R.thickness.32k_fs_LR.shape.gii'
+    lh.write_bytes(b'')
+    rh.write_bytes(b'')
+    out_file = anat_bids / 'sub-01_space-fsLR_den-91k_thickness.dscalar.nii'
+
+    with patch.object(ingress_utils, 'CiftiCreateDenseScalar') as MockWB:
+        mock_run = MockWB.return_value.run
+        mock_run.return_value.outputs = type('R', (), {'out_file': None})()
+        out = ingress_utils.collect_morphs(
+            str(anat_orig), str(anat_bids), 'subid', 'sub-01'
+        )
+    assert MockWB.called
+    assert str(lh) in out
+    assert str(rh) in out
+    assert out[str(lh)] == str(out_file)
+    assert out[str(rh)] == str(out_file)
+
+
+def test_extract_mean_signal(tmp_path):
+    """extract_mean_signal returns mean time series in mask (minimal NIFTIs)."""
+    work_dir = tmp_path / 'work'
+    work_dir.mkdir()
+    mask_path = tmp_path / 'mask.nii.gz'
+    bold_path = tmp_path / 'bold.nii.gz'
+    _minimal_nifti_3d(path=str(mask_path))
+    _minimal_nifti_4d(shape=(4, 4, 4, 6), path=str(bold_path))
+    # Ensure mask has at least one voxel so mean is defined
+    mask_img = nb.load(str(mask_path))
+    mask_data = np.asarray(mask_img.dataobj)
+    mask_data[0, 0, 0] = 1
+    nb.Nifti1Image(mask_data.astype(np.float32), mask_img.affine).to_filename(
+        str(mask_path)
+    )
+    result = ingress_utils.extract_mean_signal(
+        str(mask_path), str(bold_path), str(work_dir)
+    )
+    assert result.ndim == 1
+    assert result.shape[0] == 6
+
+
+def test_extract_mean_signal_raises_when_mask_missing(tmp_path):
+    """extract_mean_signal asserts mask file exists."""
+    work_dir = tmp_path / 'work'
+    work_dir.mkdir()
+    bold_path = tmp_path / 'bold.nii.gz'
+    _minimal_nifti_4d(path=str(bold_path))
+    with pytest.raises(AssertionError, match='File DNE'):
+        ingress_utils.extract_mean_signal(
+            str(tmp_path / 'nonexistent.nii.gz'), str(bold_path), str(work_dir)
+        )
+
+
+def test_collect_hcp_confounds(tmp_path):
+    """collect_hcp_confounds writes TSV and JSON from Movement_Regressors and RMS."""
+    task_dir = tmp_path / 'task'
+    task_dir.mkdir()
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    work_dir = tmp_path / 'work'
+    work_dir.mkdir()
+    # 4 time points, 6 motion columns (HCP order: trans x,y,z, rot x,y,z)
+    mvreg = task_dir / 'Movement_Regressors.txt'
+    mvreg.write_text('0.1 0.2 0.3 1 2 3\n0 0 0 0 0 0\n0 0 0 0 0 0\n0 0 0 0 0 0\n')
+    rmsd_file = task_dir / 'Movement_AbsoluteRMS.txt'
+    rmsd_file.write_text('0.5\n0.4\n0.3\n0.2\n')
+    bold_path = tmp_path / 'bold.nii.gz'
+    mask_path = tmp_path / 'brainmask.nii.gz'
+    csf_path = tmp_path / 'csf.nii.gz'
+    wm_path = tmp_path / 'wm.nii.gz'
+    _minimal_nifti_4d(shape=(4, 4, 4, 4), path=str(bold_path))
+    _minimal_nifti_3d(path=str(mask_path))
+    _minimal_nifti_3d(path=str(csf_path))
+    _minimal_nifti_3d(path=str(wm_path))
+    prefix = 'sub-01_task-rest_run-1'
+
+    with patch.object(ingress_utils, 'extract_mean_signal') as mock_extract:
+        mock_extract.return_value = np.array([1.0, 2.0, 3.0, 4.0])
+        ingress_utils.collect_hcp_confounds(
+            task_dir_orig=str(task_dir),
+            out_dir=str(out_dir),
+            prefix=prefix,
+            work_dir=str(work_dir),
+            bold_file=str(bold_path),
+            brainmask_file=str(mask_path),
+            csf_mask_file=str(csf_path),
+            wm_mask_file=str(wm_path),
+        )
+
+    tsv = out_dir / f'{prefix}_desc-confounds_timeseries.tsv'
+    js = out_dir / f'{prefix}_desc-confounds_timeseries.json'
+    assert tsv.exists()
+    assert js.exists()
+    df = pd.read_csv(tsv, sep='\t')
+    assert 'trans_x' in df.columns
+    assert 'rot_z' in df.columns
+    assert 'global_signal' in df.columns
+    assert 'framewise_displacement' in df.columns
+    assert len(df) == 4
+    with open(js) as f:
+        meta = json.load(f)
+    assert 'trans_x' in meta
+
+
+def test_collect_hcp_confounds_raises_when_movement_missing(tmp_path):
+    """collect_hcp_confounds asserts Movement_Regressors.txt exists."""
+    task_dir = tmp_path / 'task'
+    task_dir.mkdir()
+    with pytest.raises(AssertionError):
+        ingress_utils.collect_hcp_confounds(
+            task_dir_orig=str(task_dir),
+            out_dir=str(tmp_path),
+            prefix='sub-01_task-rest',
+            work_dir=str(tmp_path),
+            bold_file='x.nii.gz',
+            brainmask_file='y.nii.gz',
+            csf_mask_file='z.nii.gz',
+            wm_mask_file='w.nii.gz',
+        )
+
+
+def test_collect_ukbiobank_confounds(tmp_path):
+    """collect_ukbiobank_confounds writes TSV and JSON from FSL par and rms."""
+    task_dir = tmp_path / 'task'
+    mc_dir = task_dir / 'mc'
+    mc_dir.mkdir(parents=True)
+    # FSL .par: 6 columns (rot_x, rot_y, rot_z, trans_x, trans_y, trans_z), one row per volume
+    par_file = mc_dir / 'prefiltered_func_data_mcf.par'
+    par_file.write_text('0.01 0.02 0.03 0.1 0.2 0.3\n0 0 0 0 0 0\n')
+    rms_file = mc_dir / 'prefiltered_func_data_mcf_abs.rms'
+    rms_file.write_text('0.5\n0.4\n')
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    work_dir = tmp_path / 'work'
+    work_dir.mkdir()
+    bold_path = tmp_path / 'bold.nii.gz'
+    mask_path = tmp_path / 'mask.nii.gz'
+    _minimal_nifti_4d(shape=(4, 4, 4, 2), path=str(bold_path))
+    _minimal_nifti_3d(path=str(mask_path))
+    prefix = 'sub-01_ses-01_task-rest'
+
+    with patch.object(ingress_utils, 'extract_mean_signal') as mock_extract:
+        mock_extract.return_value = np.array([1.0, 2.0])
+        ingress_utils.collect_ukbiobank_confounds(
+            task_dir_orig=str(task_dir),
+            out_dir=str(out_dir),
+            prefix=prefix,
+            work_dir=str(work_dir),
+            bold_file=str(bold_path),
+            brainmask_file=str(mask_path),
+        )
+
+    tsv = out_dir / f'{prefix}_desc-confounds_timeseries.tsv'
+    js = out_dir / f'{prefix}_desc-confounds_timeseries.json'
+    assert tsv.exists()
+    assert js.exists()
+    df = pd.read_csv(tsv, sep='\t')
+    assert 'trans_x' in df.columns
+    assert 'global_signal' in df.columns
+    assert 'rmsd' in df.columns
+    assert len(df) == 2
+
+
+def test_collect_ukbiobank_confounds_raises_when_par_missing(tmp_path):
+    """collect_ukbiobank_confounds asserts par file exists."""
+    task_dir = tmp_path / 'task'
+    task_dir.mkdir()
+    (task_dir / 'mc').mkdir()
+    with pytest.raises(AssertionError):
+        ingress_utils.collect_ukbiobank_confounds(
+            task_dir_orig=str(task_dir),
+            out_dir=str(tmp_path),
+            prefix='sub-01_task-rest',
+            work_dir=str(tmp_path),
+            bold_file='x.nii.gz',
+            brainmask_file='y.nii.gz',
+        )
+
+
+def test_plot_bbreg(tmp_path):
+    """plot_bbreg produces an SVG from minimal fixed/moving/contour NIFTIs."""
+    # Use slightly larger grid so niworkflows cuts_from_bbox has enough room
+    shape = (10, 10, 10)
+    fixed = tmp_path / 'fixed.nii.gz'
+    moving = tmp_path / 'moving.nii.gz'
+    contour = tmp_path / 'contour.nii.gz'
+    out_file = tmp_path / 'report.svg'
+    _minimal_nifti_3d(shape=shape, path=str(fixed))
+    _minimal_nifti_3d(shape=shape, path=str(moving))
+    _minimal_nifti_3d(shape=shape, path=str(contour))
+    result = ingress_utils.plot_bbreg(
+        fixed_image=str(fixed),
+        moving_image=str(moving),
+        contour=str(contour),
+        out_file=str(out_file),
+    )
+    assert result == str(out_file)
+    assert out_file.exists()
+    content = out_file.read_text()
+    assert 'svg' in content.lower() or content.lstrip().startswith('<?xml')

--- a/xcp_d/tests/test_ingression_utils.py
+++ b/xcp_d/tests/test_ingression_utils.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-from pathlib import Path
 from unittest.mock import patch
 
 import nibabel as nb
@@ -97,9 +96,7 @@ def test_collect_anatomical_files_none_present(tmp_path):
     anat_bids = tmp_path / 'anat_bids'
     anat_bids.mkdir()
     base = 'sub-01_space-MNI152NLin6Asym_res-2'
-    out = ingress_utils.collect_anatomical_files(
-        str(anat_orig), str(anat_bids), base
-    )
+    out = ingress_utils.collect_anatomical_files(str(anat_orig), str(anat_bids), base)
     assert out == {}
 
 
@@ -114,18 +111,12 @@ def test_collect_anatomical_files_some_present(tmp_path):
     t1w.write_bytes(b'')
     ribbon.write_bytes(b'')
     base = 'sub-01_space-MNI152NLin6Asym_res-2'
-    out = ingress_utils.collect_anatomical_files(
-        str(anat_orig), str(anat_bids), base
-    )
+    out = ingress_utils.collect_anatomical_files(str(anat_orig), str(anat_bids), base)
     assert len(out) == 2
     assert str(t1w) in out
-    assert out[str(t1w)] == [
-        os.path.join(anat_bids, f'{base}_desc-preproc_T1w.nii.gz')
-    ]
+    assert out[str(t1w)] == [os.path.join(anat_bids, f'{base}_desc-preproc_T1w.nii.gz')]
     assert str(ribbon) in out
-    assert out[str(ribbon)] == [
-        os.path.join(anat_bids, f'{base}_desc-ribbon_T1w.nii.gz')
-    ]
+    assert out[str(ribbon)] == [os.path.join(anat_bids, f'{base}_desc-ribbon_T1w.nii.gz')]
 
 
 def test_collect_anatomical_files_brainmask_variants(tmp_path):
@@ -136,9 +127,7 @@ def test_collect_anatomical_files_brainmask_variants(tmp_path):
     anat_bids.mkdir()
     (anat_orig / 'brainmask_fs.2.0.nii.gz').write_bytes(b'')
     base = 'sub-01_space-MNI152NLin6Asym_res-2'
-    out = ingress_utils.collect_anatomical_files(
-        str(anat_orig), str(anat_bids), base
-    )
+    out = ingress_utils.collect_anatomical_files(str(anat_orig), str(anat_bids), base)
     assert len(out) == 1
     assert list(out.values())[0][0].endswith('_desc-brain_mask.nii.gz')
 
@@ -150,9 +139,7 @@ def test_collect_meshes_none_present(tmp_path):
     anat_orig.mkdir()
     (anat_orig / 'fsaverage_LR32k').mkdir()
     anat_bids.mkdir()
-    out = ingress_utils.collect_meshes(
-        str(anat_orig), str(anat_bids), 'subid', 'sub-01'
-    )
+    out = ingress_utils.collect_meshes(str(anat_orig), str(anat_bids), 'subid', 'sub-01')
     assert out == {}
 
 
@@ -167,9 +154,7 @@ def test_collect_meshes_some_present(tmp_path):
     (fsaverage / 'subid.R.pial.32k_fs_LR.surf.gii').write_bytes(b'')
     (fsaverage / 'subid.L.white.32k_fs_LR.surf.gii').write_bytes(b'')
     (fsaverage / 'subid.R.white.32k_fs_LR.surf.gii').write_bytes(b'')
-    out = ingress_utils.collect_meshes(
-        str(anat_orig), str(anat_bids), 'subid', 'sub-01'
-    )
+    out = ingress_utils.collect_meshes(str(anat_orig), str(anat_bids), 'subid', 'sub-01')
     assert len(out) == 4
     out_paths = [p for v in out.values() for p in v]
     assert any('hemi-L_pial' in p for p in out_paths)
@@ -188,9 +173,7 @@ def test_collect_morphs_skips_when_files_missing(tmp_path):
     (fsaverage / 'subid.L.thickness.32k_fs_LR.shape.gii').write_bytes(b'')
     # No R file
     with patch.object(ingress_utils, 'CiftiCreateDenseScalar') as mock_wb:
-        out = ingress_utils.collect_morphs(
-            str(anat_orig), str(anat_bids), 'subid', 'sub-01'
-        )
+        out = ingress_utils.collect_morphs(str(anat_orig), str(anat_bids), 'subid', 'sub-01')
     assert out == {}
     mock_wb.assert_not_called()
 
@@ -211,9 +194,7 @@ def test_collect_morphs_calls_interface_when_both_hemis_present(tmp_path):
     with patch.object(ingress_utils, 'CiftiCreateDenseScalar') as MockWB:
         mock_run = MockWB.return_value.run
         mock_run.return_value.outputs = type('R', (), {'out_file': None})()
-        out = ingress_utils.collect_morphs(
-            str(anat_orig), str(anat_bids), 'subid', 'sub-01'
-        )
+        out = ingress_utils.collect_morphs(str(anat_orig), str(anat_bids), 'subid', 'sub-01')
     assert MockWB.called
     assert str(lh) in out
     assert str(rh) in out
@@ -233,12 +214,8 @@ def test_extract_mean_signal(tmp_path):
     mask_img = nb.load(str(mask_path))
     mask_data = np.asarray(mask_img.dataobj)
     mask_data[0, 0, 0] = 1
-    nb.Nifti1Image(mask_data.astype(np.float32), mask_img.affine).to_filename(
-        str(mask_path)
-    )
-    result = ingress_utils.extract_mean_signal(
-        str(mask_path), str(bold_path), str(work_dir)
-    )
+    nb.Nifti1Image(mask_data.astype(np.float32), mask_img.affine).to_filename(str(mask_path))
+    result = ingress_utils.extract_mean_signal(str(mask_path), str(bold_path), str(work_dir))
     assert result.ndim == 1
     assert result.shape[0] == 6
 


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Add a bunch of Cursor-generated unit tests for the functions in the ingression module.