### PR TITLE
Fix duplicate HCP brain mask mapping in hcp ingression

### DIFF
--- a/xcp_d/ingression/hcpya.py
+++ b/xcp_d/ingression/hcpya.py
@@ -299,16 +299,6 @@ def convert_hcp_to_bids_single_subject(in_dir, out_dir, sub_ent):
         )
         copy_dictionary[bold_cifti_orig] = [bold_cifti_fmriprep]
 
-        bold_mask_orig = os.path.join(task_dir_orig, 'brainmask_fs.2.0.nii.gz')
-        if not os.path.isfile(bold_mask_orig):
-            bold_mask_orig = os.path.join(task_dir_orig, 'brainmask_fs.nii.gz')
-
-        bold_mask_fmriprep = os.path.join(
-            func_dir_bids,
-            f'{func_prefix}_{volspace_ent}_{res_ent}_desc-brain_mask.nii.gz',
-        )
-        copy_dictionary[bold_mask_orig] = [bold_mask_fmriprep]
-
         # Extract metadata for JSON files
         bold_metadata = {
             'RepetitionTime': float(nb.load(bold_nifti_orig).header.get_zooms()[-1]),


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
File `hcpya.py` currently maps the same functional brain mask output twice. The second mapping falls back to `brainmask_fs.nii.gz`, which is not present in HCP run directories. This causes FileNotFoundError during `copy_files_in_dict()`.
The commit removes the duplicate mapping and keeps the existing `brainmask_fs.2(.0).nii.gz` logic.
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
