### PR TITLE
Bump Nipype to 1.11.0

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -6,8 +6,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -302,8 +300,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -608,8 +604,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -6003,8 +5997,8 @@ packages:
   timestamp: 1718844051451
 - pypi: ./
   name: xcp-d
-  version: 0.14.2.dev30+gb414865db.d20260313
-  sha256: c8138e8f2cfe0d35b52efb5cf0659fe0d5c3cff733df294e1284f75149d883c8
+  version: 0.14.2.dev31+gfd19a52a1
+  sha256: 539ffd153bf02d1a88cb4e298fd74dc918c7ed60139790074dac1ce27e918762
   requires_dist:
   - acres
   - beautifulsoup4
@@ -6018,7 +6012,86 @@ packages:
   - networkx>=3.4.2
   - nibabel>=3.2.1
   - nilearn>=0.13.1
-  - nipype
+  - nipype>=1.11.0,<2
+  - nireports>=25.3.0
+  - nitime
+  - niworkflows>=1.14.4
+  - num2words
+  - numpy>=2.0
+  - packaging
+  - pandas
+  - psutil>=5.4
+  - pybids>=0.21.0
+  - pyyaml
+  - scikit-learn>=1.7.2
+  - scipy>=1.15.2
+  - seaborn
+  - sentry-sdk>=2.54.0
+  - templateflow>=25.1.1
+  - toml
+  - trimesh
+  - coverage ; extra == 'all'
+  - doctest-ignore-unicode ; extra == 'all'
+  - fuzzywuzzy ; extra == 'all'
+  - pre-commit ; extra == 'all'
+  - pydot>=1.2.3 ; extra == 'all'
+  - pydotplus ; extra == 'all'
+  - pytest ; extra == 'all'
+  - pytest-cov ; extra == 'all'
+  - pytest-env ; extra == 'all'
+  - pytest-xdist ; extra == 'all'
+  - python-levenshtein ; extra == 'all'
+  - recommonmark ; extra == 'all'
+  - ruff~=0.15.0 ; extra == 'all'
+  - sphinx-argparse!=0.5.0 ; extra == 'all'
+  - sphinx-design ; extra == 'all'
+  - sphinx-markdown-tables ; extra == 'all'
+  - sphinx-rtd-theme ; extra == 'all'
+  - sphinx>=4.2.0 ; extra == 'all'
+  - sphinxcontrib-apidoc ; extra == 'all'
+  - sphinxcontrib-bibtex ; extra == 'all'
+  - svgutils ; extra == 'all'
+  - pre-commit ; extra == 'dev'
+  - ruff~=0.15.0 ; extra == 'dev'
+  - doctest-ignore-unicode ; extra == 'doc'
+  - pydot>=1.2.3 ; extra == 'doc'
+  - pydotplus ; extra == 'doc'
+  - recommonmark ; extra == 'doc'
+  - sphinx-argparse!=0.5.0 ; extra == 'doc'
+  - sphinx-design ; extra == 'doc'
+  - sphinx-markdown-tables ; extra == 'doc'
+  - sphinx-rtd-theme ; extra == 'doc'
+  - sphinx>=4.2.0 ; extra == 'doc'
+  - sphinxcontrib-apidoc ; extra == 'doc'
+  - sphinxcontrib-bibtex ; extra == 'doc'
+  - svgutils ; extra == 'doc'
+  - fuzzywuzzy ; extra == 'maint'
+  - python-levenshtein ; extra == 'maint'
+  - coverage ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pytest-env ; extra == 'tests'
+  - pytest-xdist ; extra == 'tests'
+  requires_python: '>=3.10'
+  editable: true
+- pypi: ./
+  name: xcp-d
+  version: 0.14.2.dev31+gfd19a52a1
+  sha256: 539ffd153bf02d1a88cb4e298fd74dc918c7ed60139790074dac1ce27e918762
+  requires_dist:
+  - acres
+  - beautifulsoup4
+  - bids-validator>=1.14.7.post0
+  - h5py>=3.15.1
+  - importlib-resources ; python_full_version < '3.11'
+  - indexed-gzip>=1.10.1
+  - jinja2>=3.1.2
+  - joblib>=1.5.3
+  - matplotlib>=3.10.0
+  - networkx>=3.4.2
+  - nibabel>=3.2.1
+  - nilearn>=0.13.1
+  - nipype>=1.11.0,<2
   - nireports>=25.3.0
   - nitime
   - niworkflows>=1.14.4

