### PR TITLE
Replace NaNs with zeros in z-scored, concatenated data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .cursor/.cursorenv
+docs/superpowers
+.claude/settings.local.json
 
 # local path for tests
 xcp_d/tests/pytests

--- a/xcp_d/tests/test_utils_concatenation.py
+++ b/xcp_d/tests/test_utils_concatenation.py
@@ -87,11 +87,13 @@ def test_zscore_tsv(tmp_path_factory):
     rng = np.random.default_rng(42)
     n_timepoints = 100
 
-    data = pd.DataFrame({
-        'normal_1': rng.normal(5, 2, n_timepoints),
-        'normal_2': rng.normal(-3, 1, n_timepoints),
-        'all_zero': np.zeros(n_timepoints),
-    })
+    data = pd.DataFrame(
+        {
+            'normal_1': rng.normal(5, 2, n_timepoints),
+            'normal_2': rng.normal(-3, 1, n_timepoints),
+            'all_zero': np.zeros(n_timepoints),
+        }
+    )
     in_file = str(tmpdir / 'test.tsv')
     data.to_csv(in_file, sep='\t', index=False)
     out_file = str(tmpdir / 'test_zscored.tsv')

--- a/xcp_d/tests/test_utils_concatenation.py
+++ b/xcp_d/tests/test_utils_concatenation.py
@@ -87,11 +87,13 @@ def test_zscore_tsv(tmp_path_factory):
     rng = np.random.default_rng(42)
     n_timepoints = 100
 
-    data = pd.DataFrame({
-        'normal_1': rng.normal(5, 2, n_timepoints),
-        'normal_2': rng.normal(-3, 1, n_timepoints),
-        'all_zero': np.zeros(n_timepoints),
-    })
+    data = pd.DataFrame(
+        {
+            'normal_1': rng.normal(5, 2, n_timepoints),
+            'normal_2': rng.normal(-3, 1, n_timepoints),
+            'all_zero': np.zeros(n_timepoints),
+        }
+    )
     in_file = str(tmpdir / 'test.tsv')
     data.to_csv(in_file, sep='\t', index=False)
     out_file = str(tmpdir / 'test_zscored.tsv')
@@ -101,8 +103,8 @@ def test_zscore_tsv(tmp_path_factory):
 
     assert not out_data.isnull().any().any(), 'NaNs found in z-scored TSV output'
     np.testing.assert_array_equal(out_data['all_zero'].values, 0.0)
-    assert abs(out_data['normal_1'].mean()) < 1e-10
-    assert abs(out_data['normal_2'].mean()) < 1e-10
+    assert abs(out_data['normal_1'].mean()) < 1e-6
+    assert abs(out_data['normal_2'].mean()) < 1e-6
     np.testing.assert_approx_equal(out_data['normal_1'].std(ddof=0), 1.0, significant=5)
     np.testing.assert_approx_equal(out_data['normal_2'].std(ddof=0), 1.0, significant=5)
 
@@ -125,7 +127,7 @@ def test_zscore_niimg(ds001419_data, tmp_path_factory):
 
     assert not np.any(np.isnan(out_data)), 'NaNs found in z-scored NIfTI output'
     np.testing.assert_array_equal(out_data[0, 0, 0, :], 0.0)
-    assert abs(np.mean(out_data[1, 1, 1, :])) < 1e-10
+    assert abs(np.mean(out_data[1, 1, 1, :])) < 1e-6
 
     # --- CIFTI branch ---
     cifti_img = nb.load(ds001419_data['cifti_file'])
@@ -141,4 +143,4 @@ def test_zscore_niimg(ds001419_data, tmp_path_factory):
 
     assert not np.any(np.isnan(out_cdata)), 'NaNs found in z-scored CIFTI output'
     np.testing.assert_array_equal(out_cdata[:, 0], 0.0)
-    assert abs(np.mean(out_cdata[:, 1])) < 1e-10
+    assert abs(np.mean(out_cdata[:, 1])) < 1e-6

--- a/xcp_d/tests/test_utils_concatenation.py
+++ b/xcp_d/tests/test_utils_concatenation.py
@@ -79,3 +79,66 @@ def test_concatenate_niimgs(ds001419_data, tmp_path_factory):
     concat_cifti_img = nb.load(concat_cifti_file)
     assert concat_cifti_img.shape[0] == cifti_img.shape[0] * n_repeats
     assert concat_cifti_img.shape[1] == cifti_img.shape[1]
