### PR TITLE
Revert workbench to 1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=pennlinc/xcp_d-base:20260303
+ARG BASE_IMAGE=pennlinc/xcp_d-base:20260611
 
 FROM ghcr.io/prefix-dev/pixi:0.58.0 AS build
 RUN apt-get update && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -76,6 +76,7 @@ RUN GNUPGHOME=/tmp gpg --keyserver hkps://keyserver.ubuntu.com --no-default-keyr
 
 RUN apt-get update -qq \
     && apt-get install -y -q --no-install-recommends \
+           connectome-workbench=1.5.0-2 \
            ed \
            gsl-bin \
            libglib2.0-0 \

--- a/pixi.lock
+++ b/pixi.lock
@@ -24,7 +24,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/connectome-workbench-cli-2.0.1-qt6_h1234567_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
@@ -119,7 +118,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.84.0-h2ff4ddf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
@@ -157,7 +155,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.0-h4922eb0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.8-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.8-py312he3d6523_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mesalib-25.0.5-h57bcd07_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.2.2-ha770c72_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-service-2.4.2-py312hf224ee7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
@@ -193,7 +190,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py312ha707e6e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2025.5-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h8d10470_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
@@ -222,7 +218,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.6-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
@@ -319,7 +314,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/connectome-workbench-cli-2.0.1-qt6_h1234567_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
@@ -414,7 +408,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.84.0-h2ff4ddf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
@@ -452,7 +445,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.0-h4922eb0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.8-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.8-py312he3d6523_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mesalib-25.0.5-h57bcd07_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.2.2-ha770c72_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-service-2.4.2-py312hf224ee7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
@@ -488,7 +480,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py312ha707e6e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2025.5-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h8d10470_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
@@ -517,7 +508,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.6-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
@@ -625,7 +615,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/connectome-workbench-cli-2.0.1-qt6_h1234567_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.18.0-h4e3cde8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -733,7 +722,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.84.3-hf39c6af_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
@@ -777,7 +765,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.8-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.8-py312he3d6523_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mesalib-25.0.5-h57bcd07_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.2.2-ha770c72_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-service-2.4.2-py312hf224ee7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
@@ -819,7 +806,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py312ha707e6e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2025.5-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.51.2-hbc0de68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h8d10470_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
@@ -849,7 +835,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.6-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
@@ -1223,26 +1208,6 @@ packages:
   requires_dist:
   - colorama ; sys_platform == 'win32'
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/connectome-workbench-cli-2.0.1-qt6_h1234567_104.conda
-  sha256: da931f02c4bde7b9d067be58a1b2de51939af691c68fc190c87846be2187f1e4
-  md5: a4b8015d31f31793e53f6d7547dee1e4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _openmp_mutex >=4.5
-  - freetype >=2.12.1,<3.0a0
-  - libgcc >=13
-  - libgl
-  - libglu
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - mesalib >=25.0.1,<25.1.0a0
-  - openssl >=3.4.1,<4.0a0
-  - qt6-main >=6.8.2,<6.9.0a0
-  license: GPL-2.0-only
-  license_family: GPL
-  purls: []
-  size: 6185692
-  timestamp: 1741625257601
 - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
   sha256: 62447faf7e8eb691e407688c0b4b7c230de40d5ecf95bf301111b4d05c5be473
   md5: 43c2bc96af3ae5ed9e8a10ded942aa50
@@ -3155,18 +3120,6 @@ packages:
   purls: []
   size: 3961899
   timestamp: 1754315006443
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
-  sha256: a0105eb88f76073bbb30169312e797ed5449ebb4e964a756104d6e54633d17ef
-  md5: 8422fcc9e5e172c91e99aef703b3ce65
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopengl >=1.7.0,<2.0a0
-  - libstdcxx >=13
-  license: SGI-B-2.0
-  purls: []
-  size: 325262
-  timestamp: 1748692137626
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
   sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
   md5: 434ca7e50e40f4918ab701e3facd59a0
@@ -3754,30 +3707,6 @@ packages:
   - pkg:pypi/matplotlib?source=hash-mapping
   size: 8442149
   timestamp: 1763055517581
