### PR TITLE
Skip privileged Pixi lockfile updates for fork PRs

### DIFF
--- a/.github/workflows/pixi-lock.yml
+++ b/.github/workflows/pixi-lock.yml
@@ -6,7 +6,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  skip-fork-lockfile-update:
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Skip lockfile update for fork
+        run: |
+          echo "Skipping automatic lockfile updates for a fork pull request."
+          echo "If this pull request changes pyproject.toml or pixi.lock, update the lockfile locally."
   check-lockfile:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Changes proposed in this pull request

- Run the privileged lockfile checkout/update job only for pull requests whose head branch is in this repository.
- Give fork pull requests a separate, no-permissions job that does not check out or execute fork code.
- Preserve the existing manual lockfile-update guidance for forks.

This intentionally does **not** set `allow-unsafe-pr-checkout: true`.

Related to #1630.

## Documentation that should be reviewed

None; existing fork guidance in the README remains accurate.

## Validation

- Parsed `.github/workflows/pixi-lock.yml` with PyYAML.
- Asserted the fork job has empty permissions, the privileged job requires a same-repository head, and no checkout step opts into unsafe fork checkout.
- Ran `git diff --check`.