+
+
+def test_zscore_tsv(tmp_path_factory):
+    """Test xcp_d.utils.concatenation.zscore_tsv with all-zero column."""
+    tmpdir = tmp_path_factory.mktemp('test_zscore_tsv')
+    rng = np.random.default_rng(42)
+    n_timepoints = 100
+
+    data = pd.DataFrame({
+        'normal_1': rng.normal(5, 2, n_timepoints),
+        'normal_2': rng.normal(-3, 1, n_timepoints),
+        'all_zero': np.zeros(n_timepoints),
+    })
+    in_file = str(tmpdir / 'test.tsv')
+    data.to_csv(in_file, sep='\t', index=False)
+    out_file = str(tmpdir / 'test_zscored.tsv')
+
+    result = concatenation.zscore_tsv(in_file, out_file=out_file)
+    out_data = pd.read_table(result)
+
+    assert not out_data.isnull().any().any(), 'NaNs found in z-scored TSV output'
+    np.testing.assert_array_equal(out_data['all_zero'].values, 0.0)
+    assert abs(out_data['normal_1'].mean()) < 1e-10
+    assert abs(out_data['normal_2'].mean()) < 1e-10
+    np.testing.assert_approx_equal(out_data['normal_1'].std(ddof=0), 1.0, significant=5)
+    np.testing.assert_approx_equal(out_data['normal_2'].std(ddof=0), 1.0, significant=5)
+
+
+def test_zscore_niimg(ds001419_data, tmp_path_factory):
+    """Test xcp_d.utils.concatenation.zscore_niimg with all-zero voxel/vertex."""
+    tmpdir = tmp_path_factory.mktemp('test_zscore_niimg')
+
+    # --- NIfTI branch ---
+    nifti_img = nb.load(ds001419_data['nifti_file'])
+    data = nifti_img.get_fdata()
+    data[0, 0, 0, :] = 0.0  # force one voxel to all-zero
+    modified_nifti = nb.Nifti1Image(data, nifti_img.affine, nifti_img.header)
+    nifti_in = str(tmpdir / 'test.nii.gz')
+    modified_nifti.to_filename(nifti_in)
+    nifti_out = str(tmpdir / 'test_zscored.nii.gz')
+
+    result = concatenation.zscore_niimg(nifti_in, out_file=nifti_out)
+    out_data = nb.load(result).get_fdata()
+
+    assert not np.any(np.isnan(out_data)), 'NaNs found in z-scored NIfTI output'
+    np.testing.assert_array_equal(out_data[0, 0, 0, :], 0.0)
+    assert abs(np.mean(out_data[1, 1, 1, :])) < 1e-10
+
+    # --- CIFTI branch ---
+    cifti_img = nb.load(ds001419_data['cifti_file'])
+    cdata = cifti_img.get_fdata()
+    cdata[:, 0] = 0.0  # force one vertex to all-zero (axis 0 = time, axis 1 = vertices)
+    modified_cifti = nb.Cifti2Image(cdata, cifti_img.header, cifti_img.nifti_header)
+    cifti_in = str(tmpdir / 'test.dtseries.nii')
+    modified_cifti.to_filename(cifti_in)
+    cifti_out = str(tmpdir / 'test_zscored.dtseries.nii')
+
+    result = concatenation.zscore_niimg(cifti_in, out_file=cifti_out)
+    out_cdata = nb.load(result).get_fdata()
+
+    assert not np.any(np.isnan(out_cdata)), 'NaNs found in z-scored CIFTI output'
+    np.testing.assert_array_equal(out_cdata[:, 0], 0.0)
+    assert abs(np.mean(out_cdata[:, 1])) < 1e-10

--- a/xcp_d/utils/concatenation.py
+++ b/xcp_d/utils/concatenation.py
@@ -75,6 +75,7 @@ def zscore_tsv(tsv_file, out_file):
     data = pd.read_table(tsv_file)
     # Assume first axis is time
     data = data.apply(stats.zscore, axis=0)
+    data = data.fillna(0)
     data.to_csv(out_file, sep='\t', index=False)
     return out_file
 
@@ -86,11 +87,13 @@ def zscore_niimg(niimg_file, out_file):
         data = img.get_fdata()
         # Assume first axis is time
         data = stats.zscore(data, axis=0)
+        data = np.nan_to_num(data, nan=0.0)
         img_out = nb.Cifti2Image(data, img.header, img.nifti_header)
     elif isinstance(img, nb.Nifti1Image):
         data = img.get_fdata()
         # Assume fourth axis is time
         data = stats.zscore(data, axis=3)
+        data = np.nan_to_num(data, nan=0.0)
         img_out = nb.Nifti1Image(data, img.affine, img.header)
     else:
         raise ValueError(f'Unsupported image type: {type(img)}')


### PR DESCRIPTION
Closes #1620.

## Changes proposed in this pull request

- Explicitly replace NaNs due to zero-SD vertices/voxels with zeros in concatenated data (i.e., after z-scoring).
- Add Claude-related files (superpowers, local settings JSON) to gitignore. 