-- conda: https://conda.anaconda.org/conda-forge/linux-64/mesalib-25.0.5-h57bcd07_2.conda
-  sha256: b2c88c95088db3dd3048242a48e957cf53ac852047ebaafc3a822bd083ad9858
-  md5: 9b6b685b123906eb4ef270b50cbe826c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libdrm >=2.4.125,<2.5.0a0
-  - libexpat >=2.7.1,<3.0a0
-  - libgcc >=14
-  - libllvm20 >=20.1.8,<20.2.0a0
-  - libstdcxx >=14
-  - libxcb >=1.17.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - spirv-tools >=2025,<2026.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxrandr >=1.5.4,<2.0a0
-  - xorg-libxshmfence >=1.3.3,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  track_features:
-  - mesalib
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 6350427
-  timestamp: 1755729794084
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.2.2-ha770c72_17.conda
   sha256: 1e59d0dc811f150d39c2ff2da930d69dcb91cb05966b7df5b7d85133006668ed
   md5: e4ab075598123e783b788b995afbdad0
@@ -5473,20 +5402,6 @@ packages:
   version: 2.8.3
   sha256: ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2025.5-hb700be7_0.conda
-  sha256: 7547142ab1352132adf98d555ed955badd96c9f277cbd054ae52f7edd6cf6cb8
-  md5: 058d5f16eaa3018be91aa3508df00d7c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - spirv-headers >=1.4.335.0,<1.4.335.1.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 2595788
-  timestamp: 1769406054481
 - pypi: https://files.pythonhosted.org/packages/8a/07/b47472d2ffd0776826f17ccf0b4d01b224c99fbd1904aeb103dffbb4b1cc/sqlalchemy-2.0.47-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: sqlalchemy
   version: 2.0.47
@@ -6314,17 +6229,6 @@ packages:
   purls: []
   size: 33005
   timestamp: 1734229037766
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
-  sha256: c0830fe9fa78d609cd9021f797307e7e0715ef5122be3f784765dad1b4d8a193
-  md5: 9a809ce9f65460195777f2f2116bae02
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 12302
-  timestamp: 1734168591429
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
   sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
   md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f

--- a/pixi.lock
+++ b/pixi.lock
@@ -5885,8 +5885,8 @@ packages:
   timestamp: 1718844051451
 - pypi: ./
   name: xcp-d
-  version: 26.1.1.dev2+gdc2076555.d20260610
-  sha256: 805b73a2aaebc804e3d429df1a00494f92e09108a0692a084c96e80116aa08e9
+  version: 26.1.1.dev4+g7e8bdec40
+  sha256: f058b2722c80c69593871ce2e449086023e6e0558e25ab7e44a56b4b2686bfa6
   requires_dist:
   - acres
   - beautifulsoup4
@@ -5964,8 +5964,8 @@ packages:
   editable: true
 - pypi: ./
   name: xcp-d
-  version: 26.1.1.dev2+gdc2076555.d20260610
-  sha256: 805b73a2aaebc804e3d429df1a00494f92e09108a0692a084c96e80116aa08e9
+  version: 26.1.1.dev4+g7e8bdec40
+  sha256: f058b2722c80c69593871ce2e449086023e6e0558e25ab7e44a56b4b2686bfa6
   requires_dist:
   - acres
   - beautifulsoup4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,6 @@ graphviz = "12.2.*"
 pandoc = "3.7.*"
 ants = "2.6.*"
 bc = "1.07.*"  # provides dc, used by FSL's slicesdir script
-connectome-workbench-cli = { version = "2.0.*", build = "*qt6*" }
 fsl-base = "2602.*"
 fsl-avwutils = "2209.3.*"
 fsl-bet2 = "2111.8.*"

--- a/xcp_d/interfaces/execsummary.py
+++ b/xcp_d/interfaces/execsummary.py
@@ -541,4 +541,5 @@ def _plot_single_slice(img, i_slice, rh_pial, lh_pial, rh_wm, lh_wm, root_dir):
 
     filename = os.path.join(root_dir, f'test_{i_slice:03d}.png')
     fig.savefig(filename, bbox_inches='tight', facecolor='black')
+    plt.close(fig)
     return filename

