### PR TITLE
Add kwargs to _warnings.py

### DIFF
--- a/xcp_d/_warnings.py
+++ b/xcp_d/_warnings.py
@@ -7,17 +7,20 @@ _wlog = logging.getLogger('py.warnings')
 _wlog.addHandler(logging.NullHandler())
 
 
-def _warn(message, category=None, stacklevel=1, source=None):
+def _warn(message, category=None, stacklevel=1, source=None, **kwargs):
     """Redefine the warning function."""
     if category is not None:
         category = type(category).__name__
         category = category.replace('type', 'WARNING')
 
+    if kwargs:
+        logging.getLogger('py.warnings').warning(f'Extra warning kwargs: {kwargs}')
+
     logging.getLogger('py.warnings').warning(f'{category or "WARNING"}: {message}')
 
 
-def _showwarning(message, category, filename, lineno, file=None, line=None):
-    _warn(message, category=category)
+def _showwarning(message, category, filename, lineno, file=None, line=None, **kwargs):
+    _warn(message, category=category, **kwargs)
 
 
 warnings.warn = _warn


### PR DESCRIPTION
Addresses https://neurostars.org/t/xcp-d-26-0-2-fails-during-brainsprite-plot-slices-t1-t2/36172. Reproduces nipreps/fmriprep#3483. 

## Changes proposed in this pull request

- Add kwargs to `_warn()` and `_showwarning()` to allow for unexpected arguments.