--- a/pixi.lock
+++ b/pixi.lock
@@ -6,6 +6,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -259,7 +261,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/27/20770bd6bf8fbe1e16f848ba21da9df061f38d2e6483952c29d2bb5d1d8b/narwhals-2.17.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/3d/91ff1823b291de709e92b01373ab9c1d582658ce4b795e443b76761cd2c8/nilearn-0.13.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/53/c5ad0140e2e4c4d92ae45558587e26b2ebc62e39eafa30b74cb052d9375b/nipype-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2f/31/6bb544f26c38f5f8e8b6b83cbf6021909a6d825bed45cc2647440c780038/nipype-1.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/23/f87d9328c96e0107fed479ec564ce645b033ae0d6cedad2672bddeb0e065/nireports-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/5d/ae275feedaa6590cf6e185cfeb7c4d28b5e1a10fcb492fd5340b07921675/nitime-0.12.1-cp311-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/71/e399826fda4c9f41bd3b895c7d5612d4eae76269519ea923ece9f798f79f/nitransforms-25.1.0-py3-none-any.whl
@@ -300,6 +302,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -556,7 +560,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/27/20770bd6bf8fbe1e16f848ba21da9df061f38d2e6483952c29d2bb5d1d8b/narwhals-2.17.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/3d/91ff1823b291de709e92b01373ab9c1d582658ce4b795e443b76761cd2c8/nilearn-0.13.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/53/c5ad0140e2e4c4d92ae45558587e26b2ebc62e39eafa30b74cb052d9375b/nipype-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2f/31/6bb544f26c38f5f8e8b6b83cbf6021909a6d825bed45cc2647440c780038/nipype-1.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/23/f87d9328c96e0107fed479ec564ce645b033ae0d6cedad2672bddeb0e065/nireports-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/5d/ae275feedaa6590cf6e185cfeb7c4d28b5e1a10fcb492fd5340b07921675/nitime-0.12.1-cp311-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/71/e399826fda4c9f41bd3b895c7d5612d4eae76269519ea923ece9f798f79f/nitransforms-25.1.0-py3-none-any.whl
@@ -604,6 +608,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -885,7 +891,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/27/20770bd6bf8fbe1e16f848ba21da9df061f38d2e6483952c29d2bb5d1d8b/narwhals-2.17.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/3d/91ff1823b291de709e92b01373ab9c1d582658ce4b795e443b76761cd2c8/nilearn-0.13.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/53/c5ad0140e2e4c4d92ae45558587e26b2ebc62e39eafa30b74cb052d9375b/nipype-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2f/31/6bb544f26c38f5f8e8b6b83cbf6021909a6d825bed45cc2647440c780038/nipype-1.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/23/f87d9328c96e0107fed479ec564ce645b033ae0d6cedad2672bddeb0e065/nireports-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/5d/ae275feedaa6590cf6e185cfeb7c4d28b5e1a10fcb492fd5340b07921675/nitime-0.12.1-cp311-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/71/e399826fda4c9f41bd3b895c7d5612d4eae76269519ea923ece9f798f79f/nitransforms-25.1.0-py3-none-any.whl
@@ -4060,104 +4066,109 @@ packages:
   - pytest>=6.0.0 ; extra == 'test-free-threaded'
   - rich ; extra == 'test-free-threaded'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/91/53/c5ad0140e2e4c4d92ae45558587e26b2ebc62e39eafa30b74cb052d9375b/nipype-1.10.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/2f/31/6bb544f26c38f5f8e8b6b83cbf6021909a6d825bed45cc2647440c780038/nipype-1.11.0-py3-none-any.whl
   name: nipype
-  version: 1.10.0
-  sha256: 56ced3272e77952e330f13e28328a8fe2e8a69587ca89bc34234f7d06f8319bb
+  version: 1.11.0
+  sha256: 4e20282c7d30d2ff69b54fa0d1e6d3da5d66fda12ac4f9e06be183a3c1269d37
   requires_dist:
+  - acres>=0.3.0
   - click>=6.6.0
+  - etelemetry>=0.3.1
+  - filelock>=3.0.0
+  - looseversion>=1.0.1,!=1.2
+  - lxml>=4.9.1
   - networkx>=2.5
   - nibabel>=3.0
   - numpy>=1.21
