### PR TITLE
Z-score data before concatenating

### DIFF
--- a/xcp_d/interfaces/concatenation.py
+++ b/xcp_d/interfaces/concatenation.py
@@ -16,7 +16,12 @@ from nipype.interfaces.base import (
     traits,
 )
 
-from xcp_d.utils.concatenation import concatenate_niimgs, concatenate_tsvs
+from xcp_d.utils.concatenation import (
+    concatenate_niimgs,
+    concatenate_tsvs,
+    zscore_niimg,
+    zscore_tsv,
+)
 
 LOGGER = logging.getLogger('nipype.interface')
 
@@ -433,5 +438,112 @@ class ConcatenateInputs(SimpleInterface):
                 if not os.path.isfile(out_file):
                     raise RuntimeError(f'Output file {out_file} not created.')
                 self._results[name] = out_file
+
+        return runtime
+
+
+class _ZScoreInputsInputSpec(BaseInterfaceInputSpec):
+    denoised_bold = traits.List(
+        File(exists=True),
+        mandatory=True,
+        desc='Denoised BOLD data.',
+    )
+    timeseries = traits.List(
+        traits.Either(
+            traits.List(File(exists=True)),
+            Undefined,
+        ),
+        desc='List of lists of parcellated time series TSV files.',
+    )
+    timeseries_ciftis = traits.List(
+        traits.Either(
+            traits.List(File(exists=True)),
+            Undefined,
+        ),
+        desc=(
+            'List of lists of parcellated time series CIFTI files. '
+            'Only defined for CIFTI processing.'
+        ),
+    )
+
+
+class _ZScoreInputsOutputSpec(TraitedSpec):
+    denoised_bold = traits.List(
+        File(exists=True),
+        mandatory=True,
+        desc='Z-scored denoised BOLD data.',
+    )
+    timeseries = traits.List(
+        traits.Either(
+            traits.List(File(exists=True)),
+            Undefined,
+        ),
+        desc='List of lists of z-scored parcellated time series TSV files.',
+    )
+    timeseries_ciftis = traits.List(
+        traits.Either(
+            traits.List(File(exists=True)),
+            Undefined,
+        ),
+        desc=(
+            'List of lists of z-scored parcellated time series CIFTI files. '
+            'Only defined for CIFTI processing.'
+        ),
+    )
+
+
+class ZScoreInputs(SimpleInterface):
+    """Z-score inputs."""
+
+    input_spec = _ZScoreInputsInputSpec
+    output_spec = _ZScoreInputsOutputSpec
+
+    def _run_interface(self, runtime):
+        merge_inputs = {
+            'denoised_bold': self.inputs.denoised_bold,
+            'timeseries_ciftis': self.inputs.timeseries_ciftis,
+            'timeseries': self.inputs.timeseries,
+        }
+
+        for name, run_files in merge_inputs.items():
+            LOGGER.info(f'Z-scoring {name}')
+            if len(run_files) == 0 or any(not isdefined(f) for f in run_files):
+                LOGGER.warning(f'No {name} files found')
+                self._results[name] = Undefined
+                continue
+
+            elif isinstance(run_files[0], list) and not isdefined(run_files[0][0]):
+                LOGGER.warning(f'No {name} files found')
+                self._results[name] = Undefined
+                continue
+
+            # Files are organized in a list of lists, like parcellated time series, in order
+            # [['run-1_atlas-a', 'run-2_atlas-a'], ['run-1_atlas-b', 'run-2_atlas-b']]
+            out_files = []
+            for run_file in run_files:
+                if isinstance(run_file, list):
+                    out_run_files = []
+                    for run_file_ in run_file:
+                        out_file = os.path.join(runtime.cwd, os.path.basename(run_file_))
+                        if out_file.endswith('.tsv'):
+                            zscore_tsv(run_file_, out_file=out_file)
+                        else:
+                            zscore_niimg(run_file_, out_file=out_file)
+
+                        if not os.path.isfile(out_file):
+                            raise RuntimeError(f'Output file {out_file} not created.')
+                        out_run_files.append(out_file)
+                    out_files.append(out_run_files)
+                else:
+                    if run_file.endswith('.tsv'):
+                        zscore_tsv(run_file, out_file=run_file)
+                    else:
+                        zscore_niimg(run_file, out_file=run_file)
+
+                    if not os.path.isfile(run_file):
+                        raise RuntimeError(f'Output file {run_file} not created.')
+                    out_files.append(run_file)
+
+            self._results[name] = out_files
 
         return runtime

