### PR TITLE
Move atlases to cache directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 .dockersetup:
   &dockersetup
   docker:
-    - image: pennlinc/xcp_d_build:0.0.24
+    - image: pennlinc/xcp_d_build:0.0.25
   working_directory: /src/xcp_d
 
 runinstall:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pennlinc/xcp_d_build:0.0.24
+FROM pennlinc/xcp_d_build:0.0.25
 
 # Install xcp_d
 COPY . /src/xcp_d

--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -1184,7 +1184,7 @@ def _validate_parameters(opts, build_log, parser):
             opts.datasets['xcpdatlases'] = Path.home() / '.cache' / 'xcp_d' / 'XCPDAtlases'
             if not opts.datasets['xcpdatlases'].is_dir():
                 raise NotADirectoryError(
-                    f"XCP-D atlases is not a directory: {opts.datasets['xcpdatlases']}"
+                    f'XCP-D atlases is not a directory: {opts.datasets["xcpdatlases"]}'
                 )
 
         if any(atlas.startswith('4S') for atlas in opts.atlases):
@@ -1192,7 +1192,7 @@ def _validate_parameters(opts, build_log, parser):
                 opts.datasets['xcpd4s'] = Path.home() / '.cache' / 'xcp_d' / 'AtlasPack'
                 if not opts.datasets['xcpd4s'].is_dir():
                     raise NotADirectoryError(
-                        f"AtlasPack is not a directory: {opts.datasets['xcpd4s']}"
+                        f'AtlasPack is not a directory: {opts.datasets["xcpd4s"]}'
                     )
 
     # Check parameters based on the mode

--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -1181,11 +1181,11 @@ def _validate_parameters(opts, build_log, parser):
             opts.skip_outputs.append('parcellation')
     if opts.atlases:
         if 'xcpdatlases' not in opts.datasets:
-            opts.datasets['xcpdatlases'] = Path('/XCPDAtlases')
+            opts.datasets['xcpdatlases'] = Path.home() / '.cache' / 'xcp_d' / 'XCPDAtlases'
 
         if any(atlas.startswith('4S') for atlas in opts.atlases):
             if 'xcpd4s' not in opts.datasets:
-                opts.datasets['xcpd4s'] = Path('/AtlasPack')
+                opts.datasets['xcpd4s'] = Path.home() / '.cache' / 'xcp_d' / 'AtlasPack'
 
     # Check parameters based on the mode
     if opts.mode == 'abcd':

--- a/xcp_d/cli/parser.py
+++ b/xcp_d/cli/parser.py
@@ -1182,10 +1182,18 @@ def _validate_parameters(opts, build_log, parser):
     if opts.atlases:
         if 'xcpdatlases' not in opts.datasets:
             opts.datasets['xcpdatlases'] = Path.home() / '.cache' / 'xcp_d' / 'XCPDAtlases'
+            if not opts.datasets['xcpdatlases'].is_dir():
+                raise NotADirectoryError(
+                    f"XCP-D atlases is not a directory: {opts.datasets['xcpdatlases']}"
+                )
 
         if any(atlas.startswith('4S') for atlas in opts.atlases):
             if 'xcpd4s' not in opts.datasets:
                 opts.datasets['xcpd4s'] = Path.home() / '.cache' / 'xcp_d' / 'AtlasPack'
+                if not opts.datasets['xcpd4s'].is_dir():
+                    raise NotADirectoryError(
+                        f"AtlasPack is not a directory: {opts.datasets['xcpd4s']}"
+                    )
 
     # Check parameters based on the mode
     if opts.mode == 'abcd':

--- a/xcp_d/tests/test_interfaces_bids.py
+++ b/xcp_d/tests/test_interfaces_bids.py
@@ -1,10 +1,13 @@
 """Tests for xcp_d.interfaces.bids."""
 
 import os
+from pathlib import Path
 
 import pytest
 
 from xcp_d.interfaces import bids
+
+_XCPD_ATLASES = str(Path.home() / '.cache' / 'xcp_d' / 'XCPDAtlases')
 
 
 def test_copy_atlas(tmp_path_factory):
