### PR TITLE
Sync CI setup across LINC BIDS Apps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-# Dynamic config: setup workflow
+# ── Dynamic config: setup workflow ────────────────────────────────────
 # The real pipeline lives in continue_config.yml. This setup workflow
 # inspects the diff of the pushed commit and sets two pipeline parameters:
 #
@@ -10,15 +10,22 @@ version: 2.1
 #                     (Dockerfile*, pyproject.toml, pixi.lock, tox.ini,
 #                     Makefile, .dockerignore)
 #
-# A push that only touches documentation (README, *.rst, *.md, CITATION.cff,
-# .github/**, etc.) leaves has_code_changes false and skips the expensive
-# continuation workflow.
+# The continue workflow runs when has_code_changes is true OR when there
+# is no diff at all (tag builds, initial clones). A push that only touches
+# documentation (README, *.rst, *.md, CITATION.cff, .github/**, etc.)
+# leaves has_code_changes false and is skipped.
+#
+# `[skip ci]` / `[ci skip]` in a commit message is honored natively by
+# CircleCI at the VCS webhook level and needs no explicit handling here.
 
 setup: true
 
 orbs:
   # Version 2 uses the shell-based implementation and avoids the Python/pip
   # bootstrap path that breaks when get-pip.py drops older Python versions.
+  # The 1.x line pipes `https://bootstrap.pypa.io/get-pip.py` into the orb's
+  # default Python (now 3.9), which get-pip no longer supports, failing the
+  # filter step with "This script does not work on Python 3.9".
   path-filtering: circleci/path-filtering@2
 
 workflows:
@@ -33,8 +40,10 @@ workflows:
           filters:
             tags:
               only: /.*/
-          # path-filtering@1.3.0 wraps patterns with implicit ^...$ anchors,
-          # so prefix patterns need an explicit .* suffix.
+          # NOTE: path-filtering wraps each pattern with implicit `^...$`
+          # anchors, so every regex must match the *full* file path, not just
+          # a prefix. Prefix-style patterns therefore need an explicit `.*`
+          # suffix; single-file patterns match literally.
           mapping: |
             .*                has_any_changes   true
             xcp_d/.*          has_code_changes  true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -14,8 +14,12 @@ parameters:
 orbs:
   codecov: codecov/codecov@4.1.0
 
-# Reusable anchors
+# ── Reusable anchors ──────────────────────────────────────────────────
 
+# Default machine executor — used by jobs that run containers but do NOT
+# execute `docker build`. docker_layer_caching is deliberately off here
+# because it adds a ~200-credit surcharge per job and is only useful for
+# jobs that actually build images.
 _machine_defaults: &machine_defaults
   environment:
     TZ: "/usr/share/zoneinfo/America/New_York"
@@ -24,6 +28,8 @@ _machine_defaults: &machine_defaults
   working_directory: /tmp/src/xcp_d
   resource_class: large
 
+# Machine executor with docker_layer_caching — for jobs that run
+# `docker build` and benefit from warm layer caches.
 _machine_with_dlc: &machine_with_dlc
   environment:
     TZ: "/usr/share/zoneinfo/America/New_York"
@@ -33,16 +39,27 @@ _machine_with_dlc: &machine_with_dlc
   working_directory: /tmp/src/xcp_d
   resource_class: large
 
+# Shared filter block for run_tests workflow jobs — branch pushes only.
+# Tags are handled by the separate `deploy` workflow so the full integration
+# matrix is not re-run on every release (tests have already passed on the
+# main commit the tag points to).
 _default_filters: &default_filters
   tags:
     ignore: /.*/
 
+# Filter for the deploy workflow — tag pushes only, no branches.
 _tag_filters: &tag_filters
   tags:
     only: /.*/
   branches:
     ignore: /.*/
 
+# NOTE: aslprep and xcp_d authenticate with $DOCKERHUB_USERNAME/$DOCKERHUB_TOKEN,
+# while qsiprep and qsirecon use $DOCKER_USER/$DOCKER_PASS. The names are
+# deliberately left divergent until the CircleCI project env vars are
+# confirmed — the guard below means a missing variable silently skips login
+# rather than failing loudly, so renaming without setting the new var would
+# break pushes at the end of a long build.
 _docker_auth: &docker_auth
   name: Docker authentication
   command: |
@@ -53,6 +70,10 @@ _docker_auth: &docker_auth
 _setup_docker_registry: &setup_docker_registry
   name: Set up local Docker registry
   command: |
+    # registry:2 is ~25 MB and pulls in a couple of seconds over the
+    # authenticated Docker Hub connection we already have, so there's no
+    # point caching a `docker save` tarball of it — that only makes the
+    # build cache bigger and slower to save/restore.
     docker pull registry:2
     docker run -d -p 5000:5000 --restart=always --name=registry \
         -v /tmp/docker:/var/lib/registry registry:2
@@ -69,6 +90,12 @@ commands:
   restore_build_and_data:
     description: Restore workflow Docker image cache and test data cache, then start the registry
     steps:
+      # Restore the workflow-scoped key, not the shared deps key. CircleCI
+      # caches are immutable: if image_prep rebuilt the test image but the
+      # deps key already existed, its save_cache would be a no-op and this
+      # job would pull a stale image from an earlier run's registry. The
+      # workflow-scoped key is unique per run, so it always reflects the
+      # image image_prep actually produced.
       - restore_cache:
           keys:
             - build-v5-workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
@@ -112,6 +139,10 @@ commands:
       - run:
           name: Prune non-QC artifacts
           when: always
+          # HTML reports and everything they embed (figures/ SVG/PNG/GIF,
+          # linked TSVs) must survive — they're how outputs get visually
+          # QC'd. Only strip large binary derivatives that the reports
+          # don't render, plus test/pycache debris.
           command: |
             find /tmp/out/ -name "*.nii.gz" -type f -delete 2>/dev/null || true
             find /tmp/out/ \( \
@@ -317,6 +348,12 @@ jobs:
           command: |
             mkdir -p /tmp/images
             touch /tmp/images/imageprep-success.marker
+      # Two keys on purpose. The workflow-scoped key is unique per run so it
+      # is always written, guaranteeing downstream jobs restore the image
+      # this run actually produced. The deps key is shared across runs with
+      # identical Docker inputs and is what lets a later run skip the build
+      # entirely; it is a no-op once it exists, which is why it cannot be
+      # the key downstream jobs read from.
       - save_cache:
           key: build-v5-workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
           paths:
@@ -329,6 +366,9 @@ jobs:
             - /tmp/images
 
   get_data:
+    # Network- and IO-bound only — no Docker daemon needed, so run on the
+    # docker executor (cimg/base:stable, ~10 credits/min) instead of the
+    # machine executor (100 credits/min).
     docker:
       - image: cimg/base:stable
     working_directory: /tmp/src/xcp_d
@@ -452,6 +492,9 @@ jobs:
           path: /tmp/out
 
   merge_coverage:
+    # Runs `pip install coverage && coverage combine && coverage xml` — no
+    # Docker daemon needed. The docker executor (cimg/python, ~10 credits/min)
+    # is ~10x cheaper per minute than the machine executor it used to run on.
     docker:
       - image: cimg/python:3.12
     working_directory: /tmp/src/xcp_d

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,4 @@ Dockerfile*    text eol=lf
 *.png      binary
 *.jpg      binary
 *.nii.gz   binary
+*.gpg      binary

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: pipx run ruff check .
-      - run: pipx run ruff format --diff .
+      - run: pipx run --spec ruff==0.14.11 ruff check .
+      - run: pipx run --spec ruff==0.14.11 ruff format --diff .
 
   codespell:
     name: Check for spelling errors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,11 +88,20 @@ The config module is the single source of truth for runtime parameters. Never pa
 
 ### Docker
 
-- Each app has a base image with runtime dependencies and a main Dockerfile that installs the Python environment and the app itself.
-- ASLPrep, fMRIPrep, and XCP-D have migrated to **Pixi**-based multi-stage Docker builds: `Dockerfile.base` owns non-Python/non-conda runtime dependencies, while `Dockerfile` uses pixi to create `build`, `test`, and production targets from `pixi.lock`. qsiprep and qsirecon still use micromamba + `pip install`.
-- Base image naming: ASLPrep and XCP-D use date-based tags (`pennlinc/<pkg>-base:<YYYYMMDD>`); qsiprep and qsirecon use `pennlinc/<pkg>_build:<version>`.
+- Each app has a base image with runtime dependencies (`Dockerfile.base`) and a main `Dockerfile` that installs the Python environment and the app itself.
+- All four apps use **Pixi**-based multi-stage Docker builds: `Dockerfile.base` owns non-Python/non-conda runtime dependencies, while `Dockerfile` uses pixi to create `build`, `test`, and production targets from `pixi.lock`.
+- Base image naming is uniform across the four repos: `pennlinc/<pkg>-base:<YYYYMMDD>`, pinned via `ARG BASE_IMAGE` on the first line of `Dockerfile`.
 - Entrypoint is the CLI binary in the pixi environment (e.g., `/app/.pixi/envs/<env>/bin/<pkg>`).
-- Labels follow the `org.label-schema` convention.
+- Labels follow the `org.label-schema` convention; the `test` target additionally carries `org.opencontainers.image.revision`, which CI uses to refuse running tests against a stale image.
+- The base image is rebuilt only when its `BASE_IMAGE` tag is absent from Docker Hub. Editing `Dockerfile.base` without bumping the date tag does **not** trigger a rebuild.
+
+### CircleCI
+
+- All four repos use CircleCI **dynamic configuration**. `.circleci/config.yml` is a `setup: true` workflow that runs the `path-filtering` orb and hands off to `.circleci/continue_config.yml`, which holds the real pipeline. A docs-only push leaves `has_code_changes` false and skips the expensive matrix.
+- `continue_config.yml` defines two workflows: `run_tests` (branch pushes, gated on `has_code_changes`) and `deploy` (tag pushes only, which skips the matrix since the tagged commit already passed on `main`).
+- `image_prep` builds the base image (only if its tag is missing), the `test` image, and — on `main` and tags only — the production image, then pushes to Docker Hub. Integration jobs consume the test image from a local registry seeded out of the build cache.
+- The build cache uses two keys: a workflow-scoped key that downstream jobs read from (unique per run, so always written) and a shared `-deps-` key on `Dockerfile` + `pixi.lock` checksums that lets a later run skip the build entirely. Downstream jobs must not read the deps key — CircleCI caches are immutable, so it can point at an older run's image.
+- Docker Hub credentials are **not** named consistently yet: aslprep and xcp_d use `$DOCKERHUB_USERNAME`/`$DOCKERHUB_TOKEN`, qsiprep and qsirecon use `$DOCKER_USER`/`$DOCKER_PASS`. Logins are guarded by a `[[ -n ... ]]` check, so an unset variable skips login silently rather than failing.
 
 ### Release Process
 
@@ -234,7 +243,7 @@ This roadmap covers harmonization work across all four PennLINC BIDS Apps (qsipr
 ### Phase 3: Shared infrastructure
 
 11. **Extract a reusable GitHub Actions workflow** for lint + codespell + build checks, hosted in a shared repo (e.g., `PennLINC/.github`).
-12. **Standardize Dockerfile patterns** -- ASLPrep, fMRIPrep, and XCP-D have adopted pixi-based multi-stage Docker builds. Migrate qsiprep and qsirecon to the same pattern.
+12. ~~**Standardize Dockerfile patterns**~~ -- done: all four repos now use pixi-based multi-stage builds with `pennlinc/<pkg>-base:<YYYYMMDD>` base images.
 13. **Create a shared `pennlinc-style` package or cookiecutter template** providing `pyproject.toml` lint/test config, `.pre-commit-config.yaml`, `tox.ini`, and CI workflows.
 14. **Evaluate `nipreps-versions` calver** -- the `raw-options = { version_scheme = "nipreps-calver" }` line is commented out in all four repos. Decide whether to adopt it.
 


### PR DESCRIPTION
Regular synchronization of CircleCI/Docker setups across the lab's BIDS Apps.

Related to https://github.com/PennLINC/aslprep/pull/684, https://github.com/PennLINC/qsiprep/pull/1075, and https://github.com/PennLINC/qsirecon/pull/395.

### Summary

  xcp_d's CircleCI setup is already structurally correct — it was the source of the
  two-key build-cache pattern now being adopted in aslprep. **This PR makes no
  functional changes to the pipeline.** It ports the explanatory comments from
  aslprep's config (which documents *why* each cost/correctness decision was made)
  and fixes documentation that was factually wrong.

  ### Changes

  - **`.circleci/config.yml`** — expanded comments to match aslprep's: why the
    `path-filtering` orb is pinned to v2 (the 1.x line pipes `get-pip.py` into
    Python 3.9 and fails), why the setup workflow must opt into tags, and the note
    that path-filtering wraps patterns in implicit `^...$` anchors so prefix
    patterns need an explicit `.*`.
  - **`.circleci/continue_config.yml`** — comments only:
    - Why `_machine_defaults` omits `docker_layer_caching` (~200-credit surcharge
      per job, only useful for jobs that build images).
    - Why `_default_filters` ignores tags (the `deploy` workflow handles them).
    - Why the workflow-scoped cache key exists and why downstream jobs must not
      read the `-deps-` key.
    - Why `registry:2` isn't cached as a `docker save` tarball.
    - Why the artifact prune keeps HTML reports and figures.
    - Why `get_data` and `merge_coverage` run on docker executors.
    - A note that the Docker Hub credential variable names diverge across repos.
  - **`.gitattributes`** — added `*.gpg binary`.
  - **`AGENTS.md`** — corrected the shared Docker section (all four repos use pixi
    with `pennlinc/<pkg>-base:<YYYYMMDD>`, not micromamba + `pennlinc/<pkg>_build:<ver>`),
    added a shared `### CircleCI` section, struck recommendation #12 as done.

  ### Note for reviewers (not addressed here)

  `src/` and `test/` in the repo root are untracked and contain only `__pycache__`
  debris — `src/xcp_d` is leftover from the abandoned src-layout migration, and
  `test/` has no `.py` files. `packages = ["xcp_d"]` in `pyproject.toml` confirms
  the real package is still top-level. Worth gitignoring or deleting separately.

  ### Verification

  - Both CircleCI YAML files parse.
  - Cache keys and job/workflow structure cross-checked against the other repos.

  **Not verified:** no CircleCI run. Since this PR changes only comments and docs
  in the pipeline, the risk is limited to YAML validity, which is checked.