--- a/xcp_d/interfaces/concatenation.py
+++ b/xcp_d/interfaces/concatenation.py
@@ -535,14 +535,15 @@ class ZScoreInputs(SimpleInterface):
                         out_run_files.append(out_file)
                     out_files.append(out_run_files)
                 else:
+                    out_file = os.path.join(runtime.cwd, os.path.basename(run_file))
                     if run_file.endswith('.tsv'):
-                        zscore_tsv(run_file, out_file=run_file)
+                        zscore_tsv(run_file, out_file=out_file)
                     else:
-                        zscore_niimg(run_file, out_file=run_file)
+                        zscore_niimg(run_file, out_file=out_file)
 
-                    if not os.path.isfile(run_file):
-                        raise RuntimeError(f'Output file {run_file} not created.')
-                    out_files.append(run_file)
+                    if not os.path.isfile(out_file):
+                        raise RuntimeError(f'Output file {out_file} not created.')
+                    out_files.append(out_file)
 
             self._results[name] = out_files
 

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from nilearn.image import concat_imgs
 from nipype import logging
+from scipy import stats
 
 LOGGER = logging.getLogger('nipype.interface')
 
@@ -60,3 +61,31 @@ def concatenate_niimgs(files, out_file):
         concat_preproc_img.to_filename(out_file)
     else:
         os.system(f'wb_command -cifti-merge {out_file} -cifti {" -cifti ".join(files)}')  # noqa: S605
+
+
+def zscore_tsv(tsv_file, out_file):
+    """Z-score a TSV file."""
+    data = pd.read_table(tsv_file)
+    # Assume first axis is time
+    data = data.apply(stats.zscore, axis=0)
+    data.to_csv(out_file, sep='\t', index=False)
+    return out_file
+
+
+def zscore_niimg(niimg_file, out_file):
+    """Z-score a NIfTI image."""
+    img = nb.load(niimg_file)
+    if isinstance(img, nb.Cifti2Image):
+        data = img.get_data()
+        # Assume first axis is time
+        data = stats.zscore(data, axis=0)
+        img_out = nb.Cifti2Image(data, img.header, img.nifti_header)
+    elif isinstance(img, nb.Nifti1Image):
+        data = img.get_fdata()
+        # Assume fourth axis is time
+        data = stats.zscore(data, axis=3)
+        img_out = nb.Nifti1Image(data, img.affine, img.header)
+    else:
+        raise ValueError(f'Unsupported image type: {type(img)}')
+    img_out.to_filename(out_file)
+    return out_file

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -76,7 +76,7 @@ def zscore_niimg(niimg_file, out_file):
     """Z-score a NIfTI image."""
     img = nb.load(niimg_file)
     if isinstance(img, nb.Cifti2Image):
-        data = img.get_data()
+        data = img.get_fdata()
         # Assume first axis is time
         data = stats.zscore(data, axis=0)
         img_out = nb.Cifti2Image(data, img.header, img.nifti_header)

--- a/xcp_d/workflows/base.py
+++ b/xcp_d/workflows/base.py
@@ -501,7 +501,6 @@ It is released under the [CC0](https://creativecommons.org/publicdomain/zero/1.0
                 'denoised_bold',
                 'denoised_interpolated_bold',
                 'censored_denoised_bold',
-                'smoothed_denoised_bold',
                 'bold_mask',
                 'boldref',
                 'timeseries',

--- a/xcp_d/workflows/bold/cifti.py
+++ b/xcp_d/workflows/bold/cifti.py
@@ -128,7 +128,6 @@ def init_postprocess_cifti_wf(
     %(temporal_mask)s
     %(denoised_interpolated_bold)s
     %(censored_denoised_bold)s
-    %(smoothed_denoised_bold)s
     %(boldref)s
     bold_mask
     %(timeseries)s
@@ -202,7 +201,6 @@ the following post-processing was performed.
                 'denoised_bold',
                 'denoised_interpolated_bold',
                 'censored_denoised_bold',
-                'smoothed_denoised_bold',
                 'boldref',
                 'bold_mask',  # used for plotting
                 # if parcellation is performed
@@ -367,7 +365,6 @@ the following post-processing was performed.
             ('outputnode.motion_file', 'motion_file'),
             ('outputnode.temporal_mask', 'temporal_mask'),
             ('outputnode.denoised_bold', 'denoised_bold'),
-            ('outputnode.smoothed_denoised_bold', 'smoothed_denoised_bold'),
             ('outputnode.timeseries', 'timeseries'),
             ('outputnode.timeseries_ciftis', 'timeseries_ciftis'),
         ]),