-  - packaging
+  - packaging>=21.0
   - prov>=1.5.2
+  - puremagic>=1.15
   - pydot>=1.2.3
   - python-dateutil>=2.2
   - rdflib>=5.0.0
   - scipy>=1.8
   - simplejson>=3.8.0
   - traits>=6.2
-  - filelock>=3.0.0
-  - acres
-  - etelemetry>=0.3.1
-  - looseversion!=1.2
-  - puremagic
+  - black ; extra == 'all'
+  - coverage>=5.2.1 ; extra == 'all'
+  - datalad ; extra == 'all'
+  - dipy ; extra == 'all'
+  - duecredit ; extra == 'all'
+  - fuzzywuzzy ; extra == 'all'
+  - gitpython ; extra == 'all'
+  - ipython ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - nbsphinx ; extra == 'all'
+  - niflow-nipype1-workflows ; extra == 'all'
+  - nilearn ; extra == 'all'
+  - nipy ; extra == 'all'
+  - nitime ; extra == 'all'
+  - pandas>=1.5.0 ; extra == 'all'
+  - paramiko ; extra == 'all'
+  - psutil>=5.0 ; extra == 'all'
+  - pybids>=0.7.0 ; extra == 'all'
+  - pytest-cov>=2.13 ; extra == 'all'
+  - pytest-doctestplus>=1.1.0 ; extra == 'all'
+  - pytest-env>=1.1.0 ; extra == 'all'
+  - pytest-timeout>=1.4 ; extra == 'all'
+  - pytest-xdist>=2.5 ; extra == 'all'
+  - pytest>=6 ; extra == 'all'
+  - sphinx-argparse ; extra == 'all'
+  - sphinx>=2.1.2 ; extra == 'all'
+  - sphinx>=7 ; extra == 'all'
+  - sphinxcontrib-apidoc ; extra == 'all'
+  - xvfbwrapper ; extra == 'all'
   - datalad ; extra == 'data'
+  - black ; extra == 'dev'
+  - coverage>=5.2.1 ; extra == 'dev'
+  - dipy ; extra == 'dev'
+  - ipython ; extra == 'dev'
+  - matplotlib ; extra == 'dev'
+  - nbsphinx ; extra == 'dev'
+  - niflow-nipype1-workflows ; extra == 'dev'
+  - pandas>=1.5.0 ; extra == 'dev'
+  - pytest-cov>=2.13 ; extra == 'dev'
+  - pytest-doctestplus>=1.1.0 ; extra == 'dev'
+  - pytest-env>=1.1.0 ; extra == 'dev'
+  - pytest-timeout>=1.4 ; extra == 'dev'
+  - pytest-xdist>=2.5 ; extra == 'dev'
+  - pytest>=6 ; extra == 'dev'
+  - sphinx-argparse ; extra == 'dev'
+  - sphinx>=2.1.2 ; extra == 'dev'
+  - sphinx>=7 ; extra == 'dev'
+  - sphinxcontrib-apidoc ; extra == 'dev'
+  - xvfbwrapper ; extra == 'dev'
   - dipy ; extra == 'doc'
   - ipython ; extra == 'doc'
   - matplotlib ; extra == 'doc'
   - nbsphinx ; extra == 'doc'
+  - niflow-nipype1-workflows ; extra == 'doc'
   - sphinx-argparse ; extra == 'doc'
   - sphinx>=2.1.2 ; extra == 'doc'
   - sphinxcontrib-apidoc ; extra == 'doc'
   - duecredit ; extra == 'duecredit'
-  - gitpython ; extra == 'maint'
   - fuzzywuzzy ; extra == 'maint'
-  - nitime ; extra == 'nipy'
-  - nilearn ; extra == 'nipy'
+  - gitpython ; extra == 'maint'
   - dipy ; extra == 'nipy'
-  - nipy ; extra == 'nipy'
   - matplotlib ; extra == 'nipy'
+  - nilearn ; extra == 'nipy'
+  - nipy ; extra == 'nipy'
+  - nitime ; extra == 'nipy'
   - psutil>=5.0 ; extra == 'profiler'
   - pybids>=0.7.0 ; extra == 'pybids'
   - black ; extra == 'specs'
   - paramiko ; extra == 'ssh'
   - coverage>=5.2.1 ; extra == 'tests'
   - pandas>=1.5.0 ; extra == 'tests'