--- a/xcp_d/interfaces/workbench.py
+++ b/xcp_d/interfaces/workbench.py
@@ -866,6 +866,12 @@ class ShowScene(WBCommand):
     output_spec = _ShowSceneOutputSpec
     _cmd = 'wb_command -show-scene'
 
+    def _run_interface(self, runtime):
+        runtime = super()._run_interface(runtime)
+        out_file = self._list_outputs()['out_file']
+        _check_image_is_nonempty(out_file)
+        return runtime
+
     def _list_outputs(self):
         outputs = self.output_spec().get()
         outputs['out_file'] = os.path.abspath(self._gen_outfilename())
@@ -881,6 +887,17 @@ class ShowScene(WBCommand):
             if isinstance(frame_number, int)
             else f'frame_{frame_number}.png'
         )
+
+
+def _check_image_is_nonempty(image_file):
+    """Raise an error if Workbench silently produced a blank scene capture."""
+    from PIL import Image
+
+    with Image.open(image_file) as img:
+        extrema = img.convert('RGBA').getextrema()
+
+    if all(low == high for low, high in extrema):
+        raise RuntimeError(f'Workbench generated an empty scene image: {image_file}')
 
 
 class _CiftiConvertInputSpec(_WBCommandInputSpec):

--- a/xcp_d/reports/core.py
+++ b/xcp_d/reports/core.py
@@ -5,6 +5,7 @@
 This is adapted from fMRIPost-AROMA.
 """
 
+import stat
 from pathlib import Path
 
 from bids.layout import Query
@@ -12,6 +13,34 @@ from nireports.assembler.report import Report
 
 from xcp_d import config, data
 from xcp_d.interfaces.execsummary import ExecutiveSummary
+
+
+def _make_reportlets_writable(reportlets_dir, subject=None, session=None):
+    """Make SVG reportlets writable so NiReports can normalize them during indexing."""
+    if reportlets_dir is None:
+        return
+
+    reportlets_dir = Path(reportlets_dir)
+    if subject:
+        subject = str(subject).removeprefix('sub-')
+        reportlets_dir = reportlets_dir / f'sub-{subject}'
+
+    if session:
+        session = str(session).removeprefix('ses-')
+        reportlets_dir = reportlets_dir / f'ses-{session}'
+
+    if not reportlets_dir.exists():
+        return
+
+    figure_dirs = list(reportlets_dir.rglob('figures'))
+    if reportlets_dir.name == 'figures':
+        figure_dirs.append(reportlets_dir)
+
+    for figure_dir in figure_dirs:
+        for svg_file in figure_dir.glob('*.svg'):
+            mode = svg_file.stat().st_mode
+            if not mode & stat.S_IWUSR:
+                svg_file.chmod(mode | stat.S_IWUSR)
 
 
 def run_reports(
@@ -26,30 +55,34 @@ def run_reports(
     **entities,
 ):
     """Run the reports."""
-    robj = Report(
-        out_dir,
-        run_uuid,
-        bootstrap_file=bootstrap_file,
-        out_filename=out_filename,
-        reportlets_dir=dataset_dir,
-        plugins=None,
-        plugin_meta=None,
-        metadata=metadata,
-        **entities,
-    )
-
     # Count nbr of subject for which report generation failed
     try:
+        _make_reportlets_writable(
+            dataset_dir,
+            subject=entities.get('subject'),
+            session=entities.get('session'),
+        )
+        robj = Report(
+            out_dir,
+            run_uuid,
+            bootstrap_file=bootstrap_file,
+            out_filename=out_filename,
+            reportlets_dir=dataset_dir,
+            plugins=None,
+            plugin_meta=None,
+            metadata=metadata,
+            **entities,
+        )
         robj.generate_report()
     except:  # noqa: E722
         import sys
         import traceback
 
         # Store the list of subjects for which report generation failed
-        traceback.print_exception(
-            *sys.exc_info(),
-            file=str(Path(out_dir) / 'logs' / errorname),
-        )
+        error_file = Path(out_dir) / 'logs' / errorname
+        error_file.parent.mkdir(exist_ok=True, parents=True)
+        with error_file.open('w') as fo:
+            traceback.print_exception(*sys.exc_info(), file=fo)
         return subject_label
 
     return None

--- a/xcp_d/tests/test_interfaces_workbench.py
+++ b/xcp_d/tests/test_interfaces_workbench.py
@@ -1,0 +1,22 @@
+"""Tests for Workbench interfaces."""
+
+import pytest
+from PIL import Image
+
+from xcp_d.interfaces.workbench import _check_image_is_nonempty
+
+
+def test_check_image_is_nonempty(tmp_path):
+    """A uniform Workbench capture is treated as a failed render."""
+    blank_file = tmp_path / 'blank.png'
+    Image.new('RGB', (5, 5), 'black').save(blank_file)
+
+    with pytest.raises(RuntimeError, match='empty scene image'):
+        _check_image_is_nonempty(blank_file)
+
+    image_file = tmp_path / 'image.png'
+    image = Image.new('RGB', (5, 5), 'black')
+    image.putpixel((2, 2), (255, 255, 255))
+    image.save(image_file)
+
+    _check_image_is_nonempty(image_file)

--- a/xcp_d/tests/test_reports_core.py
+++ b/xcp_d/tests/test_reports_core.py
@@ -1,0 +1,37 @@
+"""Tests for report generation helpers."""
+
+import stat
+
+from xcp_d.reports import core
+
+
+def test_run_reports_catches_report_init_errors_and_unlocks_svgs(tmp_path, monkeypatch):
+    """Report setup failures should be recorded without crashing XCP-D."""
+    dataset_dir = tmp_path / 'xcpd'
+    report_dir = dataset_dir / 'sub-01'
+    figures_dir = report_dir / 'figures'
+    figures_dir.mkdir(parents=True)
+
+    svg_file = figures_dir / 'sub-01_desc-bbregister_bold.svg'
+    svg_file.write_text('<svg />')
+    svg_file.chmod(stat.S_IREAD)
+
+    def _raise_report_init(*args, **kwargs):
+        raise PermissionError('no reportlet writes')
+
+    monkeypatch.setattr(core, 'Report', _raise_report_init)
+
+    result = core.run_reports(
+        out_dir=report_dir,
+        subject_label='01',
+        run_uuid='testuuid',
+        dataset_dir=dataset_dir,
+        subject='01',
+    )
+
+    assert result == '01'
+    assert svg_file.stat().st_mode & stat.S_IWUSR
+
+    error_file = report_dir / 'logs' / 'report.err'
+    assert error_file.exists()
+    assert 'PermissionError: no reportlet writes' in error_file.read_text()

--- a/xcp_d/tests/test_utils_execsummary.py
+++ b/xcp_d/tests/test_utils_execsummary.py
@@ -46,6 +46,10 @@ def test_modify_pngs_scene_template(tmp_path_factory):
         )
 
     assert os.path.isfile(scene_file)
+    with open(scene_file) as fo:
+        scene_text = fo.read()
+    assert 'T2_IMG_PATH' not in scene_text
+    assert 'T2_IMG_NAME' not in scene_text
 
 
 def test_get_png_image_names():

--- a/xcp_d/utils/execsummary.py
+++ b/xcp_d/utils/execsummary.py
@@ -104,6 +104,7 @@ def modify_pngs_scene_template(
 
     paths = {
         'TX_IMG': anat_file,
+        'T2_IMG': anat_file,
         'RPIAL': rh_pial_surf,
         'LPIAL': lh_pial_surf,
         'RWHITE': rh_wm_surf,


### PR DESCRIPTION
Updating connectome-workbench to 2 broke the structure-specific figures in the executive summary.

## Changes proposed in this pull request

- Restored Workbench-based create_scenewise_pngs behavior by removing the pixi connectome-workbench-cli Qt6 dependency and installing pinned Ubuntu connectome-workbench=1.5.0-2 in Dockerfile.base.
- Fixed executive-summary scene templating so both TX_IMG_* and T2_IMG_* placeholders are replaced.
- Added a blank-image guard for ShowScene outputs so silent all-black Workbench renders fail clearly.
- Fixed report generation when NiReports needs to normalize read-only SVG reportlets, and corrected traceback writing for report failures.
- Added focused tests for scene placeholder replacement, blank image detection, and report failure handling.