--- a/xcp_d/workflows/bold/concatenation.py
+++ b/xcp_d/workflows/bold/concatenation.py
@@ -335,6 +335,9 @@ Prior to concatenation, the denoised BOLD data and parcellated time series were 
 
         workflow.connect([
             (concatenate_inputs, resd_smoothing_wf, [('denoised_bold', 'inputnode.bold_file')]),
+            (filter_runs, ds_smoothed_denoised_bold, [
+                (('denoised_bold', _combine_name), 'source_file'),
+            ]),
             (resd_smoothing_wf, ds_smoothed_denoised_bold, [
                 ('outputnode.smoothed_bold', 'in_file'),
             ]),

--- a/xcp_d/workflows/bold/concatenation.py
+++ b/xcp_d/workflows/bold/concatenation.py
@@ -11,12 +11,14 @@ from xcp_d.interfaces.concatenation import (
     CleanNameSource,
     ConcatenateInputs,
     FilterOutFailedRuns,
+    ZScoreInputs,
 )
 from xcp_d.interfaces.connectivity import CiftiToTSV, TSVConnect
 from xcp_d.interfaces.workbench import CiftiCorrelation
 from xcp_d.utils.doc import fill_doc
 from xcp_d.utils.utils import _select_first
 from xcp_d.workflows.bold.plotting import init_qc_report_wf
+from xcp_d.workflows.bold.postprocessing import init_resd_smoothing_wf
 
 
 @fill_doc
@@ -89,6 +91,7 @@ def init_concatenate_data_wf(TR, head_radius, mem_gb, name='concatenate_data_wf'
 
     workflow.__desc__ = """
 Postprocessing derivatives from multi-run tasks were then concatenated across runs and directions.
+Prior to concatenation, the denoised BOLD data and parcellated time series were z-scored.
 """
 
     inputnode = pe.Node(
@@ -101,7 +104,6 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
                 'denoised_bold',
                 'denoised_interpolated_bold',
                 'censored_denoised_bold',
-                'smoothed_denoised_bold',
                 'atlas_labels_files',
                 'bold_mask',  # only for niftis, from postproc workflows
                 'boldref',  # only for niftis, from postproc workflows
@@ -134,12 +136,24 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
             ('denoised_bold', 'denoised_bold'),
             ('denoised_interpolated_bold', 'denoised_interpolated_bold'),
             ('censored_denoised_bold', 'censored_denoised_bold'),
-            ('smoothed_denoised_bold', 'smoothed_denoised_bold'),
             ('bold_mask', 'bold_mask'),
             ('boldref', 'boldref'),
             ('timeseries', 'timeseries'),
             ('timeseries_ciftis', 'timeseries_ciftis'),
         ])
+    ])  # fmt:skip
+
+    z_score_inputs = pe.Node(
+        ZScoreInputs(),
+        name='z_score_inputs',
+        mem_gb=mem_gb['bold'],
+    )
+    workflow.connect([
+        (filter_runs, z_score_inputs, [
+            ('denoised_bold', 'denoised_bold'),
+            ('timeseries', 'timeseries'),
+            ('timeseries_ciftis', 'timeseries_ciftis'),
+        ]),
     ])  # fmt:skip
 
     concatenate_inputs = pe.Node(
@@ -153,10 +167,11 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
             ('preprocessed_bold', 'preprocessed_bold'),
             ('motion_file', 'motion_file'),
             ('temporal_mask', 'temporal_mask'),
-            ('denoised_bold', 'denoised_bold'),
             ('denoised_interpolated_bold', 'denoised_interpolated_bold'),
             ('censored_denoised_bold', 'censored_denoised_bold'),
-            ('smoothed_denoised_bold', 'smoothed_denoised_bold'),
+        ]),
+        (z_score_inputs, concatenate_inputs, [
+            ('denoised_bold', 'denoised_bold'),
             ('timeseries', 'timeseries'),
             ('timeseries_ciftis', 'timeseries_ciftis'),
         ]),