-  - pytest>=6 ; extra == 'tests'
-  - pytest-cov>=2.11 ; extra == 'tests'
-  - pytest-env ; extra == 'tests'
+  - pytest-cov>=2.13 ; extra == 'tests'
+  - pytest-doctestplus>=1.1.0 ; extra == 'tests'
+  - pytest-env>=1.1.0 ; extra == 'tests'
   - pytest-timeout>=1.4 ; extra == 'tests'
-  - pytest-doctestplus ; extra == 'tests'
   - pytest-xdist>=2.5 ; extra == 'tests'
+  - pytest>=6 ; extra == 'tests'
   - sphinx>=7 ; extra == 'tests'
   - xvfbwrapper ; extra == 'xvfbwrapper'
-  - fuzzywuzzy ; extra == 'all'
-  - pytest-doctestplus ; extra == 'all'
-  - pytest-timeout>=1.4 ; extra == 'all'
-  - ipython ; extra == 'all'
-  - pytest-cov>=2.11 ; extra == 'all'
-  - pybids>=0.7.0 ; extra == 'all'
-  - psutil>=5.0 ; extra == 'all'
-  - pytest-env ; extra == 'all'
-  - duecredit ; extra == 'all'
-  - pandas>=1.5.0 ; extra == 'all'
-  - black ; extra == 'all'
-  - sphinxcontrib-apidoc ; extra == 'all'
-  - gitpython ; extra == 'all'
-  - sphinx-argparse ; extra == 'all'
-  - coverage>=5.2.1 ; extra == 'all'
-  - matplotlib ; extra == 'all'
-  - pytest>=6 ; extra == 'all'
-  - nilearn ; extra == 'all'
-  - dipy ; extra == 'all'
-  - nbsphinx ; extra == 'all'
-  - sphinx>=2.1.2 ; extra == 'all'
-  - nitime ; extra == 'all'
-  - paramiko ; extra == 'all'
-  - sphinx>=7 ; extra == 'all'
-  - xvfbwrapper ; extra == 'all'
-  - pytest-xdist>=2.5 ; extra == 'all'
-  - nipy ; extra == 'all'
-  - datalad ; extra == 'all'
-  - pytest-env ; extra == 'dev'
-  - matplotlib ; extra == 'dev'
-  - pytest>=6 ; extra == 'dev'
-  - pytest-doctestplus ; extra == 'dev'
-  - pytest-timeout>=1.4 ; extra == 'dev'
-  - pandas>=1.5.0 ; extra == 'dev'
-  - pytest-xdist>=2.5 ; extra == 'dev'
-  - black ; extra == 'dev'
-  - dipy ; extra == 'dev'
-  - ipython ; extra == 'dev'
-  - sphinxcontrib-apidoc ; extra == 'dev'
-  - pytest-cov>=2.11 ; extra == 'dev'
-  - nbsphinx ; extra == 'dev'
-  - sphinx-argparse ; extra == 'dev'
-  - coverage>=5.2.1 ; extra == 'dev'
-  - sphinx>=2.1.2 ; extra == 'dev'
-  - sphinx>=7 ; extra == 'dev'
-  requires_python: '>=3.9'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/4e/23/f87d9328c96e0107fed479ec564ce645b033ae0d6cedad2672bddeb0e065/nireports-25.3.0-py3-none-any.whl
   name: nireports
   version: 25.3.0
@@ -5992,8 +6003,8 @@ packages:
   timestamp: 1718844051451
 - pypi: ./
   name: xcp-d
-  version: 0.14.2.dev30+g64e5151c7.d20260312
-  sha256: c76c9102be71b0f6d032e94beea5cea16341360e8144e14c6dd60eca11805a4d
+  version: 0.14.2.dev30+gb414865db.d20260313
+  sha256: c8138e8f2cfe0d35b52efb5cf0659fe0d5c3cff733df294e1284f75149d883c8
   requires_dist:
   - acres
   - beautifulsoup4
@@ -6007,7 +6018,7 @@ packages:
   - networkx>=3.4.2
   - nibabel>=3.2.1
   - nilearn>=0.13.1
-  - nipype>=1.9.0
+  - nipype
   - nireports>=25.3.0
   - nitime
   - niworkflows>=1.14.4
@@ -6068,85 +6079,6 @@ packages:
   - pytest-env ; extra == 'tests'
   - pytest-xdist ; extra == 'tests'
   requires_python: '>=3.10'