@@ -15,10 +18,10 @@ def test_copy_atlas(tmp_path_factory):
     # NIfTI
     atlas_info = {
         'image': (
-            '/XCPDAtlases/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Gordon_res-01_dseg.nii.gz'
+            f'{_XCPD_ATLASES}/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Gordon_res-01_dseg.nii.gz'
         ),
         'labels': (
-            '/XCPDAtlases/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Gordon_res-01_dseg.tsv'
+            f'{_XCPD_ATLASES}/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Gordon_res-01_dseg.tsv'
         ),
         'metadata': {'thing': 'stuff'},
         'dataset': 'xcpdatlases',
@@ -44,10 +47,10 @@ def test_copy_atlas(tmp_path_factory):
     # Gordon atlas is 1mm, HCP is 2mm
     atlas_info_diff_affine = {
         'image': (
-            '/XCPDAtlases/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-HCP_res-02_dseg.nii.gz'
+            f'{_XCPD_ATLASES}/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-HCP_res-02_dseg.nii.gz'
         ),
         'labels': (
-            '/XCPDAtlases/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-HCP_res-02_dseg.tsv'
+            f'{_XCPD_ATLASES}/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-HCP_res-02_dseg.tsv'
         ),
         'metadata': {'thing': 'stuff'},
         'dataset': 'xcpdatlases',
@@ -63,8 +66,8 @@ def test_copy_atlas(tmp_path_factory):
 
     # CIFTI
     atlas_info = {
-        'image': '/XCPDAtlases/tpl-fsLR/tpl-fsLR_atlas-Gordon_den-32k_dseg.dlabel.nii',
-        'labels': '/XCPDAtlases/tpl-fsLR/tpl-fsLR_atlas-Gordon_den-32k_dseg.tsv',
+        'image': f'{_XCPD_ATLASES}/tpl-fsLR/tpl-fsLR_atlas-Gordon_den-32k_dseg.dlabel.nii',
+        'labels': f'{_XCPD_ATLASES}/tpl-fsLR/tpl-fsLR_atlas-Gordon_den-32k_dseg.tsv',
         'metadata': {'thing': 'stuff'},
         'dataset': 'xcpdatlases',
     }

--- a/xcp_d/tests/test_utils_atlas.py
+++ b/xcp_d/tests/test_utils_atlas.py
@@ -1,10 +1,13 @@
 """Tests for the xcp_d.utils.atlas module."""
 
 import json
+from pathlib import Path
 
 import pytest
 
 from xcp_d.utils import atlas
+
+_XCPD_ATLASES = str(Path.home() / '.cache' / 'xcp_d' / 'XCPDAtlases')
 
 
 def test_get_atlas_names():
@@ -20,7 +23,7 @@ def test_collect_atlases(datasets, caplog, tmp_path_factory):
     schaefer_dset = datasets['schaefer100']
 
     atlas_datasets = {
-        'xcpdatlases': '/XCPDAtlases',
+        'xcpdatlases': _XCPD_ATLASES,
     }
     atlas_cache = atlas.collect_atlases(
         datasets=atlas_datasets,
@@ -55,7 +58,7 @@ def test_collect_atlases(datasets, caplog, tmp_path_factory):
     assert 'Schaefer100' not in atlas_cache
 
     # Add a duplicate atlas
-    atlas_datasets['duplicate'] = '/XCPDAtlases'
+    atlas_datasets['duplicate'] = _XCPD_ATLASES
     with pytest.raises(ValueError, match="Multiple datasets contain the same atlas 'Gordon'"):
         atlas.collect_atlases(
             datasets=atlas_datasets,

--- a/xcp_d/tests/test_workflows_connectivity.py
+++ b/xcp_d/tests/test_workflows_connectivity.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from pathlib import Path
 
 import nibabel as nb
 import numpy as np
@@ -24,6 +25,9 @@ from xcp_d.workflows.parcellation import init_load_atlases_wf
 
 np.set_printoptions(threshold=sys.maxsize)
 
+_XCPD_ATLASES = str(Path.home() / '.cache' / 'xcp_d' / 'XCPDAtlases')
+_ATLAS_PACK = str(Path.home() / '.cache' / 'xcp_d' / 'AtlasPack')
+
 
 def test_init_load_atlases_wf_nifti(ds001419_data, tmp_path_factory):
     """Test init_load_atlases_wf with a nifti input."""
@@ -36,8 +40,8 @@ def test_init_load_atlases_wf_nifti(ds001419_data, tmp_path_factory):
         config.workflow.file_format = 'nifti'
         config.execution.atlases = ['4S156Parcels', 'Glasser']
         config.execution.datasets = {
-            'xcpdatlases': '/XCPDAtlases',
-            'xcpd4s': '/AtlasPack',
+            'xcpdatlases': _XCPD_ATLASES,
+            'xcpd4s': _ATLAS_PACK,
         }
         config.nipype.omp_nthreads = 1
 
@@ -65,8 +69,8 @@ def test_init_load_atlases_wf_cifti(ds001419_data, tmp_path_factory):
         config.workflow.file_format = 'cifti'
         config.execution.atlases = ['4S156Parcels', 'Glasser']
         config.execution.datasets = {
-            'xcpdatlases': '/XCPDAtlases',
-            'xcpd4s': '/AtlasPack',
+            'xcpdatlases': _XCPD_ATLASES,
+            'xcpd4s': _ATLAS_PACK,
         }
         config.nipype.omp_nthreads = 1
 
@@ -121,12 +125,12 @@ def test_init_functional_connectivity_nifti_wf(ds001419_data, tmp_path_factory):
     # Load atlases
     atlas_names = ['Gordon', 'Glasser']
     atlas_files = [
-        '/XCPDAtlases/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Gordon_res-01_dseg.nii.gz',
-        '/XCPDAtlases/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Glasser_res-01_dseg.nii.gz',
+        f'{_XCPD_ATLASES}/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Gordon_res-01_dseg.nii.gz',
+        f'{_XCPD_ATLASES}/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Glasser_res-01_dseg.nii.gz',
     ]
     atlas_labels_files = [
-        '/XCPDAtlases/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Gordon_res-01_dseg.tsv',
-        '/XCPDAtlases/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Glasser_res-01_dseg.tsv',
+        f'{_XCPD_ATLASES}/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Gordon_res-01_dseg.tsv',
+        f'{_XCPD_ATLASES}/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_atlas-Glasser_res-01_dseg.tsv',
     ]
 
     # Perform the resampling and parcellation done by init_load_atlases_wf
@@ -270,18 +274,18 @@ def test_init_functional_connectivity_cifti_wf(ds001419_data, tmp_path_factory):
     # Load atlases
     atlas_names = ['4S1056Parcels', '4S156Parcels', '4S456Parcels', 'Gordon', 'Glasser']
     atlas_files = [
-        '/AtlasPack/tpl-fsLR/tpl-fsLR_atlas-4S1056Parcels_den-91k_dseg.dlabel.nii',
-        '/AtlasPack/tpl-fsLR/tpl-fsLR_atlas-4S156Parcels_den-91k_dseg.dlabel.nii',
-        '/AtlasPack/tpl-fsLR/tpl-fsLR_atlas-4S456Parcels_den-91k_dseg.dlabel.nii',
-        '/XCPDAtlases/tpl-fsLR/tpl-fsLR_atlas-Gordon_den-32k_dseg.dlabel.nii',
-        '/XCPDAtlases/tpl-fsLR/tpl-fsLR_atlas-Glasser_den-32k_dseg.dlabel.nii',
+        f'{_ATLAS_PACK}/tpl-fsLR/tpl-fsLR_atlas-4S1056Parcels_den-91k_dseg.dlabel.nii',
+        f'{_ATLAS_PACK}/tpl-fsLR/tpl-fsLR_atlas-4S156Parcels_den-91k_dseg.dlabel.nii',
+        f'{_ATLAS_PACK}/tpl-fsLR/tpl-fsLR_atlas-4S456Parcels_den-91k_dseg.dlabel.nii',
+        f'{_XCPD_ATLASES}/tpl-fsLR/tpl-fsLR_atlas-Gordon_den-32k_dseg.dlabel.nii',
+        f'{_XCPD_ATLASES}/tpl-fsLR/tpl-fsLR_atlas-Glasser_den-32k_dseg.dlabel.nii',
     ]
     atlas_labels_files = [
-        '/AtlasPack/tpl-fsLR/tpl-fsLR_atlas-4S1056Parcels_den-91k_dseg.tsv',
-        '/AtlasPack/tpl-fsLR/tpl-fsLR_atlas-4S156Parcels_den-91k_dseg.tsv',
-        '/AtlasPack/tpl-fsLR/tpl-fsLR_atlas-4S456Parcels_den-91k_dseg.tsv',
-        '/XCPDAtlases/tpl-fsLR/tpl-fsLR_atlas-Gordon_den-32k_dseg.tsv',
-        '/XCPDAtlases/tpl-fsLR/tpl-fsLR_atlas-Glasser_den-32k_dseg.tsv',
+        f'{_ATLAS_PACK}/tpl-fsLR/tpl-fsLR_atlas-4S1056Parcels_den-91k_dseg.tsv',
+        f'{_ATLAS_PACK}/tpl-fsLR/tpl-fsLR_atlas-4S156Parcels_den-91k_dseg.tsv',
+        f'{_ATLAS_PACK}/tpl-fsLR/tpl-fsLR_atlas-4S456Parcels_den-91k_dseg.tsv',
+        f'{_XCPD_ATLASES}/tpl-fsLR/tpl-fsLR_atlas-Gordon_den-32k_dseg.tsv',
+        f'{_XCPD_ATLASES}/tpl-fsLR/tpl-fsLR_atlas-Glasser_den-32k_dseg.tsv',
     ]
 
     # Create the node and a tmpdir to write its results out to


### PR DESCRIPTION
Closes none, but relates to #1583.

## Changes proposed in this pull request

- Move built-in atlases (AtlasPack and XCPDAtlases) from `/` to `$HOME/.cache/xcp_d`.