@@ -261,7 +276,9 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
             ds_smoothed_denoised_bold = pe.Node(
                 DerivativesDataSink(
                     dismiss_entities=dismiss_hash(),
+                    desc='denoisedSmoothed',
                     extension='.dtseries.nii',
+                    FWHM=smoothing,
                 ),
                 name='ds_smoothed_denoised_bold',
                 run_without_submitting=True,
@@ -284,8 +301,10 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
             ds_smoothed_denoised_bold = pe.Node(
                 DerivativesDataSink(
                     dismiss_entities=dismiss_hash(),
+                    desc='denoisedSmoothed',
                     extension='.nii.gz',
                     compression=True,
+                    FWHM=smoothing,
                 ),
                 name='ds_smoothed_denoised_bold',
                 run_without_submitting=True,
@@ -310,6 +329,17 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
     ])  # fmt:skip
 
     if smoothing:
+        workflow.__desc__ += ' The concatenated, z-scored denoised BOLD data was smoothed.'
+
+        resd_smoothing_wf = init_resd_smoothing_wf(mem_gb=mem_gb)
+
+        workflow.connect([
+            (concatenate_inputs, resd_smoothing_wf, [('denoised_bold', 'inputnode.bold_file')]),
+            (resd_smoothing_wf, ds_smoothed_denoised_bold, [
+                ('outputnode.smoothed_bold', 'in_file'),
+            ]),
+        ])  # fmt:skip
+
         smoothed_src = pe.Node(
             BIDSURI(
                 numinputs=1,
@@ -320,13 +350,7 @@ Postprocessing derivatives from multi-run tasks were then concatenated across ru
             run_without_submitting=True,
         )
         workflow.connect([
-            (filter_runs, smoothed_src, [('smoothed_denoised_bold', 'in1')]),
-            (filter_runs, ds_smoothed_denoised_bold, [
-                (('smoothed_denoised_bold', _combine_name), 'source_file'),
-            ]),
-            (concatenate_inputs, ds_smoothed_denoised_bold, [
-                ('smoothed_denoised_bold', 'in_file'),
-            ]),
+            (ds_denoised_bold, smoothed_src, [('out_file', 'in1')]),
             (smoothed_src, ds_smoothed_denoised_bold, [('out', 'Sources')]),
         ])  # fmt:skip
 

--- a/xcp_d/workflows/bold/nifti.py
+++ b/xcp_d/workflows/bold/nifti.py
@@ -139,7 +139,6 @@ def init_postprocess_nifti_wf(
     motion_file
         After dummy scan removal.
     %(denoised_interpolated_bold)s
-    %(smoothed_denoised_bold)s
     %(boldref)s
     bold_mask
     %(timeseries)s
@@ -210,7 +209,6 @@ the following post-processing was performed.
                 'denoised_bold',
                 'denoised_interpolated_bold',
                 'censored_denoised_bold',
-                'smoothed_denoised_bold',
                 'boldref',
                 'bold_mask',
                 # if parcellation is performed
@@ -382,7 +380,6 @@ the following post-processing was performed.
             ('outputnode.motion_file', 'motion_file'),
             ('outputnode.temporal_mask', 'temporal_mask'),
             ('outputnode.denoised_bold', 'denoised_bold'),
-            ('outputnode.smoothed_denoised_bold', 'smoothed_denoised_bold'),
             ('outputnode.timeseries', 'timeseries'),
         ]),
     ])  # fmt:skip

--- a/xcp_d/workflows/bold/outputs.py
+++ b/xcp_d/workflows/bold/outputs.py
@@ -136,7 +136,6 @@ def init_postproc_derivatives_wf(
                 'temporal_mask',
                 'denoised_bold',
                 'censored_denoised_bold',
-                'smoothed_denoised_bold',
                 'timeseries',
                 'timeseries_ciftis',
             ],
@@ -419,7 +418,6 @@ def init_postproc_derivatives_wf(
         workflow.connect([
             (inputnode, ds_smoothed_bold, [('smoothed_denoised_bold', 'in_file')]),
             (smoothed_bold_src, ds_smoothed_bold, [('out', 'Sources')]),
-            (ds_smoothed_bold, outputnode, [('out_file', 'smoothed_denoised_bold')]),
         ])  # fmt:skip
 
     # Connectivity workflow outputs


### PR DESCRIPTION
Closes #1607.

## Changes proposed in this pull request

- Z-score denoised BOLD and parcellated time series prior to concatenating.
- Create smoothed version of concatenated BOLD by directly smoothing the concatenated, z-scored, denoised BOLD instead of z-scoring and concatenating already-smoothed files.