-- pypi: ./
-  name: xcp-d
-  version: 0.14.2.dev31+g840390c3e
-  sha256: c76c9102be71b0f6d032e94beea5cea16341360e8144e14c6dd60eca11805a4d
-  requires_dist:
-  - acres
-  - beautifulsoup4
-  - bids-validator>=1.14.7.post0
-  - h5py>=3.15.1
-  - importlib-resources ; python_full_version < '3.11'
-  - indexed-gzip>=1.10.1
-  - jinja2>=3.1.2
-  - joblib>=1.5.3
-  - matplotlib>=3.10.0
-  - networkx>=3.4.2
-  - nibabel>=3.2.1
-  - nilearn>=0.13.1
-  - nipype>=1.9.0
-  - nireports>=25.3.0
-  - nitime
-  - niworkflows>=1.14.4
-  - num2words
-  - numpy>=2.0
-  - packaging
-  - pandas
-  - psutil>=5.4
-  - pybids>=0.21.0
-  - pyyaml
-  - scikit-learn>=1.7.2
-  - scipy>=1.15.2
-  - seaborn
-  - sentry-sdk>=2.54.0
-  - templateflow>=25.1.1
-  - toml
-  - trimesh
-  - coverage ; extra == 'all'
-  - doctest-ignore-unicode ; extra == 'all'
-  - fuzzywuzzy ; extra == 'all'
-  - pre-commit ; extra == 'all'
-  - pydot>=1.2.3 ; extra == 'all'
-  - pydotplus ; extra == 'all'
-  - pytest ; extra == 'all'
-  - pytest-cov ; extra == 'all'
-  - pytest-env ; extra == 'all'
-  - pytest-xdist ; extra == 'all'
-  - python-levenshtein ; extra == 'all'
-  - recommonmark ; extra == 'all'
-  - ruff~=0.15.0 ; extra == 'all'
-  - sphinx-argparse!=0.5.0 ; extra == 'all'
-  - sphinx-design ; extra == 'all'
-  - sphinx-markdown-tables ; extra == 'all'
-  - sphinx-rtd-theme ; extra == 'all'
-  - sphinx>=4.2.0 ; extra == 'all'
-  - sphinxcontrib-apidoc ; extra == 'all'
-  - sphinxcontrib-bibtex ; extra == 'all'
-  - svgutils ; extra == 'all'
-  - pre-commit ; extra == 'dev'
-  - ruff~=0.15.0 ; extra == 'dev'
-  - doctest-ignore-unicode ; extra == 'doc'
-  - pydot>=1.2.3 ; extra == 'doc'
-  - pydotplus ; extra == 'doc'
-  - recommonmark ; extra == 'doc'
-  - sphinx-argparse!=0.5.0 ; extra == 'doc'
-  - sphinx-design ; extra == 'doc'
-  - sphinx-markdown-tables ; extra == 'doc'
-  - sphinx-rtd-theme ; extra == 'doc'
-  - sphinx>=4.2.0 ; extra == 'doc'
-  - sphinxcontrib-apidoc ; extra == 'doc'
-  - sphinxcontrib-bibtex ; extra == 'doc'
-  - svgutils ; extra == 'doc'
-  - fuzzywuzzy ; extra == 'maint'
-  - python-levenshtein ; extra == 'maint'
-  - coverage ; extra == 'tests'
-  - pytest ; extra == 'tests'
-  - pytest-cov ; extra == 'tests'
-  - pytest-env ; extra == 'tests'
-  - pytest-xdist ; extra == 'tests'
-  requires_python: '>=3.10'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
   sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
   md5: b56e0c8432b56decafae7e78c5f29ba5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "networkx >= 3.4.2",  # nipype needs networkx, but 3+ isn't compatible with nipype 1.8.5
     "nibabel >= 3.2.1",
     "nilearn >= 0.13.1",  # 0.10.2 raises error with compcor from fMRIPrep 23
-    "nipype >= 1.9.0",
+    "nipype>=1.11.0,<2",
     "nireports >= 25.3.0",
     "niworkflows >= 1.14.4",
     "nitime",  # for DVARS calculation in Nipype


### PR DESCRIPTION
Closes none, but gets us https://github.com/nipy/nipype/pull/3745.

## Changes proposed in this pull request

- Run `pixi upgrade nipype` to bump nipype from 1.10.0 to 1.11.0.